### PR TITLE
Fix failing tests for the tokens package

### DIFF
--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -38,7 +38,9 @@ type TokenOptions struct {
 	ServerPrivateKey []byte `yaml:"private_key"`
 	ServerName       string `yaml:"server_name"`
 	UserID           string `json:"user_id"`
-	Duration         int    // optional
+	// The valid period of the token in seconds since its generation.
+	// Only used in GenerateLoginToken; 0 is treated as defaultDuration.
+	Duration int
 }
 
 // GenerateLoginToken generates a short term login token to be used as

--- a/tokens/tokens_handlers.go
+++ b/tokens/tokens_handlers.go
@@ -32,8 +32,8 @@ func GetUserFromToken(token string) (user string, err error) {
 	return
 }
 
-// ValidateToken validates that the Token is understood and was signed by this server.
-// Returns nil if token is valid, otherwise returns a error.
+// ValidateToken validates that the token is parseable and signed by this server.
+// Returns an error if the token is invalid, otherwise nil.
 func ValidateToken(op TokenOptions, token string) error {
 	mac, err := deSerializeMacaroon(token)
 	if err != nil {

--- a/tokens/tokens_handlers_test.go
+++ b/tokens/tokens_handlers_test.go
@@ -14,7 +14,6 @@ package tokens
 
 import (
 	"testing"
-	"time"
 )
 
 var (
@@ -30,18 +29,19 @@ var (
 	}
 )
 
-func expireZeroValidTokenOp() TokenOptions {
+func expiredValidTokenOp() TokenOptions {
 	op := validTokenOp
-	op.Duration = 0
+	// This will set the expiry to 1 second ago
+	op.Duration = -1
 	return op
 }
 
 func TestExpiredLoginToken(t *testing.T) {
-	fakeToken, err := GenerateLoginToken(expireZeroValidTokenOp())
-	// token uses 1 second precision
-	time.Sleep(time.Second)
-	res := ValidateToken(validTokenOp, fakeToken)
-	if res == nil {
+	fakeToken, err := GenerateLoginToken(expiredValidTokenOp())
+	if err != nil {
+		t.Errorf("Unexpected error from token generation: %v", err)
+	}
+	if err = ValidateToken(validTokenOp, fakeToken); err == nil {
 		t.Error("Token validation should fail for expired token")
 	}
 }
@@ -69,7 +69,7 @@ func TestValidateToken(t *testing.T) {
 	for _, invalid := range []TokenOptions{invalidKeyTokenOp, invalidUserTokenOp} {
 		res = ValidateToken(invalid, fakeToken)
 		if res == nil {
-			t.Errorf("Token validation should fail for invalid TokenOptions: ", invalid)
+			t.Error("Token validation should fail for invalid TokenOptions: ", invalid)
 		}
 	}
 }


### PR DESCRIPTION
Previously, these tests failed because of an unchecked error, an Errorf call
missing formatting directives, and a token duration value set wrong. They've
gone undetected because the CI runs `go test`, not `go test ./...` and thus
they've not been run.

This PR also refines some docs.

Signed-off-by: Alex Chen <minecnly@gmail.com>