### PR TITLE
Add StateKeyTuple type. Add helper functions for auth.

### DIFF
--- a/event.go
+++ b/event.go
@@ -22,6 +22,18 @@ import (
 	"time"
 )
 
+// A StateKeyTuple is the combination of an event type and an event state key.
+// It is often used as a key in maps.
+type StateKeyTuple struct {
+	// The "type" key of a matrix event.
+	EventType string
+	// The "state_key" of a matrix event.
+	// The empty string is a legitimate value for the "state_key" in matrix
+	// so take care to initialise this field lest you accidentally request a
+	// "state_key" with the go default of the empty string.
+	StateKey string
+}
+
 // An EventReference is a reference to a matrix event.
 type EventReference struct {
 	// The event ID of the event.

--- a/eventauth.go
+++ b/eventauth.go
@@ -66,7 +66,7 @@ func (s StateNeeded) Tuples() (res []StateKeyTuple) {
 
 // AuthEventReferences returns the auth_events references for the StateNeeded. Returns an error if the
 // provider returns an error. If an event is missing from the provider but is required in StateNeeded, it
-// is skipped under the assumption that the event will fail authentication checks.
+// is skipped over: no error is returned.
 func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []EventReference, err error) {
 	var e *Event
 	if s.Create {

--- a/eventauth.go
+++ b/eventauth.go
@@ -112,8 +112,7 @@ func TuplesFromStateNeeded(needed StateNeeded) (res []StateKeyTuple) {
 func AuthEventReferencesFromStateNeeded(authEvents map[StateKeyTuple]*Event, needed StateNeeded) (refs []EventReference) {
 	tuples := TuplesFromStateNeeded(needed)
 	for _, t := range tuples {
-		e, ok := authEvents[t]
-		if ok && e != nil {
+		if e := authEvents[t]; e != nil {
 			refs = append(refs, e.EventReference())
 		}
 	}


### PR DESCRIPTION
Helper functions are designed to map easily between StateNeeded,
StateKeyTuples and []EventReference (auth_events).