### PR TITLE
Add application service transaction and event types

### DIFF
--- a/appservice.go
+++ b/appservice.go
@@ -1,0 +1,35 @@
+/* Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gomatrixserverlib
+
+// ApplicationServiceEvent is an event format that is sent off to an
+// application service as part of a transaction.
+type ApplicationServiceEvent struct {
+	Age                   int64   `json:"age,omitempty"`
+	Content               rawJSON `json:"content,omitempty"`
+	EventID               string  `json:"event_id,omitempty"`
+	OriginServerTimestamp int64   `json:"origin_server_ts,omitempty"`
+	RoomID                string  `json:"room_id,omitempty"`
+	Sender                string  `json:"sender,omitempty"`
+	Type                  string  `json:"type,omitempty"`
+	UserID                string  `json:"user_id,omitempty"`
+}
+
+// ApplicationServiceTransaction is the transaction that is sent off to an
+// application service.
+type ApplicationServiceTransaction struct {
+	Events []ApplicationServiceEvent `json:"events"`
+}

--- a/appservice.go
+++ b/appservice.go
@@ -19,7 +19,7 @@ package gomatrixserverlib
 // application service as part of a transaction.
 type ApplicationServiceEvent struct {
 	Age                   int64   `json:"age,omitempty"`
-	Content               rawJSON `json:"content,omitempty"`
+	Content               RawJSON `json:"content,omitempty"`
 	EventID               string  `json:"event_id,omitempty"`
 	OriginServerTimestamp int64   `json:"origin_server_ts,omitempty"`
 	RoomID                string  `json:"room_id,omitempty"`

--- a/clientevent.go
+++ b/clientevent.go
@@ -28,7 +28,7 @@ const (
 
 // ClientEvent is an event which is fit for consumption by clients, in accordance with the specification.
 type ClientEvent struct {
-	Content        rawJSON   `json:"content"`
+	Content        RawJSON   `json:"content"`
 	EventID        string    `json:"event_id"`
 	OriginServerTS Timestamp `json:"origin_server_ts"`
 	// RoomID is omitted on /sync responses
@@ -36,7 +36,7 @@ type ClientEvent struct {
 	Sender   string  `json:"sender"`
 	StateKey *string `json:"state_key,omitempty"`
 	Type     string  `json:"type"`
-	Unsigned rawJSON `json:"unsigned,omitempty"`
+	Unsigned RawJSON `json:"unsigned,omitempty"`
 }
 
 // ToClientEvents converts server events to client events.
@@ -51,11 +51,11 @@ func ToClientEvents(serverEvs []Event, format EventFormat) []ClientEvent {
 // ToClientEvent converts a single server event to a client event.
 func ToClientEvent(se Event, format EventFormat) ClientEvent {
 	ce := ClientEvent{
-		Content:        rawJSON(se.Content()),
+		Content:        RawJSON(se.Content()),
 		Sender:         se.Sender(),
 		Type:           se.Type(),
 		StateKey:       se.StateKey(),
-		Unsigned:       rawJSON(se.Unsigned()),
+		Unsigned:       RawJSON(se.Unsigned()),
 		OriginServerTS: se.OriginServerTS(),
 		EventID:        se.EventID(),
 	}

--- a/event.go
+++ b/event.go
@@ -69,9 +69,9 @@ type EventBuilder struct {
 	// The create event has a depth of 1.
 	Depth int64 `json:"depth"`
 	// The JSON object for "content" key of the event.
-	Content rawJSON `json:"content"`
+	Content RawJSON `json:"content"`
 	// The JSON object for the "unsigned" key
-	Unsigned rawJSON `json:"unsigned,omitempty"`
+	Unsigned RawJSON `json:"unsigned,omitempty"`
 }
 
 // SetContent sets the JSON content key of the event.
@@ -102,12 +102,12 @@ type eventFields struct {
 	Sender         string           `json:"sender"`
 	Type           string           `json:"type"`
 	StateKey       *string          `json:"state_key"`
-	Content        rawJSON          `json:"content"`
+	Content        RawJSON          `json:"content"`
 	PrevEvents     []EventReference `json:"prev_events"`
 	AuthEvents     []EventReference `json:"auth_events"`
 	Redacts        string           `json:"redacts"`
 	Depth          int64            `json:"depth"`
-	Unsigned       rawJSON          `json:"unsigned"`
+	Unsigned       RawJSON          `json:"unsigned"`
 	OriginServerTS Timestamp        `json:"origin_server_ts"`
 	Origin         ServerName       `json:"origin"`
 }
@@ -284,7 +284,7 @@ func (e Event) Redact() Event {
 // SetUnsigned sets the unsigned key of the event.
 // Returns a copy of the event with the "unsigned" key set.
 func (e Event) SetUnsigned(unsigned interface{}) (Event, error) {
-	var eventAsMap map[string]rawJSON
+	var eventAsMap map[string]RawJSON
 	var err error
 	if err = json.Unmarshal(e.eventJSON, &eventAsMap); err != nil {
 		return Event{}, err
@@ -326,7 +326,7 @@ func (e *Event) SetUnsignedField(path string, value interface{}) error {
 	eventJSON = CanonicalJSONAssumeValid(eventJSON)
 
 	res := gjson.GetBytes(eventJSON, "unsigned")
-	unsigned := rawJSONFromResult(res, eventJSON)
+	unsigned := RawJSONFromResult(res, eventJSON)
 
 	e.eventJSON = eventJSON
 	e.fields.Unsigned = unsigned
@@ -617,7 +617,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaller
 func (er *EventReference) UnmarshalJSON(data []byte) error {
-	var tuple []rawJSON
+	var tuple []RawJSON
 	if err := json.Unmarshal(data, &tuple); err != nil {
 		return err
 	}

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -52,7 +52,7 @@ func stateNeededEquals(a, b StateNeeded) bool {
 type testEventList []Event
 
 func (tel *testEventList) UnmarshalJSON(data []byte) error {
-	var eventJSONs []rawJSON
+	var eventJSONs []RawJSON
 	var events []Event
 	if err := json.Unmarshal([]byte(data), &eventJSONs); err != nil {
 		return err
@@ -997,7 +997,7 @@ func TestRedactAllowed(t *testing.T) {
 }
 
 func TestAuthEvents(t *testing.T) {
-	power, err := NewEventFromTrustedJSON(rawJSON(`{
+	power, err := NewEventFromTrustedJSON(RawJSON(`{
 		"type": "m.room.power_levels",
 		"state_key": "",
 		"sender": "@u1:a",
@@ -1018,7 +1018,7 @@ func TestAuthEvents(t *testing.T) {
 	if e, err = a.PowerLevels(); err != nil || e != &power {
 		t.Errorf("TestAuthEvents: failed to get same power_levels event")
 	}
-	create, err := NewEventFromTrustedJSON(rawJSON(`{
+	create, err := NewEventFromTrustedJSON(RawJSON(`{
 		"type": "m.room.create",
 		"state_key": "",
 		"sender": "@u1:a",

--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -31,7 +31,7 @@ import (
 // This hash is used to detect whether the unredacted content of the event is valid.
 // Returns the event JSON with a "hashes" key added to it.
 func addContentHashesToEvent(eventJSON []byte) ([]byte, error) {
-	var event map[string]rawJSON
+	var event map[string]RawJSON
 
 	if err := json.Unmarshal(eventJSON, &event); err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func addContentHashesToEvent(eventJSON []byte) ([]byte, error) {
 	if len(unsignedJSON) > 0 {
 		event["unsigned"] = unsignedJSON
 	}
-	event["hashes"] = rawJSON(hashesJSON)
+	event["hashes"] = RawJSON(hashesJSON)
 
 	return json.Marshal(event)
 }
@@ -105,7 +105,7 @@ func referenceOfEvent(eventJSON []byte) (EventReference, error) {
 		return EventReference{}, err
 	}
 
-	var event map[string]rawJSON
+	var event map[string]RawJSON
 	if err = json.Unmarshal(redactedJSON, &event); err != nil {
 		return EventReference{}, err
 	}
@@ -150,14 +150,14 @@ func signEvent(signingName string, keyID KeyID, privateKey ed25519.PrivateKey, e
 	}
 
 	var signedEvent struct {
-		Signatures rawJSON `json:"signatures"`
+		Signatures RawJSON `json:"signatures"`
 	}
 	if err := json.Unmarshal(signedJSON, &signedEvent); err != nil {
 		return nil, err
 	}
 
 	// Unmarshal the event JSON so that we can replace the signatures key.
-	var event map[string]rawJSON
+	var event map[string]RawJSON
 	if err := json.Unmarshal(eventJSON, &event); err != nil {
 		return nil, err
 	}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -195,7 +195,7 @@ func (r RespSendJoin) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaller
 func (r *RespSendJoin) UnmarshalJSON(data []byte) error {
-	var tuple []rawJSON
+	var tuple []RawJSON
 	if err := json.Unmarshal(data, &tuple); err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func (r RespInvite) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaller
 func (r *RespInvite) UnmarshalJSON(data []byte) error {
-	var tuple []rawJSON
+	var tuple []RawJSON
 	if err := json.Unmarshal(data, &tuple); err != nil {
 		return err
 	}

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -23,7 +23,7 @@ git checkout-index -a
 
 echo "Installing lint search engine..."
 go get github.com/alecthomas/gometalinter/
-gometalinter --config=linter.json --install --update
+gometalinter --config=linter.json --install --update --debug
 
 echo "Testing..."
 go test

--- a/redactevent.go
+++ b/redactevent.go
@@ -19,16 +19,16 @@ import (
 	"encoding/json"
 )
 
-// rawJSON is a reimplementation of json.RawMessage that supports being used as a value type
+// RawJSON is a reimplementation of json.RawMessage that supports being used as a value type
 //
 // For example:
 //
 //  jsonBytes, _ := json.Marshal(struct{
 //		RawMessage json.RawMessage
-//		RawJSON rawJSON
+//		RawJSON RawJSON
 //	}{
 //		json.RawMessage(`"Hello"`),
-//		rawJSON(`"World"`),
+//		RawJSON(`"World"`),
 //	})
 //
 // Results in:
@@ -36,17 +36,17 @@ import (
 //  {"RawMessage":"IkhlbGxvIg==","RawJSON":"World"}
 //
 // See https://play.golang.org/p/FzhKIJP8-I for a full example.
-type rawJSON []byte
+type RawJSON []byte
 
 // MarshalJSON implements the json.Marshaller interface using a value receiver.
-// This means that rawJSON used as an embedded value will still encode correctly.
-func (r rawJSON) MarshalJSON() ([]byte, error) {
+// This means that RawJSON used as an embedded value will still encode correctly.
+func (r RawJSON) MarshalJSON() ([]byte, error) {
 	return []byte(r), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface using a pointer receiver.
-func (r *rawJSON) UnmarshalJSON(data []byte) error {
-	*r = rawJSON(data)
+func (r *RawJSON) UnmarshalJSON(data []byte) error {
+	*r = RawJSON(data)
 	return nil
 }
 
@@ -58,45 +58,45 @@ func redactEvent(eventJSON []byte) ([]byte, error) {
 	// Create events need to keep the creator.
 	// (In an ideal world they would keep the m.federate flag see matrix-org/synapse#1831)
 	type createContent struct {
-		Creator rawJSON `json:"creator,omitempty"`
+		Creator RawJSON `json:"creator,omitempty"`
 	}
 
 	// joinRulesContent keeps the fields needed in a m.room.join_rules event.
 	// Join rules events need to keep the join_rule key.
 	type joinRulesContent struct {
-		JoinRule rawJSON `json:"join_rule,omitempty"`
+		JoinRule RawJSON `json:"join_rule,omitempty"`
 	}
 
 	// powerLevelContent keeps the fields needed in a m.room.power_levels event.
 	// Power level events need to keep all the levels.
 	type powerLevelContent struct {
-		Users         rawJSON `json:"users,omitempty"`
-		UsersDefault  rawJSON `json:"users_default,omitempty"`
-		Events        rawJSON `json:"events,omitempty"`
-		EventsDefault rawJSON `json:"events_default,omitempty"`
-		StateDefault  rawJSON `json:"state_default,omitempty"`
-		Ban           rawJSON `json:"ban,omitempty"`
-		Kick          rawJSON `json:"kick,omitempty"`
-		Redact        rawJSON `json:"redact,omitempty"`
+		Users         RawJSON `json:"users,omitempty"`
+		UsersDefault  RawJSON `json:"users_default,omitempty"`
+		Events        RawJSON `json:"events,omitempty"`
+		EventsDefault RawJSON `json:"events_default,omitempty"`
+		StateDefault  RawJSON `json:"state_default,omitempty"`
+		Ban           RawJSON `json:"ban,omitempty"`
+		Kick          RawJSON `json:"kick,omitempty"`
+		Redact        RawJSON `json:"redact,omitempty"`
 	}
 
 	// memberContent keeps the fields needed in a m.room.member event.
 	// Member events keep the membership.
 	// (In an ideal world they would keep the third_party_invite see matrix-org/synapse#1831)
 	type memberContent struct {
-		Membership rawJSON `json:"membership,omitempty"`
+		Membership RawJSON `json:"membership,omitempty"`
 	}
 
 	// aliasesContent keeps the fields needed in a m.room.aliases event.
 	// TODO: Alias events probably don't need to keep the aliases key, but we need to match synapse here.
 	type aliasesContent struct {
-		Aliases rawJSON `json:"aliases,omitempty"`
+		Aliases RawJSON `json:"aliases,omitempty"`
 	}
 
 	// historyVisibilityContent keeps the fields needed in a m.room.history_visibility event
 	// History visibility events need to keep the history_visibility key.
 	type historyVisibilityContent struct {
-		HistoryVisibility rawJSON `json:"history_visibility,omitempty"`
+		HistoryVisibility RawJSON `json:"history_visibility,omitempty"`
 	}
 
 	// allContent keeps the union of all the content fields needed across all the event types.
@@ -114,21 +114,21 @@ func redactEvent(eventJSON []byte) ([]byte, error) {
 	// (In an ideal world they would include the "redacts" key for m.room.redaction events, see matrix-org/synapse#1831)
 	// See https://github.com/matrix-org/synapse/blob/v0.18.7/synapse/events/utils.py#L42-L56 for the list of fields
 	type eventFields struct {
-		EventID        rawJSON    `json:"event_id,omitempty"`
-		Sender         rawJSON    `json:"sender,omitempty"`
-		RoomID         rawJSON    `json:"room_id,omitempty"`
-		Hashes         rawJSON    `json:"hashes,omitempty"`
-		Signatures     rawJSON    `json:"signatures,omitempty"`
+		EventID        RawJSON    `json:"event_id,omitempty"`
+		Sender         RawJSON    `json:"sender,omitempty"`
+		RoomID         RawJSON    `json:"room_id,omitempty"`
+		Hashes         RawJSON    `json:"hashes,omitempty"`
+		Signatures     RawJSON    `json:"signatures,omitempty"`
 		Content        allContent `json:"content"`
 		Type           string     `json:"type"`
-		StateKey       rawJSON    `json:"state_key,omitempty"`
-		Depth          rawJSON    `json:"depth,omitempty"`
-		PrevEvents     rawJSON    `json:"prev_events,omitempty"`
-		PrevState      rawJSON    `json:"prev_state,omitempty"`
-		AuthEvents     rawJSON    `json:"auth_events,omitempty"`
-		Origin         rawJSON    `json:"origin,omitempty"`
-		OriginServerTS rawJSON    `json:"origin_server_ts,omitempty"`
-		Membership     rawJSON    `json:"membership,omitempty"`
+		StateKey       RawJSON    `json:"state_key,omitempty"`
+		Depth          RawJSON    `json:"depth,omitempty"`
+		PrevEvents     RawJSON    `json:"prev_events,omitempty"`
+		PrevState      RawJSON    `json:"prev_state,omitempty"`
+		AuthEvents     RawJSON    `json:"auth_events,omitempty"`
+		Origin         RawJSON    `json:"origin,omitempty"`
+		OriginServerTS RawJSON    `json:"origin_server_ts,omitempty"`
+		Membership     RawJSON    `json:"membership,omitempty"`
 	}
 
 	var event eventFields

--- a/request.go
+++ b/request.go
@@ -21,7 +21,7 @@ type FederationRequest struct {
 	// fields implement the JSON format needed for signing
 	// specified in https://matrix.org/docs/spec/server_server/unstable.html#request-authentication
 	fields struct {
-		Content     rawJSON                         `json:"content,omitempty"`
+		Content     RawJSON                         `json:"content,omitempty"`
 		Destination ServerName                      `json:"destination"`
 		Method      string                          `json:"method"`
 		Origin      ServerName                      `json:"origin"`
@@ -56,7 +56,7 @@ func (r *FederationRequest) SetContent(content interface{}) error {
 	if err != nil {
 		return err
 	}
-	r.fields.Content = rawJSON(data)
+	r.fields.Content = RawJSON(data)
 	return nil
 }
 
@@ -252,7 +252,7 @@ func readHTTPRequest(req *http.Request) (*FederationRequest, error) { // nolint:
 				req.Header.Get("Content-Type"),
 			)
 		}
-		result.fields.Content = rawJSON(content)
+		result.fields.Content = RawJSON(content)
 	}
 
 	for _, authorization := range req.Header["Authorization"] {

--- a/request_test.go
+++ b/request_test.go
@@ -104,7 +104,7 @@ func TestSignPutRequest(t *testing.T) {
 	request := NewFederationRequest(
 		"PUT", "localhost:44033", "/_matrix/federation/v1/send/1493385816575/",
 	)
-	if err := request.SetContent(rawJSON([]byte(examplePutContent))); err != nil {
+	if err := request.SetContent(RawJSON([]byte(examplePutContent))); err != nil {
 		t.Fatal(err)
 	}
 	if err := request.Sign("localhost:8800", "ed25519:a_Obwu", privateKey1); err != nil {


### PR DESCRIPTION
Typed structs spec'd at: https://matrix.org/docs/spec/application_service/unstable.html#put-transactions-txnid

Also sets RawJSON to be an exported type which was necessary for casting an already JSON-encoded string to a rawJSON.