### PR TITLE
Updated filters to match r0.5.0 specs

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -62,14 +62,16 @@ type StateFilter struct {
 
 // RoomEventFilter is used to define filtering rules for events in rooms
 type RoomEventFilter struct {
-	Limit       int      `json:"limit,omitempty"`
-	NotSenders  []string `json:"not_senders,omitempty"`
-	NotTypes    []string `json:"not_types,omitempty"`
-	Senders     []string `json:"senders,omitempty"`
-	Types       []string `json:"types,omitempty"`
-	NotRooms    []string `json:"not_rooms,omitempty"`
-	Rooms       []string `json:"rooms,omitempty"`
-	ContainsURL *bool    `json:"contains_url,omitempty"`
+	Limit                   int      `json:"limit,omitempty"`
+	NotSenders              []string `json:"not_senders,omitempty"`
+	NotTypes                []string `json:"not_types,omitempty"`
+	Senders                 []string `json:"senders,omitempty"`
+	Types                   []string `json:"types,omitempty"`
+	LazyLoadMembers         bool     `json:"lazy_load_members,omitempty"`
+	IncludeRedundantMembers bool     `json:"include_redundant_members,omitempty"`
+	NotRooms                []string `json:"not_rooms,omitempty"`
+	Rooms                   []string `json:"rooms,omitempty"`
+	ContainsURL             *bool    `json:"contains_url,omitempty"`
 }
 
 // Validate checks if the filter contains valid property values
@@ -80,7 +82,8 @@ func (filter *Filter) Validate() error {
 	return nil
 }
 
-// DefaultFilter returns the default filter used by the Matrix server if no filter is provided in the request
+// DefaultFilter returns the default filter used by the Matrix server if no filter is provided in
+// the request
 func DefaultFilter() Filter {
 	return Filter{
 		AccountData: DefaultEventFilter(),
@@ -99,7 +102,8 @@ func DefaultFilter() Filter {
 	}
 }
 
-// DefaultEventFilter returns the default event filter used by the Matrix server if no filter is provided in the request
+// DefaultEventFilter returns the default event filter used by the Matrix server if no filter is
+// provided in the request
 func DefaultEventFilter() EventFilter {
 	return EventFilter{
 		Limit:      20,
@@ -110,7 +114,8 @@ func DefaultEventFilter() EventFilter {
 	}
 }
 
-// DefaultStateFilter returns the default state event filter used by the Matrix server if no filter is provided in the request
+// DefaultStateFilter returns the default state event filter used by the Matrix server if no filter
+// is provided in the request
 func DefaultStateFilter() StateFilter {
 	return StateFilter{
 		Limit:                   20,
@@ -126,7 +131,8 @@ func DefaultStateFilter() StateFilter {
 	}
 }
 
-// DefaultRoomEventFilter returns the default room event filter used by the Matrix server if no filter is provided in the request
+// DefaultRoomEventFilter returns the default room event filter used by the Matrix server if no
+// filter is provided in the request
 func DefaultRoomEventFilter() RoomEventFilter {
 	return RoomEventFilter{
 		Limit:       20,

--- a/filter.go
+++ b/filter.go
@@ -17,35 +17,58 @@ package gomatrixserverlib
 import "errors"
 
 // Filter is used by clients to specify how the server should filter responses to e.g. sync requests
-// Specified by: https://matrix.org/docs/spec/client_server/r0.2.0.html#filtering
+// Specified by: https://matrix.org/docs/spec/client_server/r0.5.0.html#filtering
 type Filter struct {
-	AccountData FilterPart `json:"account_data,omitempty"`
-	EventFields []string   `json:"event_fields,omitempty"`
-	EventFormat string     `json:"event_format,omitempty"`
-	Presence    FilterPart `json:"presence,omitempty"`
-	Room        RoomFilter `json:"room,omitempty"`
+	EventFields []string    `json:"event_fields,omitempty"`
+	EventFormat string      `json:"event_format,omitempty"`
+	Presence    EventFilter `json:"presence,omitempty"`
+	AccountData EventFilter `json:"account_data,omitempty"`
+	Room        RoomFilter  `json:"room,omitempty"`
 }
 
-// RoomFilter is used to define filtering rules for room events
+// EventFilter is used to define filtering rules for events
+type EventFilter struct {
+	Limit      int      `json:"limit,omitempty"`
+	NotSenders []string `json:"not_senders,omitempty"`
+	NotTypes   []string `json:"not_types,omitempty"`
+	Senders    []string `json:"senders,omitempty"`
+	Types      []string `json:"types,omitempty"`
+}
+
+// RoomFilter is used to define filtering rules for room-related events
 type RoomFilter struct {
-	AccountData  FilterPart `json:"account_data,omitempty"`
-	Ephemeral    FilterPart `json:"ephemeral,omitempty"`
-	IncludeLeave bool       `json:"include_leave,omitempty"`
-	NotRooms     []string   `json:"not_rooms,omitempty"`
-	Rooms        []string   `json:"rooms,omitempty"`
-	State        FilterPart `json:"state,omitempty"`
-	Timeline     FilterPart `json:"timeline,omitempty"`
+	NotRooms     []string        `json:"not_rooms,omitempty"`
+	Rooms        []string        `json:"rooms,omitempty"`
+	Ephemeral    RoomEventFilter `json:"ephemeral,omitempty"`
+	IncludeLeave bool            `json:"include_leave,omitempty"`
+	State        StateFilter     `json:"state,omitempty"`
+	Timeline     RoomEventFilter `json:"timeline,omitempty"`
+	AccountData  RoomEventFilter `json:"account_data,omitempty"`
 }
 
-// FilterPart is used to define filtering rules for specific categories of events
-type FilterPart struct {
-	NotRooms    []string `json:"not_rooms,omitempty"`
-	Rooms       []string `json:"rooms,omitempty"`
+// StateFilter is used to define filtering rules for state events
+type StateFilter struct {
+	Limit                   int      `json:"limit,omitempty"`
+	NotSenders              []string `json:"not_senders,omitempty"`
+	NotTypes                []string `json:"not_types,omitempty"`
+	Senders                 []string `json:"senders,omitempty"`
+	Types                   []string `json:"types,omitempty"`
+	LazyLoadMembers         bool     `json:"lazy_load_members,omitempty"`
+	IncludeRedundantMembers bool     `json:"include_redundant_members,omitempty"`
+	NotRooms                []string `json:"not_rooms,omitempty"`
+	Rooms                   []string `json:"rooms,omitempty"`
+	ContainsURL             *bool    `json:"contains_url,omitempty"`
+}
+
+// RoomEventFilter is used to define filtering rules for events in rooms
+type RoomEventFilter struct {
 	Limit       int      `json:"limit,omitempty"`
 	NotSenders  []string `json:"not_senders,omitempty"`
 	NotTypes    []string `json:"not_types,omitempty"`
 	Senders     []string `json:"senders,omitempty"`
 	Types       []string `json:"types,omitempty"`
+	NotRooms    []string `json:"not_rooms,omitempty"`
+	Rooms       []string `json:"rooms,omitempty"`
 	ContainsURL *bool    `json:"contains_url,omitempty"`
 }
 
@@ -60,31 +83,59 @@ func (filter *Filter) Validate() error {
 // DefaultFilter returns the default filter used by the Matrix server if no filter is provided in the request
 func DefaultFilter() Filter {
 	return Filter{
-		AccountData: DefaultFilterPart(),
+		AccountData: DefaultEventFilter(),
 		EventFields: nil,
 		EventFormat: "client",
-		Presence:    DefaultFilterPart(),
+		Presence:    DefaultEventFilter(),
 		Room: RoomFilter{
-			AccountData:  DefaultFilterPart(),
-			Ephemeral:    DefaultFilterPart(),
+			AccountData:  DefaultRoomEventFilter(),
+			Ephemeral:    DefaultRoomEventFilter(),
 			IncludeLeave: false,
 			NotRooms:     nil,
 			Rooms:        nil,
-			State:        DefaultFilterPart(),
-			Timeline:     DefaultFilterPart(),
+			State:        DefaultStateFilter(),
+			Timeline:     DefaultRoomEventFilter(),
 		},
 	}
 }
 
-// DefaultFilterPart returns the default filter part used by the Matrix server if no filter is provided in the request
-func DefaultFilterPart() FilterPart {
-	return FilterPart{
-		NotRooms:   nil,
-		Rooms:      nil,
+// DefaultEventFilter returns the default event filter used by the Matrix server if no filter is provided in the request
+func DefaultEventFilter() EventFilter {
+	return EventFilter{
 		Limit:      20,
 		NotSenders: nil,
 		NotTypes:   nil,
 		Senders:    nil,
 		Types:      nil,
+	}
+}
+
+// DefaultStateFilter returns the default state event filter used by the Matrix server if no filter is provided in the request
+func DefaultStateFilter() StateFilter {
+	return StateFilter{
+		Limit:                   20,
+		NotSenders:              nil,
+		NotTypes:                nil,
+		Senders:                 nil,
+		Types:                   nil,
+		LazyLoadMembers:         false,
+		IncludeRedundantMembers: false,
+		NotRooms:                nil,
+		Rooms:                   nil,
+		ContainsURL:             nil,
+	}
+}
+
+// DefaultRoomEventFilter returns the default room event filter used by the Matrix server if no filter is provided in the request
+func DefaultRoomEventFilter() RoomEventFilter {
+	return RoomEventFilter{
+		Limit:       20,
+		NotSenders:  nil,
+		NotTypes:    nil,
+		Senders:     nil,
+		Types:       nil,
+		NotRooms:    nil,
+		Rooms:       nil,
+		ContainsURL: nil,
 	}
 }


### PR DESCRIPTION
I just updated the filter structs to match names and orders of the [r0.5.0](https://matrix.org/docs/spec/client_server/r0.5.0.html#filtering) specs.


