### PR TITLE
Handle events where the sender and origin do not match

### DIFF
--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -189,7 +189,7 @@ func verifyEventSignature(signingName string, keyID KeyID, publicKey ed25519.Pub
 
 // VerifyEventSignatures checks that each event in a list of events has valid
 // signatures from the server that sent it.
-func VerifyEventSignatures(ctx context.Context, events []Event, keyRing KeyRing) error { // nolint: gocyclo
+func VerifyEventSignatures(ctx context.Context, events []Event, keyRing JSONVerifier) error { // nolint: gocyclo
 	var toVerify []VerifyJSONRequest
 	for _, event := range events {
 		redactedJSON, err := redactEvent(event.eventJSON)

--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -196,12 +196,26 @@ func VerifyEventSignatures(ctx context.Context, events []Event, keyRing JSONVeri
 		if err != nil {
 			return err
 		}
-		v := VerifyJSONRequest{
-			Message:    redactedJSON,
-			AtTS:       event.OriginServerTS(),
-			ServerName: event.Origin(),
+
+		domains := make(map[ServerName]bool)
+		domains[event.Origin()] = true
+
+		// in general, we expect the domain of the sender id to be the
+		// same as the origin; however there was a bug in an old version
+		// of synapse which meant that some joins/leaves used the origin
+		// and event id supplied by the helping server instead of the
+		// joining/leaving server.
+		//
+		// That's ok, provided it's signed by the sender's server too.
+		//
+		// XXX we may have to exclude 3pid invites here, as per
+		// https://github.com/matrix-org/synapse/blob/v0.21.0/synapse/event_auth.py#L58-L64.
+		//
+		senderDomain, err := domainFromID(event.Sender())
+		if err != nil {
+			return err
 		}
-		toVerify = append(toVerify, v)
+		domains[ServerName(senderDomain)] = true
 
 		// MRoomMember invite events are signed by both the server sending
 		// the invite and the server the invite is for.
@@ -216,10 +230,18 @@ func VerifyEventSignatures(ctx context.Context, events []Event, keyRing JSONVeri
 					return err
 				}
 				if c.Membership == invite {
-					v.ServerName = ServerName(targetDomain)
-					toVerify = append(toVerify, v)
+					domains[ServerName(targetDomain)] = true
 				}
 			}
+		}
+
+		for domain := range domains {
+			v := VerifyJSONRequest{
+				Message:    redactedJSON,
+				AtTS:       event.OriginServerTS(),
+				ServerName: domain,
+			}
+			toVerify = append(toVerify, v)
 		}
 	}
 

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -215,7 +215,9 @@ type respSendJoinFields struct {
 // This checks that it would be valid as a response to /state
 // This also checks that the join event is allowed by the state.
 func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent Event) error {
-	// First check that the state is valid.
+	// First check that the state is valid and that the events in the response
+	// are correctly signed.
+	//
 	// The response to /send_join has the same data as a response to /state
 	// and the checks for a response to /state also apply.
 	if err := RespState(r).Check(ctx, keyRing); err != nil {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -108,7 +108,7 @@ func (r RespState) Events() ([]Event, error) {
 }
 
 // Check that a response to /state is valid.
-func (r RespState) Check(ctx context.Context, keyRing KeyRing) error {
+func (r RespState) Check(ctx context.Context, keyRing JSONVerifier) error {
 	var allEvents []Event
 	for _, event := range r.AuthEvents {
 		if event.StateKey() == nil {
@@ -214,7 +214,7 @@ type respSendJoinFields struct {
 // Check that a response to /send_join is valid.
 // This checks that it would be valid as a response to /state
 // This also checks that the join event is allowed by the state.
-func (r RespSendJoin) Check(ctx context.Context, keyRing KeyRing, joinEvent Event) error {
+func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent Event) error {
 	// First check that the state is valid.
 	// The response to /send_join has the same data as a response to /state
 	// and the checks for a response to /state also apply.

--- a/keyring.go
+++ b/keyring.go
@@ -69,12 +69,18 @@ type VerifyJSONResult struct {
 	Error error
 }
 
-// VerifyJSONs performs bulk JSON signature verification for a list of VerifyJSONRequests.
-// Returns a list of VerifyJSONResults with the same length and order as the request list.
-// The caller should check the Result field for each entry to see if it was valid.
-// Returns an error if there was a problem talking to the database or one of the other methods
-// of fetching the public keys.
-func (k *KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) ([]VerifyJSONResult, error) { // nolint: gocyclo
+// A JSONVerifier is an object which can verify the signatures of JSON messages.
+type JSONVerifier interface {
+	// VerifyJSONs performs bulk JSON signature verification for a list of VerifyJSONRequests.
+	// Returns a list of VerifyJSONResults with the same length and order as the request list.
+	// The caller should check the Result field for each entry to see if it was valid.
+	// Returns an error if there was a problem talking to the database or one of the other methods
+	// of fetching the public keys.
+	VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) ([]VerifyJSONResult, error)
+}
+
+// VerifyJSONs implements JSONVerifier.
+func (k KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) ([]VerifyJSONResult, error) { // nolint: gocyclo
 	results := make([]VerifyJSONResult, len(requests))
 	keyIDs := make([][]KeyID, len(requests))
 

--- a/request.go
+++ b/request.go
@@ -184,7 +184,7 @@ func isSafeInHTTPQuotedString(text string) bool { // nolint: gocyclo
 // It consumes the body of the request.
 // The JSON content can be accessed using FederationRequest.Content()
 // Returns an 400 error if there was a problem parsing the request.
-// It authenticates the request using an ed25519 signature using the KeyRing.
+// It authenticates the request using an ed25519 signature using the JSONVerifier.
 // The origin server can be accessed using FederationRequest.Origin()
 // Returns a 401 error if there was a problem authenticating the request.
 // HTTP handlers using this should be careful that they only use the parts of
@@ -192,7 +192,7 @@ func isSafeInHTTPQuotedString(text string) bool { // nolint: gocyclo
 // the query parameters, and the JSON content. In particular the version of
 // HTTP and the headers aren't protected by the signature.
 func VerifyHTTPRequest(
-	req *http.Request, now time.Time, destination ServerName, keys KeyRing,
+	req *http.Request, now time.Time, destination ServerName, keys JSONVerifier,
 ) (*FederationRequest, util.JSONResponse) {
 	request, err := readHTTPRequest(req)
 	if err != nil {


### PR DESCRIPTION
It turns out that synapse had a bug for a while (at the end of 2015) where it would send out `join` events which used the event_id (and origin) from the helping server rather than the joining server. We need to accept these events so that we can join rooms which include such events.