### PR TITLE
Warn on m.server key not found in well-known

### DIFF
--- a/well_known.go
+++ b/well_known.go
@@ -49,6 +49,10 @@ func LookupWellKnown(serverNameType ServerName) (*WellKnownResult, error) {
 		return nil, err
 	}
 
+	if wellKnownResponse.NewAddress == "" {
+		return nil, errors.New("No m.server key found in well-known response")
+	}
+
 	// Return result
 	return wellKnownResponse, nil
 }


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-federation-tester/issues/44

Show an error if no `m.server` key was found in a .well-known file.