### PR TITLE
Add EDU type used in federation

### DIFF
--- a/edu.go
+++ b/edu.go
@@ -1,0 +1,23 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gomatrixserverlib
+
+// EDU represents a EDU received via federation
+// https://matrix.org/docs/spec/server_server/unstable.html#edus
+type EDU struct {
+	Type        string  `json:"edu_type"`
+	Origin      string  `json:"origin"`
+	Destination string  `json:"destination"`
+	Content     RawJSON `json:"content"`
+}

--- a/transaction.go
+++ b/transaction.go
@@ -16,11 +16,14 @@ type Transaction struct {
 	// the destination server. Multiple transactions can be sent by the origin
 	// server to the destination server in parallel so there may be more than
 	// one previous transaction.
-	PreviousIDs []TransactionID `json:"previous_ids"`
+	PreviousIDs []TransactionID `json:"previous_ids,omitempty"`
 	// The room events pushed from the origin server to the destination server
 	// by this transaction. The events should either be events that originate
 	// on the origin server or be join m.room.member events.
 	PDUs []Event `json:"pdus"`
+	// The empheral events pushed from origin server to destination server
+	// by this transaction. The events must orginate at the origin server.
+	EDUs []EDU `json:"edus,omitempty"`
 }
 
 // A TransactionID identifies a transaction sent by a matrix server to another

--- a/transaction.go
+++ b/transaction.go
@@ -21,7 +21,7 @@ type Transaction struct {
 	// by this transaction. The events should either be events that originate
 	// on the origin server or be join m.room.member events.
 	PDUs []Event `json:"pdus"`
-	// The empheral events pushed from origin server to destination server
+	// The ephemeral events pushed from origin server to destination server
 	// by this transaction. The events must orginate at the origin server.
 	EDUs []EDU `json:"edus,omitempty"`
 }


### PR DESCRIPTION
As used in federation send transaction.
https://matrix.org/docs/spec/server_server/unstable.html#transactions

Also add omitempty to non-essential fields  https://github.com/matrix-org/synapse/blob/3c099219e0506f81fc333ff9d27cc3af5c365a2c/synapse/federation/units.py#L69-L91

`Signed-off-by: Anant Prakash <anantprakashjsr@gmail.com>`