### PR TITLE
Missing "origin" field added to RespSendJoin

### DIFF
--- a/federationtypes.go
+++ b/federationtypes.go
@@ -127,12 +127,12 @@ type RespStateIDs struct {
 
 // A RespState is the content of a response to GET /_matrix/federation/v1/state/{roomID}/{eventID}
 type RespState struct {
-	// The resident server's DNS name. This field is only for type compatibility with RespSendJoin and should be empty.
-	Origin string `json:"origin,omitempty"`
 	// A list of events giving the state of the room before the request event.
 	StateEvents []Event `json:"pdus"`
 	// A list of events needed to authenticate the state events.
 	AuthEvents []Event `json:"auth_chain"`
+	// The resident server's DNS name. This field is only for type compatibility with RespSendJoin and should be empty.
+	Origin string `json:"origin,omitempty"`
 }
 
 // RespPublicRooms is the content of a response to GET /_matrix/federation/v1/publicRooms
@@ -350,9 +350,9 @@ func (r *RespSendJoin) UnmarshalJSON(data []byte) error {
 }
 
 type respSendJoinFields struct {
-	Origin      string  `json:"origin"`
 	StateEvents []Event `json:"state"`
 	AuthEvents  []Event `json:"auth_chain"`
+	Origin      string  `json:"origin"`
 }
 
 // Check that a response to /send_join is valid.

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -313,24 +313,10 @@ type RespSendJoin struct {
 
 // MarshalJSON implements json.Marshaller
 func (r RespSendJoin) MarshalJSON() ([]byte, error) {
-	// SendJoinResponses contain the same data as a StateResponse but are
-	// formatted slightly differently on the wire:
-	//  1) The "pdus" field is renamed to "state".
-	//  2) The object is placed as the second element of a two element list
-	//     where the first element is the constant integer 200.
-	//
-	//
-	// So a state response of:
-	//
-	//		{"pdus": x, "auth_chain": y}
-	//
-	// Becomes:
-	//
-	//      [200, {"state": x, "auth_chain": y}]
-	//
+	// RespSendJoin is sent as the second element
+	// of a two element list where the first element is the constant integer 200.
 	// (This protocol oddity is the result of a typo in the synapse matrix
 	//  server, and is preserved to maintain compatibility.)
-
 	return json.Marshal([]interface{}{200, respSendJoinFields(r)})
 }
 
@@ -351,18 +337,18 @@ func (r *RespSendJoin) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// ToRespState return new RespState with the same data from the given RespSendJoin
+type respSendJoinFields struct {
+	StateEvents []Event `json:"state"`
+	AuthEvents  []Event `json:"auth_chain"`
+	Origin      string  `json:"origin"`
+}
+
+// ToRespState returns a new RespState with the same data from the given RespSendJoin
 func (r RespSendJoin) ToRespState() RespState {
 	return RespState{
 		StateEvents: r.StateEvents,
 		AuthEvents:  r.AuthEvents,
 	}
-}
-
-type respSendJoinFields struct {
-	StateEvents []Event `json:"state"`
-	AuthEvents  []Event `json:"auth_chain"`
-	Origin      string  `json:"origin,omitempty"`
 }
 
 // Check that a response to /send_join is valid.

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -127,6 +127,8 @@ type RespStateIDs struct {
 
 // A RespState is the content of a response to GET /_matrix/federation/v1/state/{roomID}/{eventID}
 type RespState struct {
+	// The resident server's DNS name. This field is only for type compatibility with RespSendJoin and should be empty.
+	Origin string `json:"origin,omitempty"`
 	// A list of events giving the state of the room before the request event.
 	StateEvents []Event `json:"pdus"`
 	// A list of events needed to authenticate the state events.
@@ -314,7 +316,7 @@ func (r RespSendJoin) MarshalJSON() ([]byte, error) {
 	//  1) The "pdus" field is renamed to "state".
 	//  2) The object is placed as the second element of a two element list
 	//     where the first element is the constant integer 200.
-	//
+	//	3) SendJoinResponses has an additional "origin" field.
 	//
 	// So a state response of:
 	//
@@ -322,7 +324,7 @@ func (r RespSendJoin) MarshalJSON() ([]byte, error) {
 	//
 	// Becomes:
 	//
-	//      [200, {"state": x, "auth_chain": y}]
+	//      [200, {""state": x, "auth_chain": y, "origin": z}]
 	//
 	// (This protocol oddity is the result of a typo in the synapse matrix
 	//  server, and is preserved to maintain compatibility.)
@@ -348,6 +350,7 @@ func (r *RespSendJoin) UnmarshalJSON(data []byte) error {
 }
 
 type respSendJoinFields struct {
+	Origin      string  `json:"origin"`
 	StateEvents []Event `json:"state"`
 	AuthEvents  []Event `json:"auth_chain"`
 }

--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -50,22 +50,18 @@ func TestParseServerName(t *testing.T) {
 }
 
 func TestRespSendJoinMarshalJSON(t *testing.T) {
-	inputData := `{"pdus":[],"auth_chain":[]}`
-	var input RespState
+	inputData := `{"state":[],"auth_chain":[],"origin":""}`
+	var input respSendJoinFields
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
 		t.Fatal(err)
 	}
 
-	gotBytes, err := json.Marshal(
-		RespSendJoin{
-			StateEvents: input.StateEvents,
-			AuthEvents:  input.AuthEvents,
-		})
+	gotBytes, err := json.Marshal(RespSendJoin(input))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := `[200,{"state":[],"auth_chain":[]}]`
+	want := `[200,{"state":[],"auth_chain":[],"origin":""}]`
 	got := string(gotBytes)
 
 	if want != got {
@@ -74,18 +70,18 @@ func TestRespSendJoinMarshalJSON(t *testing.T) {
 }
 
 func TestRespSendJoinUnmarshalJSON(t *testing.T) {
-	inputData := `[200,{"state":[],"auth_chain":[]}]`
+	inputData := `[200,{"state":[],"auth_chain":[],"origin":""}]`
 	var input RespSendJoin
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
 		t.Fatal(err)
 	}
 
-	gotBytes, err := json.Marshal(input.ToRespState())
+	gotBytes, err := json.Marshal(respSendJoinFields(input))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := `{"pdus":[],"auth_chain":[]}`
+	want := `{"state":[],"auth_chain":[],"origin":""}`
 	got := string(gotBytes)
 
 	if want != got {

--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -1,7 +1,6 @@
 package gomatrixserverlib
 
 import (
-	"encoding/json"
 	"testing"
 )
 
@@ -47,45 +46,4 @@ func TestParseServerName(t *testing.T) {
 			t.Errorf("Expected serverName '%s' to be rejected but was accepted", input)
 		}
 	}
-}
-
-func TestRespSendJoinMarshalJSON(t *testing.T) {
-	inputData := `{"pdus":[],"auth_chain":[],"origin":""}`
-	var input RespState
-	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
-		t.Fatal(err)
-	}
-
-	gotBytes, err := json.Marshal(RespSendJoin(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := `[200,{"state":[],"auth_chain":[],"origin":""}]`
-	got := string(gotBytes)
-
-	if want != got {
-		t.Errorf("json.Marshal(RespSendJoin(%q)): wanted %q, got %q", inputData, want, got)
-	}
-}
-
-func TestRespSendJoinUnmarshalJSON(t *testing.T) {
-	inputData := `[200,{"state":[],"auth_chain":[]}]`
-	var input RespSendJoin
-	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
-		t.Fatal(err)
-	}
-
-	gotBytes, err := json.Marshal(RespState(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := `{"pdus":[],"auth_chain":[]}`
-	got := string(gotBytes)
-
-	if want != got {
-		t.Errorf("json.Marshal(RespSendJoin(%q)): wanted %q, got %q", inputData, want, got)
-	}
-
 }

--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -50,7 +50,7 @@ func TestParseServerName(t *testing.T) {
 }
 
 func TestRespSendJoinMarshalJSON(t *testing.T) {
-	inputData := `{"pdus":[],"auth_chain":[]}`
+	inputData := `{"pdus":[],"auth_chain":[],"origin":""}`
 	var input RespState
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
 		t.Fatal(err)
@@ -61,7 +61,7 @@ func TestRespSendJoinMarshalJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := `[200,{"state":[],"auth_chain":[]}]`
+	want := `[200,{"state":[],"auth_chain":[],"origin":""}]`
 	got := string(gotBytes)
 
 	if want != got {

--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -1,6 +1,7 @@
 package gomatrixserverlib
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -46,4 +47,49 @@ func TestParseServerName(t *testing.T) {
 			t.Errorf("Expected serverName '%s' to be rejected but was accepted", input)
 		}
 	}
+}
+
+func TestRespSendJoinMarshalJSON(t *testing.T) {
+	inputData := `{"pdus":[],"auth_chain":[]}`
+	var input RespState
+	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
+		t.Fatal(err)
+	}
+
+	gotBytes, err := json.Marshal(
+		RespSendJoin{
+			StateEvents: input.StateEvents,
+			AuthEvents:  input.AuthEvents,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `[200,{"state":[],"auth_chain":[]}]`
+	got := string(gotBytes)
+
+	if want != got {
+		t.Errorf("json.Marshal(RespSendJoin(%q)): wanted %q, got %q", inputData, want, got)
+	}
+}
+
+func TestRespSendJoinUnmarshalJSON(t *testing.T) {
+	inputData := `[200,{"state":[],"auth_chain":[]}]`
+	var input RespSendJoin
+	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
+		t.Fatal(err)
+	}
+
+	gotBytes, err := json.Marshal(input.ToRespState())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `{"pdus":[],"auth_chain":[]}`
+	got := string(gotBytes)
+
+	if want != got {
+		t.Errorf("json.Marshal(RespSendJoin(%q)): wanted %q, got %q", inputData, want, got)
+	}
+
 }


### PR DESCRIPTION
In this PR, i have added the missing `"origin"` field of `RespSendJoin` and also made some changes to `TestRespSendJoinMarshalJSON`.