### PR TITLE
Allow creating federation client with custom http.Transport

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,14 +49,22 @@ type UserInfo struct {
 
 // NewClient makes a new Client (with default timeout)
 func NewClient() *Client {
-	return NewClientWithTimeout(requestTimeout)
+	return NewClientWithTimeout(requestTimeout, newFederationTripper())
+}
+
+// NewClientWithTransport makes a new Client with an existing transport
+func NewClientWithTransport(transport http.RoundTripper) *Client {
+	return NewClientWithTimeout(requestTimeout, transport)
 }
 
 // NewClientWithTimeout makes a new Client with a specified request timeout
-func NewClientWithTimeout(timeout time.Duration) *Client {
-	return &Client{client: http.Client{
-		Transport: newFederationTripper(),
-		Timeout:   timeout}}
+func NewClientWithTimeout(timeout time.Duration, transport http.RoundTripper) *Client {
+	return &Client{
+		client: http.Client{
+			Transport: transport,
+			Timeout:   timeout,
+		},
+	}
 }
 
 type federationTripper struct {

--- a/federationclient.go
+++ b/federationclient.go
@@ -2,6 +2,7 @@ package gomatrixserverlib
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -23,6 +24,19 @@ func NewFederationClient(
 ) *FederationClient {
 	return &FederationClient{
 		Client:           *NewClient(),
+		serverName:       serverName,
+		serverKeyID:      keyID,
+		serverPrivateKey: privateKey,
+	}
+}
+
+// NewFederationClientWithTransport makes a new FederationClient with a custom
+// transport.
+func NewFederationClientWithTransport(
+	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey, transport *http.Transport,
+) *FederationClient {
+	return &FederationClient{
+		Client:           *NewClientWithTransport(transport),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,


### PR DESCRIPTION
This allows passing in a custom `http.Transport`, such as those provided by libp2p, when creating a federation client. Outgoing federation requests will use the custom transport instead of the default TLS senders.