### PR TITLE
Support for third-party invites

### DIFF
--- a/base64.go
+++ b/base64.go
@@ -18,6 +18,7 @@ package gomatrixserverlib
 import (
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 )
 
 // A Base64String is a string of bytes that are base64 encoded when used in JSON.
@@ -43,6 +44,12 @@ func (b64 *Base64String) UnmarshalJSON(raw []byte) (err error) {
 	if err = json.Unmarshal(raw, &str); err != nil {
 		return
 	}
-	*b64, err = base64.RawStdEncoding.DecodeString(str)
+	// We must check whether the string was encoded in a URL-safe way in order
+	// to use the appropriate encoding.
+	if strings.ContainsAny(str, "-_") {
+		*b64, err = base64.RawURLEncoding.DecodeString(str)
+	} else {
+		*b64, err = base64.RawStdEncoding.DecodeString(str)
+	}
 	return
 }

--- a/base64_test.go
+++ b/base64_test.go
@@ -45,6 +45,19 @@ func TestUnmarshalBase64(t *testing.T) {
 	}
 }
 
+func TestUnmarshalUrlSafeBase64(t *testing.T) {
+	input := []byte(`"dGhpc_9pc_9h_3Rlc3Q"`)
+	want := "this\xffis\xffa\xfftest"
+	var got Base64String
+	err := json.Unmarshal(input, &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("json.Unmarshal(%q): wanted %q got %q", string(input), want, string(got))
+	}
+}
+
 func TestMarshalBase64Struct(t *testing.T) {
 	input := struct{ Value Base64String }{Base64String("this\xffis\xffa\xfftest")}
 	want := `{"Value":"dGhpc/9pc/9h/3Rlc3Q"}`

--- a/eventauth.go
+++ b/eventauth.go
@@ -18,6 +18,9 @@ package gomatrixserverlib
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/matrix-org/util"
 )
@@ -766,6 +769,8 @@ type membershipAllower struct {
 	powerLevels powerLevelContent
 	// The m.room.join_rules content for the room.
 	joinRule joinRuleContent
+	// The m.room.third_party_invite content referenced by this event.
+	thirdPartyInvite thirdPartyInviteContent
 }
 
 // newMembershipAllower loads the information needed to authenticate the m.room.member event
@@ -797,6 +802,13 @@ func newMembershipAllower(authEvents AuthEventProvider, event Event) (m membersh
 	// We only need to check the join rules if the proposed membership is "join".
 	if m.newMember.Membership == "join" {
 		if m.joinRule, err = newJoinRuleContentFromAuthEvents(authEvents); err != nil {
+			return
+		}
+	}
+	// If this event comes from a third_party_invite, we need to check it against the original event.
+	if m.newMember.ThirdPartyInvite != nil {
+		token := m.newMember.ThirdPartyInvite.Signed.Token
+		if m.thirdPartyInvite, err = newThirdPartyInviteContentFromAuthEvents(authEvents, token); err != nil {
 			return
 		}
 	}
@@ -835,7 +847,7 @@ func (m *membershipAllower) membershipAllowed(event Event) error {
 	if m.newMember.Membership == invite && m.newMember.ThirdPartyInvite != nil {
 		// Special case third party invites
 		// https://github.com/matrix-org/synapse/blob/v0.18.5/synapse/api/auth.py#L393
-		panic(fmt.Errorf("ThirdPartyInvite not implemented"))
+		return m.membershipAllowedFronThirdPartyInvite()
 	}
 
 	if m.targetID == m.senderID {
@@ -845,6 +857,42 @@ func (m *membershipAllower) membershipAllowed(event Event) error {
 	}
 	// Otherwise this is an attempt to modify the membership of somebody else.
 	return m.membershipAllowedOther()
+}
+
+// membershipAllowedFronThirdPartyInvite determines if the member events is following
+// up the third_party_invite event it claims.
+func (m *membershipAllower) membershipAllowedFronThirdPartyInvite() error {
+	// Check if the event's target matches with the Matrix ID provided by the
+	// identity server.
+	if m.targetID != m.newMember.ThirdPartyInvite.Signed.MXID {
+		return errorf(
+			"The invite target %s doesn't match with the Matrix ID provided by the identity server %s",
+			m.targetID, m.newMember.ThirdPartyInvite.Signed.MXID,
+		)
+	}
+	// Marshal the "signed" so it can be verified by VerifyJSON.
+	marshalledSigned, err := json.Marshal(m.newMember.ThirdPartyInvite.Signed)
+	if err != nil {
+		return err
+	}
+	// Check each signature with each public key. If one signature could be
+	// verified with one public key, accept the event.
+	for _, publicKey := range m.thirdPartyInvite.PublicKeys {
+		for domain, signatures := range m.newMember.ThirdPartyInvite.Signed.Signatures {
+			for keyID := range signatures {
+				if strings.HasPrefix(keyID, "ed25519") {
+					if err = VerifyJSON(
+						domain, KeyID(keyID),
+						ed25519.PublicKey(publicKey.PublicKey),
+						marshalledSigned,
+					); err == nil {
+						return nil
+					}
+				}
+			}
+		}
+	}
+	return errorf("Couldn't verify signature on third-party invite for %s", m.targetID)
 }
 
 // membershipAllowedSelf determines if the change made by the user to their own membership is allowed.

--- a/eventauth.go
+++ b/eventauth.go
@@ -847,7 +847,7 @@ func (m *membershipAllower) membershipAllowed(event Event) error {
 	if m.newMember.Membership == invite && m.newMember.ThirdPartyInvite != nil {
 		// Special case third party invites
 		// https://github.com/matrix-org/synapse/blob/v0.18.5/synapse/api/auth.py#L393
-		return m.membershipAllowedFronThirdPartyInvite()
+		return m.membershipAllowedFromThirdPartyInvite()
 	}
 
 	if m.targetID == m.senderID {
@@ -861,7 +861,7 @@ func (m *membershipAllower) membershipAllowed(event Event) error {
 
 // membershipAllowedFronThirdPartyInvite determines if the member events is following
 // up the third_party_invite event it claims.
-func (m *membershipAllower) membershipAllowedFronThirdPartyInvite() error {
+func (m *membershipAllower) membershipAllowedFromThirdPartyInvite() error {
 	// Check if the event's target matches with the Matrix ID provided by the
 	// identity server.
 	if m.targetID != m.newMember.ThirdPartyInvite.Signed.MXID {

--- a/eventauth.go
+++ b/eventauth.go
@@ -224,15 +224,7 @@ func accumulateStateNeeded(result *StateNeeded, eventType, sender string, stateK
 }
 
 // thirdPartyInviteToken extracts the token from the third_party_invite.
-func thirdPartyInviteToken(thirdPartyInviteData rawJSON) (string, error) {
-	var thirdPartyInvite struct {
-		Signed struct {
-			Token string `json:"token"`
-		} `json:"signed"`
-	}
-	if err := json.Unmarshal(thirdPartyInviteData, &thirdPartyInvite); err != nil {
-		return "", err
-	}
+func thirdPartyInviteToken(thirdPartyInvite *memberThirdPartyInvite) (string, error) {
 	if thirdPartyInvite.Signed.Token == "" {
 		return "", fmt.Errorf("missing 'third_party_invite.signed.token' JSON key")
 	}
@@ -840,7 +832,7 @@ func (m *membershipAllower) membershipAllowed(event Event) error {
 		// Otherwise fall back to the normal checks.
 	}
 
-	if m.newMember.Membership == invite && len(m.newMember.ThirdPartyInvite) != 0 {
+	if m.newMember.Membership == invite && m.newMember.ThirdPartyInvite != nil {
 		// Special case third party invites
 		// https://github.com/matrix-org/synapse/blob/v0.18.5/synapse/api/auth.py#L393
 		panic(fmt.Errorf("ThirdPartyInvite not implemented"))

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -285,7 +285,7 @@ func testEventAllowed(t *testing.T, testCaseJSON string) {
 			panic(err)
 		}
 		if err := Allowed(event, &tc.AuthEvents); err == nil {
-			t.Fatalf("Expected %q to not be allowed but it was: %q", string(data), err)
+			t.Fatalf("Expected %q to not be allowed but it was", string(data))
 		}
 	}
 }

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -169,7 +169,12 @@ func TestStateNeededForInvite3PID(t *testing.T) {
 		StateKey: &skey,
 		Sender:   "@u1:a",
 	}
-	b.SetContent(memberContent{"invite", rawJSON(`{"signed":{"token":"my_token"}}`)})
+
+	b.SetContent(memberContent{"invite", &memberThirdPartyInvite{
+		Signed: memberThirdPartyInviteSigned{
+			Token: "my_token",
+		},
+	}})
 	testStateNeededForAuth(t, `[{
 		"type": "m.room.member",
 		"state_key": "@u2:b",

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -537,6 +537,146 @@ func TestAllowedWithNoPowerLevels(t *testing.T) {
 	}`)
 }
 
+func TestAllowedInviteFrom3PID(t *testing.T) {
+	testEventAllowed(t, `{
+		"auth_events": {
+			"create": {
+				"type": "m.room.create",
+				"state_key": "",
+				"sender": "@u1:a",
+				"room_id": "!r1:a",
+				"event_id": "$e1:a",
+				"content": {"creator": "@u1:a"}
+			},
+			"member": {
+				"@u1:a": {
+					"type": "m.room.member",
+					"sender": "@u1:a",
+					"room_id": "!r1:a",
+					"state_key": "@u1:a",
+					"event_id": "$e2:a",
+					"content": {"membership": "join"}
+				}
+			},
+			"third_party_invite": {
+				"my_token": {
+					"type": "m.room.third_party_invite",
+					"sender": "@u1:a",
+					"room_id": "!r1:a",
+					"state_key": "my_token",
+					"event_id": "$e3:a",
+					"content": {
+						"display_name": "foo...@bar...",
+						"public_key": "pubkey",
+						"key_validity_url": "https://example.tld/isvalid",
+						"public_keys": [
+							{
+								"public_key": "mrV51jApZKahGjfMhlevp+QtSSTDKCLaLVCzYc4HELY",
+								"key_validity_url": "https://example.tld/isvalid"
+							}
+						]
+					}
+				}
+			}
+		},
+		"allowed": [{
+			"type": "m.room.member",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"state_key": "@u2:a",
+			"event_id": "$e4:a",
+			"content": {
+				"membership": "invite",
+				"third_party_invite": {
+					"display_name": "foo...@bar...",
+					"signed": {
+						"token": "my_token",
+						"mxid": "@u2:a",
+						"signatures": {
+							"example.tld": {
+								"ed25519:0": "CibGFS0vX93quJFppsQbYQKJFIwxiYEK87lNmekS/fdetUMXPdR2wwNDd09J1jJ28GCH3GogUTuFDB1ScPFxBg"
+							}
+						}
+					}
+				}
+			}
+		}],
+		"not_allowed": [{
+			"type": "m.room.member",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"state_key": "@u2:a",
+			"event_id": "$e4:a",
+			"content": {
+				"membership": "invite",
+				"third_party_invite": {
+					"display_name": "foo...@bar...",
+					"signed": {
+						"token": "my_token",
+						"mxid": "@u2:a",
+						"signatures": {
+							"example.tld": {
+								"ed25519:0": "some_signature"
+							}
+						}
+					}
+				}
+			},
+			"unsigned": {
+				"not_allowed": "Bad signature"
+			}
+		}, {
+			"type": "m.room.member",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"state_key": "@u2:a",
+			"event_id": "$e5:a",
+			"content": {
+				"membership": "invite",
+				"third_party_invite": {
+					"display_name": "foo...@bar...",
+					"signed": {
+						"token": "my_token",
+						"mxid": "@u3:a",
+						"signatures": {
+							"example.tld": {
+								"ed25519:0": "CibGFS0vX93quJFppsQbYQKJFIwxiYEK87lNmekS/fdetUMXPdR2wwNDd09J1jJ28GCH3GogUTuFDB1ScPFxBg"
+							}
+						}
+					}
+				}
+			},
+			"unsigned": {
+				"not_allowed": "MXID doesn't match state key"
+			}
+		}, {
+			"type": "m.room.member",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"state_key": "@u2:a",
+			"event_id": "$e6:a",
+			"content": {
+				"membership": "invite",
+				"third_party_invite": {
+					"display_name": "foo...@bar...",
+					"signed": {
+						"token": "my_other_token",
+						"mxid": "@u2:a",
+						"signatures": {
+							"example.tld": {
+								"ed25519:0": "CibGFS0vX93quJFppsQbYQKJFIwxiYEK87lNmekS/fdetUMXPdR2wwNDd09J1jJ28GCH3GogUTuFDB1ScPFxBg"
+							}
+						}
+					}
+				}
+			},
+			"unsigned": {
+				"not_allowed": "Token doesn't refer to a known third-party invite"
+			}
+		}]
+	}`)
+}
+
 func TestAllowedNoFederation(t *testing.T) {
 	testEventAllowed(t, `{
 		"auth_events": {

--- a/eventcontent.go
+++ b/eventcontent.go
@@ -108,7 +108,18 @@ type memberContent struct {
 	// We use the membership key in order to check if the user is in the room.
 	Membership string `json:"membership"`
 	// We use the third_party_invite key to special case thirdparty invites.
-	ThirdPartyInvite rawJSON `json:"third_party_invite,omitempty"`
+	ThirdPartyInvite *memberThirdPartyInvite `json:"third_party_invite,omitempty"`
+}
+
+type memberThirdPartyInvite struct {
+	DisplayName string                       `json:"display_name"`
+	Signed      memberThirdPartyInviteSigned `json:"signed"`
+}
+
+type memberThirdPartyInviteSigned struct {
+	MXID       string                       `json:"mxid"`
+	Signatures map[string]map[string]string `json:"signatures"`
+	Token      string                       `json:"token"`
 }
 
 // newMemberContentFromAuthEvents loads the member content from the member event for the user ID in the auth events.
@@ -132,6 +143,37 @@ func newMemberContentFromAuthEvents(authEvents AuthEventProvider, userID string)
 func newMemberContentFromEvent(event Event) (c memberContent, err error) {
 	if err = json.Unmarshal(event.Content(), &c); err != nil {
 		err = errorf("unparsable member event content: %s", err.Error())
+		return
+	}
+	return
+}
+
+// thirdPartyInviteContent is the JSON content of a m.room.third_party_invite event needed for auth checks.
+// See https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-third-party-invite for descriptions of the fields.
+type thirdPartyInviteContent struct {
+	// Public keys are used to verify the signature of a m.room.member event that
+	// came from a m.room.third_party_invite event
+	PublicKeys []struct {
+		PublicKey Base64String `json:"public_key"`
+	} `json:"public_keys"`
+}
+
+func newThirdPartyInviteContentFromAuthEvents(authEvents AuthEventProvider, token string) (t thirdPartyInviteContent, err error) {
+	var thirdPartyInviteEvent *Event
+	if thirdPartyInviteEvent, err = authEvents.ThirdPartyInvite(token); err != nil {
+		return
+	}
+	if thirdPartyInviteEvent == nil {
+		// If there isn't a third_party_invite event, then we return with an error
+		err = errorf("Couldn't find third party invite event")
+		return
+	}
+	return newThirdPartyInviteContentFromEvent(*thirdPartyInviteEvent)
+}
+
+func newThirdPartyInviteContentFromEvent(event Event) (t thirdPartyInviteContent, err error) {
+	if err = json.Unmarshal(event.Content(), &t); err != nil {
+		err = errorf("unparsable third party invite event content: %s", err.Error())
 		return
 	}
 	return

--- a/eventcontent.go
+++ b/eventcontent.go
@@ -168,13 +168,8 @@ func newThirdPartyInviteContentFromAuthEvents(authEvents AuthEventProvider, toke
 		err = errorf("Couldn't find third party invite event")
 		return
 	}
-	return newThirdPartyInviteContentFromEvent(*thirdPartyInviteEvent)
-}
-
-func newThirdPartyInviteContentFromEvent(event Event) (t thirdPartyInviteContent, err error) {
-	if err = json.Unmarshal(event.Content(), &t); err != nil {
+	if err = json.Unmarshal(thirdPartyInviteEvent.Content(), &t); err != nil {
 		err = errorf("unparsable third party invite event content: %s", err.Error())
-		return
 	}
 	return
 }


### PR DESCRIPTION
This PR adds support for `m.room.member` events of `invite` membership derived from `m.room.third_party_invite` events.