### PR TITLE
bugfix: don't make federation calls for keys if we don't need to

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -160,6 +160,18 @@ func (k KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) 
 	}
 	k.checkUsingKeys(requests, results, keyIDs, keysFromDatabase)
 
+	// If we can verify using the keys from the database, don't make a federation call.
+	doFederationHit := false
+	for _, r := range results {
+		if r.Error != nil {
+			doFederationHit = true
+			break
+		}
+	}
+	if !doFederationHit {
+		return results, nil
+	}
+
 	for _, fetcher := range k.KeyFetchers {
 		// TODO: we should distinguish here between expired keys, and those we don't have.
 		// If the key has expired, it's no use re-requesting it.


### PR DESCRIPTION
Previously, we would check using the keys from the database, then promptly
discard that and do federation calls.

This patch is required for P2P as the excessive key requests would cause the requesting peer to be temporarily blacklisted on the network.