### PR TITLE
Validation of filter.EventFormat should allow ""

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -51,7 +51,7 @@ type FilterPart struct {
 
 // Validate checks if the filter contains valid property values
 func (filter *Filter) Validate() error {
-	if filter.EventFormat != "client" && filter.EventFormat != "federation" {
+	if filter.EventFormat != "" && filter.EventFormat != "client" && filter.EventFormat != "federation" {
 		return errors.New("Bad event_format value. Must be one of [\"client\", \"federation\"]")
 	}
 	return nil


### PR DESCRIPTION
`event_format` is an optional field: https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-user-userid-filter

Signed-off-by: Alex Chen <minecnly@gmail.com>