### PR TITLE
Use /key/v2/server to get keys direct

### DIFF
--- a/client.go
+++ b/client.go
@@ -175,7 +175,29 @@ func (fc *Client) LookupUserInfo(
 	return
 }
 
-// LookupServerKeys lookups up the keys for a matrix server from a matrix server.
+// GetServerKeys asks a matrix server for its signing keys and TLS cert
+func (fc *Client) GetServerKeys(
+	ctx context.Context, matrixServer ServerName,
+) (ServerKeys, error) {
+	url := url.URL{
+		Scheme: "matrix",
+		Host:   string(matrixServer),
+		Path:   "/_matrix/key/v2/server",
+	}
+
+	var body ServerKeys
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return body, err
+	}
+
+	err = fc.DoRequestAndParseResponse(
+		ctx, req, &body,
+	)
+	return body, err
+}
+
+// LookupServerKeys looks up the keys for a matrix server from a matrix server.
 // The first argument is the name of the matrix server to download the keys from.
 // The second argument is a map from (server name, key ID) pairs to timestamps.
 // The (server name, key ID) pair identifies the key to download.

--- a/keyring.go
+++ b/keyring.go
@@ -333,9 +333,9 @@ func (d *DirectKeyFetcher) FetchKeys(
 	}
 
 	results := map[PublicKeyRequest]PublicKeyLookupResult{}
-	for server, reqs := range byServer {
+	for server := range byServer {
 		// TODO: make these requests in parallel
-		serverResults, err := d.fetchKeysForServer(ctx, server, reqs)
+		serverResults, err := d.fetchKeysForServer(ctx, server)
 		if err != nil {
 			// TODO: Should we actually be erroring here? or should we just drop those keys from the result map?
 			return nil, err
@@ -348,25 +348,23 @@ func (d *DirectKeyFetcher) FetchKeys(
 }
 
 func (d *DirectKeyFetcher) fetchKeysForServer(
-	ctx context.Context, serverName ServerName, requests map[PublicKeyRequest]Timestamp,
+	ctx context.Context, serverName ServerName,
 ) (map[PublicKeyRequest]PublicKeyLookupResult, error) {
-	serverKeys, err := d.Client.LookupServerKeys(ctx, serverName, requests)
+	keys, err := d.Client.GetServerKeys(ctx, serverName)
 	if err != nil {
 		return nil, err
 	}
+	// Check that the keys are valid for the server.
+	checks, _, _ := CheckKeys(serverName, time.Unix(0, 0), keys, nil)
+	if !checks.AllChecksOK {
+		return nil, fmt.Errorf("gomatrixserverlib: key response direct from %q failed checks", serverName)
+	}
 
 	results := map[PublicKeyRequest]PublicKeyLookupResult{}
-	for _, keys := range serverKeys {
-		// Check that the keys are valid for the server.
-		checks, _, _ := CheckKeys(serverName, time.Unix(0, 0), keys, nil)
-		if !checks.AllChecksOK {
-			return nil, fmt.Errorf("gomatrixserverlib: key response direct from %q failed checks", serverName)
-		}
 
-		// TODO: What happens if the same key ID appears in multiple responses?
-		// We should probably take the response with the highest valid_until_ts.
-		mapServerKeysToPublicKeyLookupResult(keys, results)
-	}
+	// TODO: What happens if the same key ID appears in multiple responses?
+	// We should probably take the response with the highest valid_until_ts.
+	mapServerKeysToPublicKeyLookupResult(keys, results)
 
 	return results, nil
 }

--- a/keyring.go
+++ b/keyring.go
@@ -303,7 +303,8 @@ func (p *PerspectiveKeyFetcher) FetchKeys(
 			return nil, fmt.Errorf("gomatrixserverlib: key response from perspective server failed checks")
 		}
 
-		// TODO: What happens if the same key ID appears in multiple responses?
+		// TODO (matrix-org/dendrite#345): What happens if the same key ID
+		// appears in multiple responses?
 		// We should probably take the response with the highest valid_until_ts.
 		mapServerKeysToPublicKeyLookupResult(keys, results)
 	}
@@ -363,8 +364,7 @@ func (d *DirectKeyFetcher) fetchKeysForServer(
 	results := map[PublicKeyRequest]PublicKeyLookupResult{}
 
 	// TODO (matrix-org/dendrite#345): What happens if the same key ID
-	// appears in multiple responses? We should probably take the response
-	// with the highest valid_until_ts.
+	// appears in multiple responses? We should probably reject the response.
 	mapServerKeysToPublicKeyLookupResult(keys, results)
 
 	return results, nil

--- a/keyring.go
+++ b/keyring.go
@@ -362,8 +362,9 @@ func (d *DirectKeyFetcher) fetchKeysForServer(
 
 	results := map[PublicKeyRequest]PublicKeyLookupResult{}
 
-	// TODO: What happens if the same key ID appears in multiple responses?
-	// We should probably take the response with the highest valid_until_ts.
+	// TODO (matrix-org/dendrite#345): What happens if the same key ID
+	// appears in multiple responses? We should probably take the response
+	// with the highest valid_until_ts.
 	mapServerKeysToPublicKeyLookupResult(keys, results)
 
 	return results, nil


### PR DESCRIPTION
... because /key/v2/query is only if you're talking to a perspectives server.