### PR TITLE
Ensure resp.Body is closed

### DIFF
--- a/well_known.go
+++ b/well_known.go
@@ -30,6 +30,9 @@ func LookupWellKnown(serverNameType ServerName) (*WellKnownResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != 200 {
 		return nil, errors.New("No .well-known found")
 	}


### PR DESCRIPTION
The go docs says we must call resp.Body.Close().
This frees up resources(sockets)