### PR TITLE
Set a 30s timeout on client requests.

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,7 +48,9 @@ type UserInfo struct {
 
 // NewClient makes a new Client
 func NewClient() *Client {
-	return &Client{client: http.Client{Transport: newFederationTripper()}}
+	return &Client{client: http.Client{
+		Transport: newFederationTripper(),
+		Timeout:   requestTimeout}}
 }
 
 type federationTripper struct {
@@ -64,7 +66,7 @@ func newFederationTripper() *federationTripper {
 			// By avoiding the default implementation we can keep the ServerName
 			// as the empty string so that crypto/tls doesn't add SNI.
 			DialTLS: func(network, addr string) (net.Conn, error) {
-				rawconn, err := net.DialTimeout(network, addr, requestTimeout)
+				rawconn, err := net.Dial(network, addr)
 				if err != nil {
 					return nil, err
 				}

--- a/client.go
+++ b/client.go
@@ -26,10 +26,14 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/util"
 )
+
+// HTTP/HTTPS request timeout
+const requestTimeout time.Duration = time.Duration(30) * time.Second
 
 // A Client makes request to the federation listeners of matrix
 // homeservers
@@ -60,7 +64,7 @@ func newFederationTripper() *federationTripper {
 			// By avoiding the default implementation we can keep the ServerName
 			// as the empty string so that crypto/tls doesn't add SNI.
 			DialTLS: func(network, addr string) (net.Conn, error) {
-				rawconn, err := net.Dial(network, addr)
+				rawconn, err := net.DialTimeout(network, addr, requestTimeout)
 				if err != nil {
 					return nil, err
 				}

--- a/client.go
+++ b/client.go
@@ -32,7 +32,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-// HTTP/HTTPS request timeout
+// Default HTTPS request timeout
 const requestTimeout time.Duration = time.Duration(30) * time.Second
 
 // A Client makes request to the federation listeners of matrix
@@ -46,11 +46,16 @@ type UserInfo struct {
 	Sub string `json:"sub"`
 }
 
-// NewClient makes a new Client
+// NewClient makes a new Client (with default timeout)
 func NewClient() *Client {
+	return NewClientWithTimeout(requestTimeout)
+}
+
+// NewClientWithTimeout makes a new Client with a specified request timeout
+func NewClientWithTimeout(timeout time.Duration) *Client {
 	return &Client{client: http.Client{
 		Transport: newFederationTripper(),
-		Timeout:   requestTimeout}}
+		Timeout:   timeout}}
 }
 
 type federationTripper struct {


### PR DESCRIPTION
Scalar is not currently specifying HTTP timeouts. As mentioned here - https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779 - Go doesn't specify sensible defaults and we need to make sure that we do so, especially in production.

This was specifically brought to light via calls to scalar/api/register, which were timing out and filling up the apache front-end. This endpoint is designed to make outbound HTTP requests to provision a user on a HS. If the the destination HS is poorly configured or not set up for federation, it might fail such that it doesn't timeout.

See - matrix-org/scalar#260 for further details.