### PR TITLE
Fix type in error

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -398,7 +398,7 @@ func aliasEventAllowed(event Event, authEvents AuthEventProvider) error {
 	// Check that the state key matches the server sending this event.
 	// https://github.com/matrix-org/synapse/blob/v0.18.5/synapse/api/auth.py#L158
 	if !event.StateKeyEquals(senderDomain) {
-		return errorf("alias state_key does not match sender domain, %q != %q", senderDomain, event.StateKey())
+		return errorf("alias state_key does not match sender domain, %q != %q", senderDomain, *event.StateKey())
 	}
 
 	return nil


### PR DESCRIPTION
~~We didn't pick up on this because our CI apparently doesn't run `go test`, but this fixes `go test`.~~

This is only caught in golang 1.11 and we're currently on golang 1.10 but with plans to update to 1.11, so might as well get this fixed.