### PR TITLE
Add a KeyRing for storing server keys for verifying signed JSON

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,6 +144,11 @@ func (fc *Client) LookupUserInfo(matrixServer, token string) (u UserInfo, err er
 }
 
 // LookupServerKeys lookups up the keys for a matrix server from a matrix server.
+// Takes a map from (server name, key ID) pairs to timestamps.
+// The timestamps tell the server when the keys need to be valid until.
+// Perspective servers can use that timestamp to determine whether they can
+// return a cached copy of the keys or whether they will need to retrieve a fresh
+// copy of the keys.
 // Returns the keys or an error if there was a problem talking to the server.
 func (fc *Client) LookupServerKeys(
 	matrixServer string, keyRequests map[PublicKeyRequest]Timestamp,

--- a/client.go
+++ b/client.go
@@ -144,7 +144,9 @@ func (fc *Client) LookupUserInfo(matrixServer, token string) (u UserInfo, err er
 }
 
 // LookupServerKeys lookups up the keys for a matrix server from a matrix server.
-// Takes a map from (server name, key ID) pairs to timestamps.
+// The first argument is the name of the matrix server to download the keys from.
+// The second argument is a map from (server name, key ID) pairs to timestamps.
+// The (server name, key ID) pair identifies the key to download.
 // The timestamps tell the server when the keys need to be valid until.
 // Perspective servers can use that timestamp to determine whether they can
 // return a cached copy of the keys or whether they will need to retrieve a fresh

--- a/client.go
+++ b/client.go
@@ -201,6 +201,8 @@ func (fc *Client) ServerKeys(
 
 	result := map[PublicKeyRequest]ServerKeys{}
 	for _, keys := range body.ServerKeys {
+		// TODO: What happens if the same key ID appears in multiple responses?
+		// We should probably take the response with the highest valid_until_ts.
 		for keyID := range keys.VerifyKeys {
 			result[PublicKeyRequest{keys.ServerName, keyID}] = keys
 		}

--- a/client.go
+++ b/client.go
@@ -201,6 +201,7 @@ func (fc *Client) ServerKeys(
 
 	result := map[PublicKeyRequest]ServerKeys{}
 	for _, keys := range body.ServerKeys {
+		keys.FromServer = matrixServer
 		// TODO: What happens if the same key ID appears in multiple responses?
 		// We should probably take the response with the highest valid_until_ts.
 		for keyID := range keys.VerifyKeys {

--- a/keyring.go
+++ b/keyring.go
@@ -115,6 +115,8 @@ func (k *KeyRing) VerifyJSONs(requests []VerifyJSONRequest) ([]VerifyJSONResult,
 			// This means that we've checked every JSON object we can check.
 			return results, nil
 		}
+		// TODO: Coalesce in-flight requests for the same keys.
+		// Otherwise we risk spamming the servers we query the keys from.
 		keysFetched, err := k.KeyFetchers[i].FetchKeys(keyRequests)
 		if err != nil {
 			return nil, err

--- a/keyring.go
+++ b/keyring.go
@@ -206,7 +206,7 @@ type PerspectiveKeyFetcher struct {
 
 // FetchKeys implements KeyFetcher
 func (p *PerspectiveKeyFetcher) FetchKeys(requests map[PublicKeyRequest]Timestamp) (map[PublicKeyRequest]ServerKeys, error) {
-	results, err := p.Client.ServerKeys(p.ServerName, requests)
+	results, err := p.Client.LookupServerKeys(p.ServerName, requests)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (d *DirectKeyFetcher) FetchKeys(requests map[PublicKeyRequest]Timestamp) (m
 func (d *DirectKeyFetcher) fetchKeysForServer(
 	serverName string, requests map[PublicKeyRequest]Timestamp,
 ) (map[PublicKeyRequest]ServerKeys, error) {
-	results, err := d.Client.ServerKeys(serverName, requests)
+	results, err := d.Client.LookupServerKeys(serverName, requests)
 	if err != nil {
 		return nil, err
 	}
@@ -294,8 +294,7 @@ func (d *DirectKeyFetcher) fetchKeysForServer(
 		// Check that the keys are valid for the server.
 		checks, _, _ := CheckKeys(req.ServerName, time.Unix(0, 0), keys, nil)
 		if !checks.AllChecksOK {
-			// This is bad because it means that the perspective server was trying to feed us an invalid response.
-			return nil, fmt.Errorf("gomatrixserverlib: key response from perspective server failed checks")
+			return nil, fmt.Errorf("gomatrixserverlib: key response direct from %q failed checks", serverName)
 		}
 	}
 

--- a/keyring.go
+++ b/keyring.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// A Timestamp is a millisecond posix timestamp.
-type Timestamp uint64
-
 // A PublicKeyRequest is a request for a public key with a particular key ID.
 type PublicKeyRequest struct {
 	// The server to fetch a key for.

--- a/keyring.go
+++ b/keyring.go
@@ -18,6 +18,13 @@ type PublicKeyRequest struct {
 // A KeyFetcher is a way of fetching public keys in bulk.
 type KeyFetcher interface {
 	// Lookup a batch of public keys.
+	// Takes a map from (server name, key ID) pairs to timestamp.
+	// The timestamp is when the keys need to be vaild up to.
+	// Returns a map from (server name, key ID) pairs to server key objects for
+	// that server name containing that key ID
+	// The result may have fewer (server name, key ID) pairs than were in the request.
+	// The result may have more (server name, key ID) pairs than were in the request.
+	// Returns an error if there was a problem fetching the keys.
 	FetchKeys(requests map[PublicKeyRequest]Timestamp) (map[PublicKeyRequest]ServerKeys, error)
 }
 

--- a/keyring.go
+++ b/keyring.go
@@ -1,0 +1,175 @@
+package gomatrixserverlib
+
+import (
+	"fmt"
+	"golang.org/x/crypto/ed25519"
+	"strings"
+)
+
+// A PublicKeyRequest is a request for a public key with a particular key ID.
+type PublicKeyRequest struct {
+	// The server to fetch a key for.
+	ServerName string
+	// The ID of the key to fetch.
+	KeyID string
+}
+
+// A KeyFetcher is a way of fetching public keys in bulk.
+type KeyFetcher interface {
+	// Lookup a batch of public keys.
+	FetchKeys(requests []PublicKeyRequest) (map[PublicKeyRequest]ServerKeys, error)
+}
+
+// A KeyDatabase is a store for caching public keys.
+type KeyDatabase interface {
+	KeyFetcher
+	// Add a block public keys to the database.
+	StoreKeys(map[PublicKeyRequest]ServerKeys) error
+}
+
+// A KeyRing stores keys for matrix servers and provides methods for verifying JSON messages.
+type KeyRing struct {
+	KeyFetchers []KeyFetcher
+	KeyDatabase KeyDatabase
+}
+
+// A VerifyJSONRequest is a request to check for a signature on a JSON message.
+// A JSON message is valid for a server if the message has at least one valid
+// signature from that server.
+type VerifyJSONRequest struct {
+	// The name of the matrix server to check for a signature for.
+	ServerName string
+	// The millisecond posix timestamp the message needs to be valid at.
+	AtTS uint64
+	// The JSON bytes.
+	Message []byte
+}
+
+// A VerifyJSONResult is the result of checking the signature of a JSON message.
+type VerifyJSONResult struct {
+	// Embedded copy of the request this result is for.
+	VerifyJSONRequest
+	// Whether the message passed the signature checks.
+	// This will be nil if the message passed the checks.
+	// This will have an error if the message did not pass the checks.
+	Result error
+}
+
+// VerifyJSONs performs bulk JSON signature verification for a list of VerifyJSONRequests.
+// Returns a list of VerifyJSONResults with the same length as the request list.
+// The caller should check the Result field for each entry to see if it was valid.
+// Returns an error if there was a problem talking to the database or one of the other methods
+// of fetching the public keys.
+func (k *KeyRing) VerifyJSONs(requests []VerifyJSONRequest) ([]VerifyJSONResult, error) {
+	results := make([]VerifyJSONResult, len(requests))
+	keyIDs := make([][]string, len(requests))
+
+	for i := range requests {
+		results[i].VerifyJSONRequest = requests[i]
+		ids, err := ListKeyIDs(requests[i].ServerName, requests[i].Message)
+		if err != nil {
+			results[i].Result = fmt.Errorf("gomatrixserverlib: error extracting key IDs")
+			continue
+		}
+		for _, keyID := range ids {
+			if k.isAlgorithmSupported(keyID) {
+				keyIDs[i] = append(keyIDs[i], keyID)
+			}
+		}
+		if len(keyIDs[i]) == 0 {
+			results[i].Result = fmt.Errorf("gomatrixserverlib: not signed by %q with a supported algorithm", results[i].ServerName)
+			continue
+		}
+		// Set a place holder error in the result field.
+		// This will be unset if one of the signature checks passes.
+		// This will be overwritten if one of the signature checks fails.
+		// Therefore this will only remain in place if the keys couldn't be downloaded.
+		results[i].Result = fmt.Errorf("gomatrixserverlib: could not download key for %q", results[i].ServerName)
+	}
+
+	keyRequests := k.publicKeyRequests(results, keyIDs)
+	if len(keyRequests) == 0 {
+		// There aren't any keys to fetch so we can stop here.
+		// This will happen if all the objects are missing supported signatures.
+		return results, nil
+	}
+	keysFromDatabase, err := k.KeyDatabase.FetchKeys(keyRequests)
+	if err != nil {
+		return nil, err
+	}
+	k.checkUsingKeys(results, keyIDs, keysFromDatabase)
+
+	for i := range k.KeyFetchers {
+		keyRequests := k.publicKeyRequests(results, keyIDs)
+		if len(keyRequests) == 0 {
+			// There aren't any keys to fetch so we can stop here.
+			// This means that we've checked every JSON object we can check.
+			return results, nil
+		}
+		keysFetched, err := k.KeyFetchers[i].FetchKeys(keyRequests)
+		if err != nil {
+			return nil, err
+		}
+		k.checkUsingKeys(results, keyIDs, keysFetched)
+
+		// Add the keys to the database so that we won't need to fetch them again.
+		if err := k.KeyDatabase.StoreKeys(keysFetched); err != nil {
+			return nil, err
+		}
+	}
+
+	return results, nil
+}
+
+func (k *KeyRing) isAlgorithmSupported(keyID string) bool {
+	return strings.HasPrefix(keyID, "ed25519:")
+}
+
+func (k *KeyRing) publicKeyRequests(results []VerifyJSONResult, keyIDs [][]string) []PublicKeyRequest {
+	keyRequestSet := map[PublicKeyRequest]struct{}{}
+	for i := range results {
+		if results[i].Result == nil {
+			continue
+		}
+		for _, keyID := range keyIDs[i] {
+			keyRequestSet[PublicKeyRequest{results[i].ServerName, keyID}] = struct{}{}
+		}
+	}
+	var keyRequests []PublicKeyRequest
+	for keyRequest := range keyRequestSet {
+		keyRequests = append(keyRequests, keyRequest)
+	}
+	return keyRequests
+}
+
+func (k *KeyRing) checkUsingKeys(results []VerifyJSONResult, keyIDs [][]string, keys map[PublicKeyRequest]ServerKeys) {
+	for i := range results {
+		if results[i].Result == nil {
+			// We've already checked this message and it passed the signature checks.
+			// So we can skip to the next message.
+			continue
+		}
+		for _, keyID := range keyIDs[i] {
+			serverKeys, ok := keys[PublicKeyRequest{results[i].ServerName, keyID}]
+			if !ok {
+				// No key for this key ID so we continue onto the next key ID.
+				continue
+			}
+			publicKey := serverKeys.PublicKey(keyID, results[i].AtTS)
+			if publicKey == nil {
+				// The key wasn't valid at the timestamp we needed it to be valid at.
+				// So skip onto the next key.
+				results[i].Result = fmt.Errorf("gomatrixserverlib: key with ID %q for %q not valid at %d", keyID, results[i].ServerName, results[i].AtTS)
+				continue
+			}
+			if err := VerifyJSON(results[i].ServerName, keyID, ed25519.PublicKey(publicKey), results[i].Message); err != nil {
+				// The signature wasn't valid, record the error and try the next key ID.
+				results[i].Result = err
+				continue
+			}
+			// The signature is valid, set the result to nil.
+			results[i].Result = nil
+			break
+		}
+	}
+}

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -1,0 +1,139 @@
+package gomatrixserverlib
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var privateKeySeed1 = `QJvXAPj0D9MUb1exkD8pIWmCvT1xajlsB8jRYz/G5HE`
+var privateKeySeed2 = `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
+
+// testKeys taken from a copy of synapse.
+var testKeys = `{
+	"old_verify_keys": {
+		"ed25519:old": {
+			"expired_ts": 929059200,
+			"key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik"
+		}
+	},
+	"server_name": "localhost:8800",
+	"signatures": {
+		"localhost:8800": {
+			"ed25519:a_Obwu": "xkr4Z49ODoQnRi//ePfXlt8Q68vzd+DkzBNCt60NcwnLjNREx0qVQrw1iTFSoxkgGtz30NDkmyffDrCrmX5KBw"
+		}
+	},
+	"tls_fingerprints": [
+		{
+			"sha256": "I2ohBnqpb5m3HldWFwyA10WdjqDksukiKVUdZ690WzM"
+		}
+	],
+	"valid_until_ts": 1493142432964,
+	"verify_keys": {
+		"ed25519:a_Obwu": {
+			"key": "2UwTWD4+tgTgENV7znGGNqhAOGY+BW1mRAnC6W6FBQg"
+		}
+	}
+}`
+
+type testKeyDatabase struct{}
+
+func (db *testKeyDatabase) FetchKeys(requests map[PublicKeyRequest]Timestamp) (map[PublicKeyRequest]ServerKeys, error) {
+	results := map[PublicKeyRequest]ServerKeys{}
+	var keys ServerKeys
+	if err := json.Unmarshal([]byte(testKeys), &keys); err != nil {
+		return nil, err
+	}
+
+	req1 := PublicKeyRequest{"localhost:8800", "ed25519:old"}
+	req2 := PublicKeyRequest{"localhost:8800", "ed25519:a_Obwu"}
+
+	for req := range requests {
+		if req == req1 || req == req2 {
+			results[req] = keys
+		}
+	}
+	return results, nil
+}
+
+func (db *testKeyDatabase) StoreKeys(requests map[PublicKeyRequest]ServerKeys) error {
+	return nil
+}
+
+func TestVerifyJSONsSuccess(t *testing.T) {
+	// Check that trying to verify the server key JSON works.
+	k := KeyRing{nil, &testKeyDatabase{}}
+	results, err := k.VerifyJSONs([]VerifyJSONRequest{{
+		ServerName: "localhost:8800",
+		Message:    []byte(testKeys),
+		AtTS:       1493142432964,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Result != nil {
+		t.Fatalf("VerifyJSON(): Wanted [{Result: nil}] got %#v", results)
+	}
+}
+
+func TestVerifyJSONsUnknownServerFails(t *testing.T) {
+	// Check that trying to verify JSON for an unknown server fails.
+	k := KeyRing{nil, &testKeyDatabase{}}
+	results, err := k.VerifyJSONs([]VerifyJSONRequest{{
+		ServerName: "unknown:8800",
+		Message:    []byte(testKeys),
+		AtTS:       1493142432964,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Result == nil {
+		t.Fatalf("VerifyJSON(): Wanted [{Result: <some error>}] got %#v", results)
+	}
+}
+
+func TestVerifyJSONsDistantFutureFails(t *testing.T) {
+	// Check that trying to verify JSON from the distant future fails.
+	distantFuture := Timestamp(2000000000000)
+	k := KeyRing{nil, &testKeyDatabase{}}
+	results, err := k.VerifyJSONs([]VerifyJSONRequest{{
+		ServerName: "unknown:8800",
+		Message:    []byte(testKeys),
+		AtTS:       distantFuture,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Result == nil {
+		t.Fatalf("VerifyJSON(): Wanted [{Result: <some error>}] got %#v", results)
+	}
+}
+
+func TestVerifyJSONsFetcherError(t *testing.T) {
+	// Check that if the database errors then the attempt to verify JSON fails.
+	k := KeyRing{nil, &erroringKeyDatabase{}}
+	results, err := k.VerifyJSONs([]VerifyJSONRequest{{
+		ServerName: "localhost:8800",
+		Message:    []byte(testKeys),
+		AtTS:       1493142432964,
+	}})
+	if err != error(&testErrorFetch) || results != nil {
+		t.Fatalf("VerifyJSONs(): Wanted (nil, <some error>) got (%#v, %q)", results, err)
+	}
+}
+
+type erroringKeyDatabase struct{}
+
+type erroringKeyDatabaseError int
+
+func (e *erroringKeyDatabaseError) Error() string { return "An error with the key database" }
+
+var testErrorFetch = erroringKeyDatabaseError(1)
+var testErrorStore = erroringKeyDatabaseError(2)
+
+func (e *erroringKeyDatabase) FetchKeys(requests map[PublicKeyRequest]Timestamp) (map[PublicKeyRequest]ServerKeys, error) {
+	return nil, &testErrorFetch
+}
+
+func (e *erroringKeyDatabase) StoreKeys(keys map[PublicKeyRequest]ServerKeys) error {
+	return &testErrorStore
+}

--- a/keys.go
+++ b/keys.go
@@ -115,6 +115,7 @@ func FetchKeysDirect(serverName, addr, sni string) (*ServerKeys, *tls.Connection
 		return nil, nil, err
 	}
 	var keys ServerKeys
+	keys.FromServer = serverName
 	if err = json.NewDecoder(response.Body).Decode(&keys); err != nil {
 		return nil, nil, err
 	}

--- a/keys.go
+++ b/keys.go
@@ -39,15 +39,15 @@ type ServerKeys struct {
 	VerifyKeys map[string]struct { // The current signing keys in use on this server.
 		Key Base64String `json:"key"` // The public key.
 	} `json:"verify_keys"`
-	ValidUntilTS  uint64              `json:"valid_until_ts"` // When this result is valid until in milliseconds.
+	ValidUntilTS  Timestamp           `json:"valid_until_ts"` // When this result is valid until in milliseconds.
 	OldVerifyKeys map[string]struct { // Old keys that are now only valid for checking historic events.
 		Key       Base64String `json:"key"`        // The public key.
-		ExpiredTS uint64       `json:"expired_ts"` // When this key stopped being valid for event signing.
+		ExpiredTS Timestamp    `json:"expired_ts"` // When this key stopped being valid for event signing.
 	} `json:"old_verify_keys"`
 }
 
 // PublicKey returns a public key with the given ID valid at the given TS or nil if no such key exists.
-func (keys ServerKeys) PublicKey(keyID string, atTS uint64) []byte {
+func (keys ServerKeys) PublicKey(keyID string, atTS Timestamp) []byte {
 	if currentKey, ok := keys.VerifyKeys[keyID]; ok && (atTS <= keys.ValidUntilTS) {
 		return currentKey.Key
 	}
@@ -136,7 +136,7 @@ func CheckKeys(serverName string, now time.Time, keys ServerKeys, connState *tls
 	checks KeyChecks, ed25519Keys map[string]Base64String, sha256Fingerprints []Base64String,
 ) {
 	checks.MatchingServerName = serverName == keys.ServerName
-	checks.FutureValidUntilTS = uint64(now.UnixNano()) < keys.ValidUntilTS*1000000
+	checks.FutureValidUntilTS = Timestamp(now.UnixNano()) < keys.ValidUntilTS*1000000
 	checks.AllChecksOK = checks.MatchingServerName && checks.FutureValidUntilTS
 
 	ed25519Keys = checkVerifyKeys(keys, &checks)

--- a/keys.go
+++ b/keys.go
@@ -62,6 +62,7 @@ func (keys *ServerKeys) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements json.Marshaler
 func (keys ServerKeys) MarshalJSON() ([]byte, error) {
+	// We already have a copy of the serialised JSON for the keys so we can return that directly.
 	return keys.Raw, nil
 }
 

--- a/signing.go
+++ b/signing.go
@@ -75,6 +75,21 @@ func SignJSON(signingName, keyID string, privateKey ed25519.PrivateKey, message 
 	return json.Marshal(object)
 }
 
+// ListKeyIDs lists the key IDs a given entity has signed a message with.
+func ListKeyIDs(signingName string, message []byte) ([]string, error) {
+	var object struct {
+		Signatures map[string]map[string]json.RawMessage `json:"signatures"`
+	}
+	if err := json.Unmarshal(message, &object); err != nil {
+		return nil, err
+	}
+	var result []string
+	for keyID := range object.Signatures[signingName] {
+		result = append(result, keyID)
+	}
+	return result, nil
+}
+
 // VerifyJSON checks that the entity has signed the message using a particular key.
 func VerifyJSON(signingName, keyID string, publicKey ed25519.PublicKey, message []byte) error {
 	var object map[string]*json.RawMessage

--- a/timestamp.go
+++ b/timestamp.go
@@ -1,0 +1,4 @@
+package gomatrixserverlib
+
+// A Timestamp is a millisecond posix timestamp.
+type Timestamp uint64


### PR DESCRIPTION
This implements the logic in https://github.com/matrix-org/synapse/blob/master/synapse/crypto/keyring.py for checking signed JSON by fetching the ed25519 keys from the remote server either directly or via a perspective server.