### PR TITLE
Return MissingAuthEventError when auth events are missing

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,15 @@
+package gomatrixserverlib
+
+import "fmt"
+
+type MissingAuthEventError struct {
+	AuthEventID string
+	ForEventID  string
+}
+
+func (e MissingAuthEventError) Error() string {
+	return fmt.Sprintf(
+		"gomatrixserverlib: missing auth event with ID %s for event %s",
+		e.AuthEventID, e.ForEventID,
+	)
+}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -213,10 +213,7 @@ func (r RespState) Events() ([]Event, error) {
 			for _, ref := range top.AuthEvents() {
 				authEvent := eventsByID[ref.EventID]
 				if authEvent == nil {
-					return nil, fmt.Errorf(
-						"gomatrixserverlib: missing auth event with ID %q for event %q",
-						ref.EventID, top.EventID(),
-					)
+					return nil, MissingAuthEventError{ref.EventID, top.EventID()}
 				}
 				if outputted[authEvent] {
 					continue
@@ -419,10 +416,7 @@ func checkAllowedByAuthEvents(event Event, eventsByID map[string]*Event) error {
 	for _, authRef := range event.AuthEvents() {
 		authEvent := eventsByID[authRef.EventID]
 		if authEvent == nil {
-			return fmt.Errorf(
-				"gomatrixserverlib: missing auth event with ID %q for event %q",
-				authRef.EventID, event.EventID(),
-			)
+			return MissingAuthEventError{authRef.EventID, event.EventID()}
 		}
 		if err := authEvents.AddEvent(authEvent); err != nil {
 			return err


### PR DESCRIPTION
We really should return concrete error types for more error conditions but this at least lets me fix the problem where fetching missing auth events over federation in Dendrite.