### PR TITLE
Add method for listing the events in a /state response

### DIFF
--- a/federationtypes.go
+++ b/federationtypes.go
@@ -48,10 +48,11 @@ func (r RespState) Events() ([]Event, error) {
 		eventsByID[r.AuthEvents[i].EventID()] = &r.AuthEvents[i]
 	}
 
-	visited := map[*Event]bool{}
+	queued := map[*Event]bool{}
+	outputted := map[*Event]bool{}
 	var result []Event
 	for _, event := range eventsByID {
-		if visited[event] {
+		if outputted[event] {
 			// If we've already written the event then we can skip it.
 			continue
 		}
@@ -63,9 +64,11 @@ func (r RespState) Events() ([]Event, error) {
 		// that we can check we aren't creating cycles.
 		stack := []*Event{event}
 
-	LoopStack:
+	LoopProcessTopOfStack:
 		for len(stack) > 0 {
 			top := stack[len(stack)-1]
+			// Check if we can output the top of the stack.
+			// We can output it if we have outputted all of its auth_events.
 			for _, ref := range top.AuthEvents() {
 				authEvent := eventsByID[ref.EventID]
 				if authEvent == nil {
@@ -74,28 +77,27 @@ func (r RespState) Events() ([]Event, error) {
 						ref.EventID, top.EventID(),
 					)
 				}
-				if visited[authEvent] {
+				if outputted[authEvent] {
 					continue
 				}
-				for i := range stack {
-					if stack[i] == authEvent {
-						return nil, fmt.Errorf(
-							"gomatrixserverlib: auth event cycle for ID %q",
-							ref.EventID,
-						)
-					}
+				if queued[authEvent] {
+					return nil, fmt.Errorf(
+						"gomatrixserverlib: auth event cycle for ID %q",
+						ref.EventID,
+					)
 				}
 				// If we haven't visited the auth event yet then we need to
 				// process it before processing the event currently on top of
 				// the stack.
 				stack = append(stack, authEvent)
-				continue LoopStack
+				queued[authEvent] = true
+				continue LoopProcessTopOfStack
 			}
 			// If we've processed all the auth events for the event on top of
-			// the stack then we can append it to the result an try processing
+			// the stack then we can append it to the result and try processing
 			// the item below it in the stack.
 			result = append(result, *top)
-			visited[top] = true
+			outputted[top] = true
 			stack = stack[:len(stack)-1]
 		}
 	}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -36,6 +36,7 @@ type RespState struct {
 
 // Events combines the auth events and the state events and returns
 // them in an order where every event comes after its auth events.
+// Each event will only appear once in the output list.
 // Returns an error if there are missing auth events or if there is
 // a cycle in the auth events.
 func (r RespState) Events() ([]Event, error) {


### PR DESCRIPTION
Returns the events in an order where every event comes after its
auth_events. This is necessary to insert the events into the roomserver
in dendrite.