### PR TITLE
Fix error message on domain mismatch

### DIFF
--- a/event.go
+++ b/event.go
@@ -422,7 +422,7 @@ func (e Event) CheckFields() error {
 		if e.fields.Type != MRoomMember {
 			return fmt.Errorf(
 				"gomatrixserverlib: sender domain doesn't match origin: %q != %q",
-				eventDomain, e.fields.Origin,
+				senderDomain, e.fields.Origin,
 			)
 		}
 		c, err := newMemberContentFromEvent(e)
@@ -432,7 +432,7 @@ func (e Event) CheckFields() error {
 		if c.Membership != invite || c.ThirdPartyInvite == nil {
 			return fmt.Errorf(
 				"gomatrixserverlib: sender domain doesn't match origin: %q != %q",
-				eventDomain, e.fields.Origin,
+				senderDomain, e.fields.Origin,
 			)
 		}
 	}


### PR DESCRIPTION
In the message happening on a mismatch between an event's domain and its sender's domain, the wrong variable was used, resulting in meaningless errors such as

```
sender domain doesn't match origin: "matrix.org" != "matrix.org"
```