### PR TITLE
Update to go v1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
- - 1.10
+ - 1.10.x
 install:
 script: ./travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
- - 1.8
+ - 1.10
 install:
 script: ./travis.sh

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ gomatrixserverlib
 =================
 [![GoDoc](https://godoc.org/github.com/matrix-org/gomatrixserverlib?status.svg)](https://godoc.org/github.com/matrix-org/gomatrixserverlib)
 
-Go library for common functions needed by matrix servers.
+Go library for common functions needed by matrix servers. This library assumes Go 1.10+.

--- a/linter.json
+++ b/linter.json
@@ -13,8 +13,6 @@
         "ineffassign",
         "gosec",
         "misspell",
-        "gosimple",
-        "megacheck",
         "unparam",
         "goimports",
         "goconst",


### PR DESCRIPTION
Bumps the minimum golang version to 1.10 due to latest Ubuntu LTS containing 1.10.