### PR TITLE
Shorten line length of method declaration

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -318,7 +318,7 @@ func (p *PerspectiveKeyFetcher) FetchKeys(
 		}
 
 		// Check that the keys are valid for the server they claim to be
-		checks, _, _ := CheckKeys(keys.ServerName, time.Unix(0, 0), keys, nil)
+		checks, _, _ := CheckKeys(keys.ServerName, time.Unix(0, 0), keys, nil, nil)
 		if !checks.AllChecksOK {
 			// This is bad because it means that the perspective server was trying to feed us an invalid response.
 			return nil, fmt.Errorf("gomatrixserverlib: key response from perspective server failed checks")
@@ -382,7 +382,7 @@ func (d *DirectKeyFetcher) fetchKeysForServer(
 		return nil, err
 	}
 	// Check that the keys are valid for the server.
-	checks, _, _ := CheckKeys(serverName, time.Unix(0, 0), keys, nil)
+	checks, _, _ := CheckKeys(serverName, time.Unix(0, 0), keys, nil, nil)
 	if !checks.AllChecksOK {
 		return nil, fmt.Errorf("gomatrixserverlib: key response direct from %q failed checks", serverName)
 	}

--- a/keys.go
+++ b/keys.go
@@ -161,7 +161,7 @@ type KeyChecks struct {
 }
 
 // CheckKeys checks the keys returned from a server to make sure they are valid.
-// If the checks pass then also return a map of key_id to Ed25519 public key and a list of SHA256 TLS fingerprints.
+// If the checks pass then also return a map of key_id to Ed25519 public key
 func CheckKeys(
 	serverName ServerName,
 	now time.Time,

--- a/keys.go
+++ b/keys.go
@@ -166,12 +166,11 @@ func CheckKeys(
 	serverName ServerName,
 	now time.Time,
 	keys ServerKeys,
-	wellKnown *WellKnownResult,
 ) (
 	checks KeyChecks,
 	ed25519Keys map[KeyID]Base64String,
 ) {
-	checks.MatchingServerName = serverName == keys.ServerName || serverName == wellKnown.NewAddress
+	checks.MatchingServerName = serverName == keys.ServerName
 	checks.FutureValidUntilTS = keys.ValidUntilTS.Time().After(now)
 	checks.AllChecksOK = checks.MatchingServerName && checks.FutureValidUntilTS
 

--- a/keys.go
+++ b/keys.go
@@ -174,15 +174,15 @@ type KeyChecks struct {
 // CheckKeys checks the keys returned from a server to make sure they are valid.
 // If the checks pass then also return a map of key_id to Ed25519 public key and a list of SHA256 TLS fingerprints.
 func CheckKeys(
-  serverName ServerName,
-  now time.Time,
-  keys ServerKeys,
-  connState *tls.ConnectionState,
-  wellKnown *WellKnownResult,
+	serverName ServerName,
+	now time.Time,
+	keys ServerKeys,
+	connState *tls.ConnectionState,
+	wellKnown *WellKnownResult,
 ) (
 	checks KeyChecks,
-  ed25519Keys map[KeyID]Base64String,
-  sha256Fingerprints []Base64String,
+	ed25519Keys map[KeyID]Base64String,
+	sha256Fingerprints []Base64String,
 ) {
 	checks.MatchingServerName = serverName == keys.ServerName || serverName == wellKnown.NewAddress
 	checks.FutureValidUntilTS = keys.ValidUntilTS.Time().After(now)

--- a/keys.go
+++ b/keys.go
@@ -173,10 +173,18 @@ type KeyChecks struct {
 
 // CheckKeys checks the keys returned from a server to make sure they are valid.
 // If the checks pass then also return a map of key_id to Ed25519 public key and a list of SHA256 TLS fingerprints.
-func CheckKeys(serverName ServerName, now time.Time, keys ServerKeys, connState *tls.ConnectionState) (
-	checks KeyChecks, ed25519Keys map[KeyID]Base64String, sha256Fingerprints []Base64String,
+func CheckKeys(
+  serverName ServerName,
+  now time.Time,
+  keys ServerKeys,
+  connState *tls.ConnectionState,
+  wellKnown *WellKnownResult,
+) (
+	checks KeyChecks,
+  ed25519Keys map[KeyID]Base64String,
+  sha256Fingerprints []Base64String,
 ) {
-	checks.MatchingServerName = serverName == keys.ServerName
+	checks.MatchingServerName = serverName == keys.ServerName || serverName == wellKnown.NewAddress
 	checks.FutureValidUntilTS = keys.ValidUntilTS.Time().After(now)
 	checks.AllChecksOK = checks.MatchingServerName && checks.FutureValidUntilTS
 


### PR DESCRIPTION
~~Adds parameters to `CheckKeys` that lets you specify whether well-known is being used or not, and the new server name if so.~~

~~https://github.com/matrix-org/matrix-federation-tester/pull/19~~

Simply does some aesthetics updates now as all PR functionality was moved to matrix-federation-tester.