### PR TITLE
Improve logging of outgoing federation requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 )
 
 // Default HTTPS request timeout
@@ -332,10 +333,11 @@ func (fc *Client) DoRequestAndParseResponse(
 //
 func (fc *Client) DoHTTPRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
 	reqID := util.RandomString(12)
-	logger := util.GetLogger(ctx).
-		WithField("out.req.ID", reqID).
-		WithField("out.req.method", req.Method).
-		WithField("out.req.uri", req.URL)
+	logger := util.GetLogger(ctx).WithFields(logrus.Fields{
+		"out.req.ID":     reqID,
+		"out.req.method": req.Method,
+		"out.req.uri":    req.URL,
+	})
 	logger.Info("Outgoing request")
 	newCtx := util.ContextWithLogger(ctx, logger)
 
@@ -347,9 +349,10 @@ func (fc *Client) DoHTTPRequest(ctx context.Context, req *http.Request) (*http.R
 	}
 
 	// we haven't yet read the body, so this is slightly premature, but it's the easiest place.
-	logger.WithField("out.req.code", resp.StatusCode).
-		WithField("out.req.duration_ms", int(time.Since(start)/time.Millisecond)).
-		Info("Outgoing request returned")
+	logger.WithFields(logrus.Fields{
+		"out.req.code":        resp.StatusCode,
+		"out.req.duration_ms": int(time.Since(start) / time.Millisecond),
+	}).Info("Outgoing request returned")
 
 	return resp, nil
 }


### PR DESCRIPTION
Try to log outbound federation requests more consistently and more usefully