### PR TITLE
Use correct go test comamnd

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -26,7 +26,7 @@ go get github.com/alecthomas/gometalinter/
 gometalinter --config=linter.json --install
 
 echo "Testing..."
-go test
+go test ./...
 
 echo "Looking for lint..."
 gometalinter --config=linter.json


### PR DESCRIPTION
The `hooks/pre-commit` script only runs `go test`, whereas it should be `go test ./...` to run tests in every package.

Relies on #137.