### PR TITLE
Make VerifyEventSignatures return a list of errors

### DIFF
--- a/eventcrypto_test.go
+++ b/eventcrypto_test.go
@@ -272,8 +272,10 @@ func (v *StubVerifier) VerifyJSONs(ctx context.Context, requests []VerifyJSONReq
 	return v.results, nil
 }
 
-func TestVerifyEventSignatures(t *testing.T) {
-	verifier := StubVerifier{}
+func TestVerifyAllEventSignatures(t *testing.T) {
+	verifier := StubVerifier{
+		results: make([]VerifyJSONResult, 2),
+	}
 
 	eventJSON := []byte(`{
 		"type": "m.room.name",
@@ -295,7 +297,7 @@ func TestVerifyEventSignatures(t *testing.T) {
 	event.eventJSON = eventJSON
 
 	events := []Event{event}
-	if err := VerifyEventSignatures(context.Background(), events, &verifier); err != nil {
+	if err := VerifyAllEventSignatures(context.Background(), events, &verifier); err != nil {
 		t.Fatal(err)
 	}
 
@@ -329,8 +331,10 @@ func TestVerifyEventSignatures(t *testing.T) {
 	}
 }
 
-func TestVerifyEventSignaturesForInvite(t *testing.T) {
-	verifier := StubVerifier{}
+func TestVerifyAllEventSignaturesForInvite(t *testing.T) {
+	verifier := StubVerifier{
+		results: make([]VerifyJSONResult, 2),
+	}
 
 	eventJSON := []byte(`{
 		"type": "m.room.member",
@@ -352,7 +356,7 @@ func TestVerifyEventSignaturesForInvite(t *testing.T) {
 	event.eventJSON = eventJSON
 
 	events := []Event{event}
-	if err := VerifyEventSignatures(context.Background(), events, &verifier); err != nil {
+	if err := VerifyAllEventSignatures(context.Background(), events, &verifier); err != nil {
 		t.Fatal(err)
 	}
 

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -138,7 +138,7 @@ func (r RespState) Check(ctx context.Context, keyRing JSONVerifier) error {
 
 	// Check if the events pass signature checks.
 	logger.Infof("Checking event signatures for %d events of room state", len(allEvents))
-	if err := VerifyEventSignatures(ctx, allEvents, keyRing); err != nil {
+	if err := VerifyAllEventSignatures(ctx, allEvents, keyRing); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
To implement room joins properly, we're going to need to figure out which
events are valid and which are not. A single error isn't going to cut it.

Also add VerifyAllEventSignatures which provides the old behaviour.