### PR TITLE
Use gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: go
 go:
  - 1.8
 install:
- - go get github.com/golang/lint/golint
- - go get github.com/fzipp/gocyclo
+ - go get github.com/alecthomas/gometalinter
  - go get golang.org/x/crypto/ed25519
  - go get github.com/matrix-org/util
  - go get github.com/matrix-org/gomatrix
- - go get github.com/client9/misspell/...
- - go get github.com/gordonklaus/ineffassign
 script: ./hooks/pre-commit

--- a/client.go
+++ b/client.go
@@ -114,7 +114,7 @@ func (fc *Client) LookupUserInfo(matrixServer ServerName, token string) (u UserI
 	var response *http.Response
 	response, err = fc.client.Get(url.String())
 	if response != nil {
-		defer response.Body.Close()
+		defer response.Body.Close() // nolint: errcheck
 	}
 	if err != nil {
 		return
@@ -152,7 +152,7 @@ func (fc *Client) LookupUserInfo(matrixServer ServerName, token string) (u UserI
 // return a cached copy of the keys or whether they will need to retrieve a fresh
 // copy of the keys.
 // Returns the keys or an error if there was a problem talking to the server.
-func (fc *Client) LookupServerKeys(
+func (fc *Client) LookupServerKeys( // nolint: gocyclo
 	matrixServer ServerName, keyRequests map[PublicKeyRequest]Timestamp,
 ) (map[PublicKeyRequest]ServerKeys, error) {
 	url := url.URL{
@@ -185,7 +185,7 @@ func (fc *Client) LookupServerKeys(
 
 	response, err := fc.client.Post(url.String(), "application/json", bytes.NewBuffer(requestBytes))
 	if response != nil {
-		defer response.Body.Close()
+		defer response.Body.Close() // nolint: errcheck
 	}
 	if err != nil {
 		return nil, err

--- a/clientevent_test.go
+++ b/clientevent_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestToClientEvent(t *testing.T) {
+func TestToClientEvent(t *testing.T) { // nolint: gocyclo
 	ev, err := NewEventFromTrustedJSON([]byte(`{
 		"type": "m.room.name",
 		"state_key": "",

--- a/event.go
+++ b/event.go
@@ -361,7 +361,7 @@ const (
 // Returns an error if the total length of the event JSON is too long.
 // Returns an error if the event ID doesn't match the origin of the event.
 // https://matrix.org/docs/spec/client_server/r0.2.0.html#size-limits
-func (e Event) CheckFields() error {
+func (e Event) CheckFields() error { // nolint: gocyclo
 	if len(e.eventJSON) > maxEventLength {
 		return fmt.Errorf(
 			"gomatrixserverlib: event is too long, length %d > maximum %d",

--- a/eventauth.go
+++ b/eventauth.go
@@ -83,7 +83,7 @@ func (s StateNeeded) Tuples() (res []StateKeyTuple) {
 // AuthEventReferences returns the auth_events references for the StateNeeded. Returns an error if the
 // provider returns an error. If an event is missing from the provider but is required in StateNeeded, it
 // is skipped over: no error is returned.
-func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []EventReference, err error) {
+func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []EventReference, err error) { // nolint: gocyclo
 	var e *Event
 	if s.Create {
 		if e, err = provider.Create(); err != nil {
@@ -299,7 +299,7 @@ func (a *AuthEvents) ThirdPartyInvite(stateKey string) (*Event, error) {
 func NewAuthEvents(events []*Event) AuthEvents {
 	a := AuthEvents{make(map[StateKeyTuple]*Event)}
 	for _, e := range events {
-		a.AddEvent(e)
+		a.AddEvent(e) // nolint: errcheck
 	}
 	return a
 }
@@ -812,7 +812,7 @@ func newMembershipAllower(authEvents AuthEventProvider, event Event) (m membersh
 }
 
 // membershipAllowed checks whether the membership event is allowed
-func (m *membershipAllower) membershipAllowed(event Event) error {
+func (m *membershipAllower) membershipAllowed(event Event) error { // nolint: gocyclo
 	if m.create.roomID != event.RoomID() {
 		return errorf("create event has different roomID: %q != %q", event.RoomID(), m.create.roomID)
 	}
@@ -856,7 +856,7 @@ func (m *membershipAllower) membershipAllowed(event Event) error {
 }
 
 // membershipAllowedSelf determines if the change made by the user to their own membership is allowed.
-func (m *membershipAllower) membershipAllowedSelf() error {
+func (m *membershipAllower) membershipAllowedSelf() error { // nolint: gocyclo
 	if m.newMember.Membership == join {
 		// A user that is not in the room is allowed to join if the room
 		// join rules are "public".
@@ -890,7 +890,7 @@ func (m *membershipAllower) membershipAllowedSelf() error {
 }
 
 // membershipAllowedOther determines if the user is allowed to change the membership of another user.
-func (m *membershipAllower) membershipAllowedOther() error {
+func (m *membershipAllower) membershipAllowedOther() error { // nolint: gocyclo
 	senderLevel := m.powerLevels.userLevel(m.senderID)
 	targetLevel := m.powerLevels.userLevel(m.targetID)
 

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -128,7 +128,9 @@ func TestStateNeededForJoin(t *testing.T) {
 		StateKey: &skey,
 		Sender:   "@u1:a",
 	}
-	b.SetContent(memberContent{"join", nil})
+	if err := b.SetContent(memberContent{"join", nil}); err != nil {
+		t.Fatal(err)
+	}
 	testStateNeededForAuth(t, `[{
 		"type": "m.room.member",
 		"state_key": "@u1:a",
@@ -149,7 +151,9 @@ func TestStateNeededForInvite(t *testing.T) {
 		StateKey: &skey,
 		Sender:   "@u1:a",
 	}
-	b.SetContent(memberContent{"invite", nil})
+	if err := b.SetContent(memberContent{"invite", nil}); err != nil {
+		t.Fatal(err)
+	}
 	testStateNeededForAuth(t, `[{
 		"type": "m.room.member",
 		"state_key": "@u2:b",
@@ -169,7 +173,9 @@ func TestStateNeededForInvite3PID(t *testing.T) {
 		StateKey: &skey,
 		Sender:   "@u1:a",
 	}
-	b.SetContent(memberContent{"invite", rawJSON(`{"signed":{"token":"my_token"}}`)})
+	if err := b.SetContent(memberContent{"invite", rawJSON(`{"signed":{"token":"my_token"}}`)}); err != nil {
+		t.Fatal(err)
+	}
 	testStateNeededForAuth(t, `[{
 		"type": "m.room.member",
 		"state_key": "@u2:b",

--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -98,7 +98,7 @@ func checkEventContentHash(eventJSON []byte) error {
 
 	sha256Hash := sha256.Sum256(hashableEventJSON)
 
-	if bytes.Compare(sha256Hash[:], []byte(hashes.Sha256)) != 0 {
+	if !bytes.Equal(sha256Hash[:], []byte(hashes.Sha256)) {
 		return fmt.Errorf("Invalid Sha256 content hash: %v != %v", sha256Hash[:], []byte(hashes.Sha256))
 	}
 
@@ -187,7 +187,7 @@ func verifyEventSignature(signingName string, keyID KeyID, publicKey ed25519.Pub
 
 // VerifyEventSignatures checks that each event in a list of events has valid
 // signatures from the server that sent it.
-func VerifyEventSignatures(events []Event, keyRing KeyRing) error {
+func VerifyEventSignatures(events []Event, keyRing KeyRing) error { // nolint: gocyclo
 	var toVerify []VerifyJSONRequest
 	for _, event := range events {
 		redactedJSON, err := redactEvent(event.eventJSON)

--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/eventcrypto_test.go
+++ b/eventcrypto_test.go
@@ -18,8 +18,9 @@ package gomatrixserverlib
 import (
 	"bytes"
 	"encoding/base64"
-	"golang.org/x/crypto/ed25519"
 	"testing"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 func TestVerifyEventSignatureTestVectors(t *testing.T) {

--- a/federationclient.go
+++ b/federationclient.go
@@ -2,11 +2,12 @@ package gomatrixserverlib
 
 import (
 	"encoding/json"
-	"github.com/matrix-org/gomatrix"
-	"golang.org/x/crypto/ed25519"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/matrix-org/gomatrix"
+	"golang.org/x/crypto/ed25519"
 )
 
 // An FederationClient is a matrix federation client that adds

--- a/federationclient.go
+++ b/federationclient.go
@@ -42,7 +42,7 @@ func (ac *FederationClient) doRequest(r FederationRequest, resBody interface{}) 
 
 	res, err := ac.client.Do(req)
 	if res != nil {
-		defer res.Body.Close()
+		defer res.Body.Close() // nolint: errcheck
 	}
 
 	if err != nil {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -185,9 +185,7 @@ func (r RespSendJoin) MarshalJSON() ([]byte, error) {
 	// (This protocol oddity is the result of a typo in the synapse matrix
 	//  server, and is preserved to maintain compatibility.)
 
-	return json.Marshal([]interface{}{200, respSendJoinFields{
-		r.StateEvents, r.AuthEvents,
-	}})
+	return json.Marshal([]interface{}{200, respSendJoinFields(r)})
 }
 
 // UnmarshalJSON implements json.Unmarshaller

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,23 +2,17 @@
 
 set -eu
 
-golint ./...
-misspell -error .
+echo "Installing lint search engine..."
+go install github.com/alecthomas/gometalinter/
+gometalinter --config=linter.json --install
 
-# gofmt doesn't exit with an error code if the files don't match the expected
-# format. So we have to run it and see if it outputs anything.
-if gofmt -l -s . 2>&1 | read
-then
-    echo "Error: not all code had been formatted with gofmt."
-    echo "Fixing the following files"
-    gofmt -s -w -l .
-    echo
-    echo "Please add them to the commit"
-    git status --short
-    exit 1
-fi
+echo "Looking for lint..."
+gometalinter --config=linter.json
 
-ineffassign .
-go tool vet --all --shadow .
-gocyclo -over 16 .
-go test -timeout 5s . ./...
+echo "Double checking spelling..."
+misspell -error src *.md
+
+echo "Testing..."
+go test
+
+echo "Done!"

--- a/keyring.go
+++ b/keyring.go
@@ -2,9 +2,10 @@ package gomatrixserverlib
 
 import (
 	"fmt"
-	"golang.org/x/crypto/ed25519"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // A PublicKeyRequest is a request for a public key with a particular key ID.

--- a/keyring.go
+++ b/keyring.go
@@ -72,7 +72,7 @@ type VerifyJSONResult struct {
 // The caller should check the Result field for each entry to see if it was valid.
 // Returns an error if there was a problem talking to the database or one of the other methods
 // of fetching the public keys.
-func (k *KeyRing) VerifyJSONs(requests []VerifyJSONRequest) ([]VerifyJSONResult, error) {
+func (k *KeyRing) VerifyJSONs(requests []VerifyJSONRequest) ([]VerifyJSONResult, error) { // nolint: gocyclo
 	results := make([]VerifyJSONResult, len(requests))
 	keyIDs := make([][]KeyID, len(requests))
 

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 var privateKeySeed1 = `QJvXAPj0D9MUb1exkD8pIWmCvT1xajlsB8jRYz/G5HE`
-var privateKeySeed2 = `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
 
 // testKeys taken from a copy of synapse.
 var testKeys = `{

--- a/linter.json
+++ b/linter.json
@@ -13,6 +13,8 @@
         "gas",
         "misspell",
         "gosimple",
-        "megacheck"
+        "megacheck",
+        "unparam",
+        "goimports"
     ]
 }

--- a/linter.json
+++ b/linter.json
@@ -12,6 +12,7 @@
         "ineffassign",
         "gas",
         "misspell",
-        "gosimple"
+        "gosimple",
+        "megacheck"
     ]
 }

--- a/linter.json
+++ b/linter.json
@@ -15,6 +15,11 @@
         "gosimple",
         "megacheck",
         "unparam",
-        "goimports"
+        "goimports",
+        "goconst",
+        "unconvert",
+        "errcheck",
+        "interfacer",
+        "testify"
     ]
 }

--- a/linter.json
+++ b/linter.json
@@ -1,0 +1,17 @@
+{
+    "Enable": [
+        "vet",
+        "vetshadow",
+        "gotype",
+        "deadcode",
+        "gocyclo",
+        "golint",
+        "varcheck",
+        "structcheck",
+        "aligncheck",
+        "ineffassign",
+        "gas",
+        "misspell",
+        "gosimple"
+    ]
+}

--- a/request.go
+++ b/request.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/matrix-org/util"
-	"golang.org/x/crypto/ed25519"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/matrix-org/util"
+	"golang.org/x/crypto/ed25519"
 )
 
 // A FederationRequest is a request to send to a remote server or a request

--- a/request.go
+++ b/request.go
@@ -156,7 +156,7 @@ func (r *FederationRequest) HTTPRequest() (*http.Request, error) {
 //
 //    qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / %x80-FF
 //
-func isSafeInHTTPQuotedString(text string) bool {
+func isSafeInHTTPQuotedString(text string) bool { // nolint: gocyclo
 	for i := 0; i < len(text); i++ {
 		c := text[i]
 		switch {
@@ -234,7 +234,7 @@ func VerifyHTTPRequest(
 }
 
 // Returns an error if there was a problem reading the content of the request
-func readHTTPRequest(req *http.Request) (*FederationRequest, error) {
+func readHTTPRequest(req *http.Request) (*FederationRequest, error) { // nolint: gocyclo
 	var result FederationRequest
 
 	result.fields.Method = req.Method

--- a/request_test.go
+++ b/request_test.go
@@ -159,7 +159,6 @@ func TestVerifyPutRequest(t *testing.T) {
 }
 
 var privateKey1 = mustLoadPrivateKey(privateKeySeed1)
-var privateKey2 = mustLoadPrivateKey(privateKeySeed2)
 
 func mustLoadPrivateKey(seed string) ed25519.PrivateKey {
 	seedBytes, err := base64.RawStdEncoding.DecodeString(seed)

--- a/request_test.go
+++ b/request_test.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
-	"golang.org/x/crypto/ed25519"
 	"net/http"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // This GET request is taken from a request made by a synapse run by sytest.

--- a/resolve.go
+++ b/resolve.go
@@ -38,12 +38,12 @@ type DNSResult struct {
 }
 
 // LookupServer looks up a matrix server in DNS.
-func LookupServer(serverName ServerName) (*DNSResult, error) {
+func LookupServer(serverName ServerName) (*DNSResult, error) { // nolint: gocyclo
 	var result DNSResult
 	result.Hosts = map[string]HostResult{}
 
 	hosts := map[string][]net.SRV{}
-	if strings.Index(string(serverName), ":") == -1 {
+	if strings.Contains(string(serverName), ":") {
 		// If there isn't an explicit port set then try to look up the SRV record.
 		var err error
 		result.SRVCName, result.SRVRecords, err = net.LookupSRV("matrix", "tcp", string(serverName))

--- a/signing.go
+++ b/signing.go
@@ -18,6 +18,7 @@ package gomatrixserverlib
 import (
 	"encoding/json"
 	"fmt"
+
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/stateresolution.go
+++ b/stateresolution.go
@@ -99,7 +99,7 @@ func (r *stateResolver) Member(key string) (*Event, error) {
 	return r.resolvedMembers[key], nil
 }
 
-func (r *stateResolver) addConflicted(events []Event) {
+func (r *stateResolver) addConflicted(events []Event) { // nolint: gocyclo
 	type conflictKey struct {
 		eventType string
 		stateKey  string


### PR DESCRIPTION
Inspired by matrix-org/dendrite#210

However:
  * It doesn't vendor the linters
  * It enables more of the linters
  * The linters have been left on their default settings
  * Offending code has been annotated with // nolint as required.