### PR TITLE
Don't error on lack of .well-known

### DIFF
--- a/well_known.go
+++ b/well_known.go
@@ -14,7 +14,8 @@ type WellKnownResult struct {
 }
 
 // LookupWellKnown looks up a well-known record for a matrix server. If one if
-// found, it returns the server to redirect to.
+// found, it returns the server to redirect to. It also returns a boolean which
+// value is true if a well-known record was found, false otherwise.
 func LookupWellKnown(serverNameType ServerName) (*WellKnownResult, bool, error) {
 	serverName := string(serverNameType)
 


### PR DESCRIPTION
Add a boolean value which describes whether a `/.well-known/matrix/server` file could be found for this server, instead of displaying the lack of one as an error.

Required by https://github.com/matrix-org/matrix-federation-tester/pull/52