### PR TITLE
Make KeyFetcher interface return keys

### DIFF
--- a/base64.go
+++ b/base64.go
@@ -26,13 +26,31 @@ import (
 // When the bytes are unmarshalled from JSON they are decoded from base64.
 type Base64String []byte
 
+// Encode encodes the bytes as base64
+func (b64 Base64String) Encode() string {
+	return base64.RawStdEncoding.EncodeToString(b64)
+}
+
+// Decode decodes the given input into this Base64String
+func (b64 *Base64String) Decode(str string) error {
+	// We must check whether the string was encoded in a URL-safe way in order
+	// to use the appropriate encoding.
+	var err error
+	if strings.ContainsAny(str, "-_") {
+		*b64, err = base64.RawURLEncoding.DecodeString(str)
+	} else {
+		*b64, err = base64.RawStdEncoding.DecodeString(str)
+	}
+	return err
+}
+
 // MarshalJSON encodes the bytes as base64 and then encodes the base64 as a JSON string.
 // This takes a value receiver so that maps and slices of Base64String encode correctly.
 func (b64 Base64String) MarshalJSON() ([]byte, error) {
 	// This could be made more efficient by using base64.RawStdEncoding.Encode
 	// to write the base64 directly to the JSON. We don't need to JSON escape
 	// any of the characters used in base64.
-	return json.Marshal(base64.RawStdEncoding.EncodeToString(b64))
+	return json.Marshal(b64.Encode())
 }
 
 // UnmarshalJSON decodes a JSON string and then decodes the resulting base64.
@@ -44,12 +62,6 @@ func (b64 *Base64String) UnmarshalJSON(raw []byte) (err error) {
 	if err = json.Unmarshal(raw, &str); err != nil {
 		return
 	}
-	// We must check whether the string was encoded in a URL-safe way in order
-	// to use the appropriate encoding.
-	if strings.ContainsAny(str, "-_") {
-		*b64, err = base64.RawURLEncoding.DecodeString(str)
-	} else {
-		*b64, err = base64.RawStdEncoding.DecodeString(str)
-	}
+	err = b64.Decode(str)
 	return
 }

--- a/client.go
+++ b/client.go
@@ -172,10 +172,10 @@ func (fc *Client) LookupUserInfo(
 // Perspective servers can use that timestamp to determine whether they can
 // return a cached copy of the keys or whether they will need to retrieve a fresh
 // copy of the keys.
-// Returns the keys or an error if there was a problem talking to the server.
+// Returns the keys returned by the server, or an error if there was a problem talking to the server.
 func (fc *Client) LookupServerKeys(
 	ctx context.Context, matrixServer ServerName, keyRequests map[PublicKeyRequest]Timestamp,
-) (map[PublicKeyRequest]ServerKeys, error) {
+) ([]ServerKeys, error) {
 	url := url.URL{
 		Scheme: "matrix",
 		Host:   string(matrixServer),
@@ -221,19 +221,7 @@ func (fc *Client) LookupServerKeys(
 		return nil, err
 	}
 
-	result := map[PublicKeyRequest]ServerKeys{}
-	for _, keys := range body.ServerKeyList {
-		keys.FromServer = matrixServer
-		// TODO: What happens if the same key ID appears in multiple responses?
-		// We should probably take the response with the highest valid_until_ts.
-		for keyID := range keys.VerifyKeys {
-			result[PublicKeyRequest{keys.ServerName, keyID}] = keys
-		}
-		for keyID := range keys.OldVerifyKeys {
-			result[PublicKeyRequest{keys.ServerName, keyID}] = keys
-		}
-	}
-	return result, nil
+	return body.ServerKeyList, nil
 }
 
 // CreateMediaDownloadRequest creates a request for media on a homeserver and returns the http.Response or an error

--- a/keyring.go
+++ b/keyring.go
@@ -123,6 +123,8 @@ func (k KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) 
 	k.checkUsingKeys(requests, results, keyIDs, keysFromDatabase)
 
 	for i := range k.KeyFetchers {
+		// TODO: we should distinguish here between expired keys, and those we don't have.
+		// If the key has expired, it's no use re-requesting it.
 		keyRequests := k.publicKeyRequests(requests, results, keyIDs)
 		if len(keyRequests) == 0 {
 			// There aren't any keys to fetch so we can stop here.

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -2,7 +2,6 @@ package gomatrixserverlib
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 )
 
@@ -39,26 +38,44 @@ type testKeyDatabase struct{}
 
 func (db *testKeyDatabase) FetchKeys(
 	ctx context.Context, requests map[PublicKeyRequest]Timestamp,
-) (map[PublicKeyRequest]ServerKeys, error) {
-	results := map[PublicKeyRequest]ServerKeys{}
-	var keys ServerKeys
-	if err := json.Unmarshal([]byte(testKeys), &keys); err != nil {
-		return nil, err
-	}
+) (map[PublicKeyRequest]PublicKeyLookupResult, error) {
+	results := map[PublicKeyRequest]PublicKeyLookupResult{}
 
 	req1 := PublicKeyRequest{"localhost:8800", "ed25519:old"}
 	req2 := PublicKeyRequest{"localhost:8800", "ed25519:a_Obwu"}
 
 	for req := range requests {
-		if req == req1 || req == req2 {
-			results[req] = keys
+		if req == req1 {
+			vk := VerifyKey{}
+			err := vk.Key.Decode("O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik")
+			if err != nil {
+				return nil, err
+			}
+			results[req] = PublicKeyLookupResult{
+				VerifyKey:    vk,
+				ValidUntilTS: PublicKeyNotValid,
+				ExpiredTS:    929059200,
+			}
+		}
+
+		if req == req2 {
+			vk := VerifyKey{}
+			err := vk.Key.Decode("2UwTWD4+tgTgENV7znGGNqhAOGY+BW1mRAnC6W6FBQg")
+			if err != nil {
+				return nil, err
+			}
+			results[req] = PublicKeyLookupResult{
+				VerifyKey:    vk,
+				ValidUntilTS: 1493142432964,
+				ExpiredTS:    PublicKeyNotExpired,
+			}
 		}
 	}
 	return results, nil
 }
 
 func (db *testKeyDatabase) StoreKeys(
-	ctx context.Context, requests map[PublicKeyRequest]ServerKeys,
+	ctx context.Context, requests map[PublicKeyRequest]PublicKeyLookupResult,
 ) error {
 	return nil
 }
@@ -136,12 +153,12 @@ var testErrorStore = erroringKeyDatabaseError(2)
 
 func (e *erroringKeyDatabase) FetchKeys(
 	ctx context.Context, requests map[PublicKeyRequest]Timestamp,
-) (map[PublicKeyRequest]ServerKeys, error) {
+) (map[PublicKeyRequest]PublicKeyLookupResult, error) {
 	return nil, &testErrorFetch
 }
 
 func (e *erroringKeyDatabase) StoreKeys(
-	ctx context.Context, keys map[PublicKeyRequest]ServerKeys,
+	ctx context.Context, keys map[PublicKeyRequest]PublicKeyLookupResult,
 ) error {
 	return &testErrorStore
 }

--- a/keys.go
+++ b/keys.go
@@ -37,8 +37,6 @@ type ServerName string
 type ServerKeys struct {
 	// Copy of the raw JSON for signature checking.
 	Raw []byte
-	// The server the raw JSON was downloaded from.
-	FromServer ServerName
 	// The decoded JSON fields.
 	ServerKeyFields
 }
@@ -140,7 +138,6 @@ func FetchKeysDirect(serverName ServerName, addr, sni string) (*ServerKeys, *tls
 		return nil, nil, err
 	}
 	var keys ServerKeys
-	keys.FromServer = serverName
 	if err = json.NewDecoder(response.Body).Decode(&keys); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR reworks the KeyFetcher interface so that, for each key requested, it returns that key in the form of a PublicKeyLookupRequest, rather than the raw JSON which came from the /keys/v1/query response. This will give us a better basis on which to implement fetching keys from
perspectives servers.

The corollary is that we also need to update KeyDatabase to work at the higher level (of keys instead of JSON).

(We'll need to update the application level to handle the changes in interfaces).