### PR TITLE
Change gas to gosec

### DIFF
--- a/linter.json
+++ b/linter.json
@@ -11,7 +11,7 @@
         "structcheck",
         "maligned",
         "ineffassign",
-        "gas",
+        "gosec",
         "misspell",
         "gosimple",
         "megacheck",


### PR DESCRIPTION
Apparently gometallinter has renamed gas to gosec. alecthomas/gometalinter#505
This fixes travis failure.

`Signed-off-by: Anant Prakash <anantprakashjsr@gmail.com>`