### PR TITLE
Remove AS-specific event type in favor of generic Event

### DIFF
--- a/appservice.go
+++ b/appservice.go
@@ -15,27 +15,8 @@
 
 package gomatrixserverlib
 
-// ApplicationServiceUnsigned is the contents of the unsigned field of an
-// ApplicationServiceEvent.
-type ApplicationServiceUnsigned struct {
-	Age int64 `json:"age,omitempty"`
-}
-
-// ApplicationServiceEvent is an event format that is sent off to an
-// application service as part of a transaction.
-type ApplicationServiceEvent struct {
-	Unsigned              ApplicationServiceUnsigned `json:"unsigned,omitempty"`
-	Content               RawJSON                    `json:"content,omitempty"`
-	EventID               string                     `json:"event_id,omitempty"`
-	OriginServerTimestamp int64                      `json:"origin_server_ts,omitempty"`
-	RoomID                string                     `json:"room_id,omitempty"`
-	Sender                string                     `json:"sender,omitempty"`
-	Type                  string                     `json:"type,omitempty"`
-	UserID                string                     `json:"user_id,omitempty"`
-}
-
 // ApplicationServiceTransaction is the transaction that is sent off to an
 // application service.
 type ApplicationServiceTransaction struct {
-	Events []ApplicationServiceEvent `json:"events"`
+	Events []Event `json:"events"`
 }


### PR DESCRIPTION
We were using an event type that was specific for AS's, but this is kind of a pain because whenever we add something important to the event type, you'd also have to update this event type so that AS's got the new info as well.

Instead, just use the same type for everything.