### PR TITLE
Add misspell to the precommit hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ install:
  - go get golang.org/x/crypto/ed25519
  - go get github.com/matrix-org/util
  - go get github.com/matrix-org/gomatrix
+ - go get github.com/client9/misspell/...
 script: ./hooks/pre-commit

--- a/event.go
+++ b/event.go
@@ -54,7 +54,7 @@ type EventBuilder struct {
 	Type string `json:"type"`
 	// The state_key of the event if the event is a state event or nil if the event is not a state event.
 	StateKey *string `json:"state_key,omitempty"`
-	// The events that immediately preceeded this event in the room history.
+	// The events that immediately preceded this event in the room history.
 	PrevEvents []EventReference `json:"prev_events"`
 	// The events needed to authenticate this event.
 	AuthEvents []EventReference `json:"auth_events"`
@@ -112,7 +112,7 @@ var emptyEventReferenceList = []EventReference{}
 // Build a new Event.
 // This is used when a local event is created on this server.
 // Call this after filling out the necessary fields.
-// This can be called mutliple times on the same builder.
+// This can be called multiple times on the same builder.
 // A different event ID must be supplied each time this is called.
 func (eb *EventBuilder) Build(eventID string, now time.Time, origin ServerName, keyID KeyID, privateKey ed25519.PrivateKey) (result Event, err error) {
 	var event struct {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -213,7 +213,7 @@ type respSendJoinFields struct {
 	AuthEvents  []Event `json:"auth_chain"`
 }
 
-// Check that a reponse to /send_join is valid.
+// Check that a response to /send_join is valid.
 // This checks that it would be valid as a response to /state
 // This also checks that the join event is allowed by the state.
 func (r RespSendJoin) Check(keyRing KeyRing, joinEvent Event) error {

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,6 +3,7 @@
 set -eu
 
 golint ./...
+misspell -error .
 go fmt
 go tool vet --all --shadow .
 gocyclo -over 16 .

--- a/json.go
+++ b/json.go
@@ -23,7 +23,7 @@ import (
 	"unicode/utf8"
 )
 
-// CanonicalJSON re-encodes the JSON in a cannonical encoding. The encoding is
+// CanonicalJSON re-encodes the JSON in a canonical encoding. The encoding is
 // the shortest possible encoding using integer values with sorted object keys.
 // https://matrix.org/docs/spec/server_server/unstable.html#canonical-json
 func CanonicalJSON(input []byte) ([]byte, error) {
@@ -223,7 +223,7 @@ func compactUnicodeEscape(input, output []byte, index int) ([]byte, int) {
 // Taken from https://github.com/NegativeMjark/indolentjson-rust/blob/8b959791fe2656a88f189c5d60d153be05fe3deb/src/readhex.rs#L21
 func readHexDigits(input []byte) uint32 {
 	hex := binary.BigEndian.Uint32(input)
-	// substract '0'
+	// subtract '0'
 	hex -= 0x30303030
 	// strip the higher bits, maps 'a' => 'A'
 	hex &= 0x1F1F1F1F

--- a/keys.go
+++ b/keys.go
@@ -167,7 +167,7 @@ type KeyChecks struct {
 	AllEd25519ChecksOK        *bool                   // All the Ed25519 checks are ok. or null if there weren't any to check.
 	Ed25519Checks             map[KeyID]Ed25519Checks // Checks for Ed25519 keys.
 	HasTLSFingerprint         bool                    // The server has at least one fingerprint.
-	AllTLSFingerprintChecksOK *bool                   // All the fingerpint checks are ok.
+	AllTLSFingerprintChecksOK *bool                   // All the fingerprint checks are ok.
 	TLSFingerprintChecks      []TLSFingerprintChecks  // Checks for TLS fingerprints.
 	MatchingTLSFingerprint    *bool                   // The TLS fingerprint for the connection matches one of the listed fingerprints.
 }

--- a/transaction.go
+++ b/transaction.go
@@ -24,7 +24,7 @@ type Transaction struct {
 }
 
 // A TransactionID identifies a transaction sent by a matrix server to another
-// matrix server. The ID must be unique amoungst the transactions sent from the
+// matrix server. The ID must be unique amongst the transactions sent from the
 // origin server to the destination, but doesn't have to be globally unique.
 // The ID must be safe to insert into a URL path segment. The ID should have a
 // format matching '^[0-9A-Za-z\-_]*$'


### PR DESCRIPTION
This seems like a quick way to avoid some common spelling mistakes