### PR TITLE
Fix timeouts for federationclient

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -2,7 +2,6 @@ package gomatrixserverlib
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 
 	"golang.org/x/crypto/ed25519"

--- a/federationclient.go
+++ b/federationclient.go
@@ -22,7 +22,7 @@ func NewFederationClient(
 	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           Client{client: http.Client{Transport: newFederationTripper()}},
+		Client:           *NewClient(),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,


### PR DESCRIPTION
Construct the Client used by FederationClient correctly, so that it is
configured to time out requests.