### PR TITLE
Pass a `context.Context` to the federation client methods

### DIFF
--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -17,6 +17,7 @@ package gomatrixserverlib
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -188,7 +189,7 @@ func verifyEventSignature(signingName string, keyID KeyID, publicKey ed25519.Pub
 
 // VerifyEventSignatures checks that each event in a list of events has valid
 // signatures from the server that sent it.
-func VerifyEventSignatures(events []Event, keyRing KeyRing) error { // nolint: gocyclo
+func VerifyEventSignatures(ctx context.Context, events []Event, keyRing KeyRing) error { // nolint: gocyclo
 	var toVerify []VerifyJSONRequest
 	for _, event := range events {
 		redactedJSON, err := redactEvent(event.eventJSON)
@@ -222,7 +223,7 @@ func VerifyEventSignatures(events []Event, keyRing KeyRing) error { // nolint: g
 		}
 	}
 
-	results, err := keyRing.VerifyJSONs(toVerify)
+	results, err := keyRing.VerifyJSONs(ctx, toVerify)
 	if err != nil {
 		return err
 	}

--- a/federationclient.go
+++ b/federationclient.go
@@ -141,14 +141,16 @@ func (ac *FederationClient) SendJoin(
 // server.
 // This is used to exchange a m.room.third_party_invite event for a m.room.member
 // one in a room the local server isn't a member of.
-func (ac *FederationClient) ExchangeThirdPartyInvite(s ServerName, builder EventBuilder) (err error) {
+func (ac *FederationClient) ExchangeThirdPartyInvite(
+	ctx context.Context, s ServerName, builder EventBuilder,
+) (err error) {
 	path := "/_matrix/federation/v1/exchange_third_party_invite/" +
 		url.PathEscape(builder.RoomID)
 	req := NewFederationRequest("PUT", s, path)
 	if err = req.SetContent(builder); err != nil {
 		return
 	}
-	err = ac.doRequest(req, nil)
+	err = ac.doRequest(ctx, req, nil)
 	return
 }
 

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -1,6 +1,7 @@
 package gomatrixserverlib
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -107,7 +108,7 @@ func (r RespState) Events() ([]Event, error) {
 }
 
 // Check that a response to /state is valid.
-func (r RespState) Check(keyRing KeyRing) error {
+func (r RespState) Check(ctx context.Context, keyRing KeyRing) error {
 	var allEvents []Event
 	for _, event := range r.AuthEvents {
 		if event.StateKey() == nil {
@@ -133,7 +134,7 @@ func (r RespState) Check(keyRing KeyRing) error {
 	}
 
 	// Check if the events pass signature checks.
-	if err := VerifyEventSignatures(allEvents, keyRing); err != nil {
+	if err := VerifyEventSignatures(ctx, allEvents, keyRing); err != nil {
 		return nil
 	}
 
@@ -214,11 +215,11 @@ type respSendJoinFields struct {
 // Check that a response to /send_join is valid.
 // This checks that it would be valid as a response to /state
 // This also checks that the join event is allowed by the state.
-func (r RespSendJoin) Check(keyRing KeyRing, joinEvent Event) error {
+func (r RespSendJoin) Check(ctx context.Context, keyRing KeyRing, joinEvent Event) error {
 	// First check that the state is valid.
 	// The response to /send_join has the same data as a response to /state
 	// and the checks for a response to /state also apply.
-	if err := RespState(r).Check(keyRing); err != nil {
+	if err := RespState(r).Check(ctx, keyRing); err != nil {
 		return err
 	}
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,13 +6,13 @@ echo "Installing lint search engine..."
 go get github.com/alecthomas/gometalinter/
 gometalinter --config=linter.json --install
 
+echo "Testing..."
+go test
+
 echo "Looking for lint..."
 gometalinter --config=linter.json
 
 echo "Double checking spelling..."
 misspell -error src *.md
-
-echo "Testing..."
-go test
 
 echo "Done!"

--- a/request.go
+++ b/request.go
@@ -215,7 +215,7 @@ func VerifyHTTPRequest(
 		return nil, util.MessageResponse(401, message)
 	}
 
-	results, err := keys.VerifyJSONs([]VerifyJSONRequest{{
+	results, err := keys.VerifyJSONs(req.Context(), []VerifyJSONRequest{{
 		ServerName: request.Origin(),
 		AtTS:       AsTimestamp(now),
 		Message:    toVerify,


### PR DESCRIPTION
This allows us to timeout and cancel requests to matrix servers.