### PR TITLE
Room version metadata and HeaderedEvent

### DIFF
--- a/clientevent.go
+++ b/clientevent.go
@@ -15,9 +15,6 @@
 
 package gomatrixserverlib
 
-// EventFormat specifies the format of a client event
-type EventFormat int
-
 const (
 	// FormatAll will include all client event keys
 	FormatAll EventFormat = iota
@@ -31,13 +28,12 @@ type ClientEvent struct {
 	Content        RawJSON   `json:"content"`
 	EventID        string    `json:"event_id"`
 	OriginServerTS Timestamp `json:"origin_server_ts"`
-	// RoomID is omitted on /sync responses
-	RoomID   string  `json:"room_id,omitempty"`
-	Sender   string  `json:"sender"`
-	StateKey *string `json:"state_key,omitempty"`
-	Type     string  `json:"type"`
-	Unsigned RawJSON `json:"unsigned,omitempty"`
-	Redacts  string  `json:"redacts,omitempty"`
+	RoomID         string    `json:"room_id,omitempty"` // RoomID is omitted on /sync responses
+	Sender         string    `json:"sender"`
+	StateKey       *string   `json:"state_key,omitempty"`
+	Type           string    `json:"type"`
+	Unsigned       RawJSON   `json:"unsigned,omitempty"`
+	Redacts        string    `json:"redacts,omitempty"`
 }
 
 // ToClientEvents converts server events to client events.

--- a/event.go
+++ b/event.go
@@ -86,13 +86,6 @@ func (eb *EventBuilder) SetUnsigned(unsigned interface{}) (err error) {
 	return
 }
 
-// A VersionedEvent is a wrapper around an Event that contains information
-// about the room version.
-type VersionedEvent struct {
-	RoomVersion RoomVersion
-	Event
-}
-
 // An Event is a matrix event.
 // The event should always contain valid JSON.
 // If the event content hash is invalid then the event is redacted.

--- a/event.go
+++ b/event.go
@@ -622,6 +622,17 @@ func (e Event) MarshalJSON() ([]byte, error) {
 	return e.eventJSON, nil
 }
 
+// Headered returns a HeaderedEvent encapsulating the original event, with the
+// supplied headers.
+func (e Event) Headered(roomVersion RoomVersion) HeaderedEvent {
+	return HeaderedEvent{
+		EventHeader: EventHeader{
+			RoomVersion: roomVersion,
+		},
+		Event: e,
+	}
+}
+
 // UnmarshalJSON implements json.Unmarshaller
 func (er *EventReference) UnmarshalJSON(data []byte) error {
 	var tuple []RawJSON

--- a/event.go
+++ b/event.go
@@ -86,6 +86,13 @@ func (eb *EventBuilder) SetUnsigned(unsigned interface{}) (err error) {
 	return
 }
 
+// A VersionedEvent is a wrapper around an Event that contains information
+// about the room version.
+type VersionedEvent struct {
+	RoomVersion RoomVersion
+	Event
+}
+
 // An Event is a matrix event.
 // The event should always contain valid JSON.
 // If the event content hash is invalid then the event is redacted.

--- a/eventversion.go
+++ b/eventversion.go
@@ -1,5 +1,7 @@
 package gomatrixserverlib
 
+import "fmt"
+
 // RoomVersion refers to the room version for a specific room.
 type RoomVersion string
 
@@ -85,34 +87,44 @@ type roomVersion struct {
 }
 
 // StateResAlgorithm returns the state resolution for the given room version.
-func (v RoomVersion) StateResAlgorithm() StateResAlgorithm {
+func (v RoomVersion) StateResAlgorithm() (StateResAlgorithm, error) {
 	if r, ok := roomVersionMeta[v]; ok {
-		return r.stateResAlgorithm
+		return r.stateResAlgorithm, nil
 	}
-	panic("gomatrixserverlib: unsupported room version")
+	return 0, UnsupportedRoomVersionError{v}
 }
 
 // EventFormat returns the event format for the given room version.
-func (v RoomVersion) EventFormat() EventFormat {
+func (v RoomVersion) EventFormat() (EventFormat, error) {
 	if r, ok := roomVersionMeta[v]; ok {
-		return r.eventFormat
+		return r.eventFormat, nil
 	}
-	panic("gomatrixserverlib: unsupported room version")
+	return 0, UnsupportedRoomVersionError{v}
 }
 
 // EventIDFormat returns the event ID format for the given room version.
-func (v RoomVersion) EventIDFormat() EventIDFormat {
+func (v RoomVersion) EventIDFormat() (EventIDFormat, error) {
 	if r, ok := roomVersionMeta[v]; ok {
-		return r.eventIDFormat
+		return r.eventIDFormat, nil
 	}
-	panic("gomatrixserverlib: unsupported room version")
+	return 0, UnsupportedRoomVersionError{v}
 }
 
 // EnforceSignatureChecks returns true if the given room version calls for
 // strict signature checking (room version 5 and onward) or false otherwise.
-func (v RoomVersion) EnforceSignatureChecks() bool {
+func (v RoomVersion) EnforceSignatureChecks() (bool, error) {
 	if r, ok := roomVersionMeta[v]; ok {
-		return r.enforceSignatureChecks
+		return r.enforceSignatureChecks, nil
 	}
-	panic("gomatrixserverlib: unsupported room version")
+	return false, UnsupportedRoomVersionError{v}
+}
+
+// UnsupportedRoomVersionError occurs when a call has been made with a room
+// version that is not supported by this version of gomatrixserverlib.
+type UnsupportedRoomVersionError struct {
+	Version RoomVersion
+}
+
+func (e UnsupportedRoomVersionError) Error() string {
+	return fmt.Sprintf("gomatrixserverlib: unsupported version '%s'", e.Version)
 }

--- a/eventversion.go
+++ b/eventversion.go
@@ -75,7 +75,7 @@ var roomVersionMeta = map[RoomVersion]roomVersion{
 	},
 }
 
-// RoomVersionMeta contains information about a given room version, e.g. which
+// roomVersion contains information about a given room version, e.g. which
 // state resolution algorithm or event ID format to use.
 type roomVersion struct {
 	stateResAlgorithm      StateResAlgorithm

--- a/eventversion.go
+++ b/eventversion.go
@@ -89,7 +89,7 @@ func (v RoomVersion) StateResAlgorithm() StateResAlgorithm {
 	if r, ok := roomVersionMeta[v]; ok {
 		return r.stateResAlgorithm
 	}
-	return StateResV1
+	panic("gomatrixserverlib: unsupported room version")
 }
 
 // EventFormat returns the event format for the given room version.
@@ -97,7 +97,7 @@ func (v RoomVersion) EventFormat() EventFormat {
 	if r, ok := roomVersionMeta[v]; ok {
 		return r.eventFormat
 	}
-	return EventFormatV1
+	panic("gomatrixserverlib: unsupported room version")
 }
 
 // EventIDFormat returns the event ID format for the given room version.
@@ -105,7 +105,7 @@ func (v RoomVersion) EventIDFormat() EventIDFormat {
 	if r, ok := roomVersionMeta[v]; ok {
 		return r.eventIDFormat
 	}
-	return EventIDFormatV1
+	panic("gomatrixserverlib: unsupported room version")
 }
 
 // EnforceSignatureChecks returns true if the given room version calls for
@@ -114,5 +114,5 @@ func (v RoomVersion) EnforceSignatureChecks() bool {
 	if r, ok := roomVersionMeta[v]; ok {
 		return r.enforceSignatureChecks
 	}
-	return false
+	panic("gomatrixserverlib: unsupported room version")
 }

--- a/eventversion.go
+++ b/eventversion.go
@@ -1,0 +1,118 @@
+package gomatrixserverlib
+
+// RoomVersion refers to the room version for a specific room.
+type RoomVersion string
+
+// StateResAlgorithm refers to a version of the state resolution algorithm.
+type StateResAlgorithm int
+
+// EventFormat refers to the formatting of the event fields struct.
+type EventFormat int
+
+// EventIDFormat refers to the formatting used to generate new event IDs.
+type EventIDFormat int
+
+// Room version constants. These are strings because the version grammar
+// allows for future expansion.
+// https://matrix.org/docs/spec/#room-version-grammar
+const (
+	RoomVersionV1 RoomVersion = "1"
+	RoomVersionV2 RoomVersion = "2"
+	RoomVersionV3 RoomVersion = "3"
+	RoomVersionV4 RoomVersion = "4"
+	RoomVersionV5 RoomVersion = "5"
+)
+
+// Event format constants.
+const (
+	EventFormatV1 EventFormat = iota + 1 // prev_events and auth_events as event references
+	EventFormatV2                        // prev_events and auth_events as string array of event IDs
+)
+
+// Event ID format constants.
+const (
+	EventIDFormatV1 EventIDFormat = iota + 1 // randomised
+	EventIDFormatV2                          // base64-encoded hash of event
+	EventIDFormatV3                          // URL-safe base64-encoded hash of event
+)
+
+// State resolution constants.
+const (
+	StateResV1 StateResAlgorithm = iota + 1 // state resolution v1
+	StateResV2                              // state resolution v2
+)
+
+var roomVersionMeta = map[RoomVersion]roomVersion{
+	"1": roomVersion{
+		stateResAlgorithm:      StateResV1,
+		eventFormat:            EventFormatV1,
+		eventIDFormat:          EventIDFormatV1,
+		enforceSignatureChecks: false,
+	},
+	"2": roomVersion{
+		stateResAlgorithm:      StateResV2,
+		eventFormat:            EventFormatV1,
+		eventIDFormat:          EventIDFormatV1,
+		enforceSignatureChecks: false,
+	},
+	"3": roomVersion{
+		stateResAlgorithm:      StateResV2,
+		eventFormat:            EventFormatV2,
+		eventIDFormat:          EventIDFormatV2,
+		enforceSignatureChecks: false,
+	},
+	"4": roomVersion{
+		stateResAlgorithm:      StateResV2,
+		eventFormat:            EventFormatV2,
+		eventIDFormat:          EventIDFormatV3,
+		enforceSignatureChecks: false,
+	},
+	"5": roomVersion{
+		stateResAlgorithm:      StateResV2,
+		eventFormat:            EventFormatV2,
+		eventIDFormat:          EventIDFormatV3,
+		enforceSignatureChecks: true,
+	},
+}
+
+// RoomVersionMeta contains information about a given room version, e.g. which
+// state resolution algorithm or event ID format to use.
+type roomVersion struct {
+	stateResAlgorithm      StateResAlgorithm
+	eventFormat            EventFormat
+	eventIDFormat          EventIDFormat
+	enforceSignatureChecks bool
+}
+
+// StateResAlgorithm returns the state resolution for the given room version.
+func (v RoomVersion) StateResAlgorithm() StateResAlgorithm {
+	if r, ok := roomVersionMeta[v]; ok {
+		return r.stateResAlgorithm
+	}
+	return StateResV1
+}
+
+// EventFormat returns the event format for the given room version.
+func (v RoomVersion) EventFormat() EventFormat {
+	if r, ok := roomVersionMeta[v]; ok {
+		return r.eventFormat
+	}
+	return EventFormatV1
+}
+
+// EventIDFormat returns the event ID format for the given room version.
+func (v RoomVersion) EventIDFormat() EventIDFormat {
+	if r, ok := roomVersionMeta[v]; ok {
+		return r.eventIDFormat
+	}
+	return EventIDFormatV1
+}
+
+// EnforceSignatureChecks returns true if the given room version calls for
+// strict signature checking (room version 5 and onward) or false otherwise.
+func (v RoomVersion) EnforceSignatureChecks() bool {
+	if r, ok := roomVersionMeta[v]; ok {
+		return r.enforceSignatureChecks
+	}
+	return false
+}

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -1,0 +1,35 @@
+package gomatrixserverlib
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// HeaderedEventHeader contains header fields for an event that contains
+// additional metadata, e.g. room version.
+type EventHeader struct {
+	RoomVersion RoomVersion `json:"room_version"`
+}
+
+// HeaderedEvent is a wrapper around an Event that contains information
+// about the room version.
+type HeaderedEvent struct {
+	EventHeader
+	Event
+}
+
+// UnmarshalJSON implements json.Unmarshaller
+func (e *HeaderedEvent) UnmarshalJSON(data []byte) error {
+	var m EventHeader
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	switch m.RoomVersion {
+	case RoomVersionV1, RoomVersionV2:
+		fmt.Println("room v1 or v2")
+	}
+	if err := json.Unmarshal(data, e); err != nil {
+		return err
+	}
+	return nil
+}

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -12,9 +12,10 @@ import (
 // this struct must have a "json:" name tag or otherwise the reflection
 // code for marshalling and unmarshalling headered events will not work.
 // They must be unique and not overlap with a name tag from the Event
-// struct or otherwise panics may occur.
+// struct or otherwise panics may occur, so header  name tags are instead
+// prefixed with an underscore.
 type EventHeader struct {
-	RoomVersion RoomVersion `json:"room_version"`
+	RoomVersion RoomVersion `json:"_room_version"`
 }
 
 // HeaderedEvent is a wrapper around an Event that contains information

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -8,13 +8,16 @@ import (
 )
 
 // HeaderedEventHeader contains header fields for an event that contains
-// additional metadata, e.g. room version.
+// additional metadata, e.g. room version. IMPORTANT NOTE: All fields in
+// this struct must have a "json:" name tag or otherwise the reflection
+// code for marshalling and unmarshalling headered events will not work.
 type EventHeader struct {
 	RoomVersion RoomVersion `json:"room_version"`
 }
 
 // HeaderedEvent is a wrapper around an Event that contains information
-// about the room version.
+// about the room version. All header fields will be added into the event
+// when marshalling into JSON and will be separated out when unmarshalling.
 type HeaderedEvent struct {
 	EventHeader
 	Event
@@ -23,37 +26,48 @@ type HeaderedEvent struct {
 // UnmarshalJSON implements json.Unmarshaller
 func (e *HeaderedEvent) UnmarshalJSON(data []byte) error {
 	var err error
+	// First extract the headers from the JSON.
 	var m EventHeader
 	if err = json.Unmarshal(data, &m); err != nil {
 		return err
 	}
+	// Now strip any of the header fields from the JSON input data.
 	fields := reflect.TypeOf(e.EventHeader)
 	for i := 0; i < fields.NumField(); i++ {
 		if data, err = sjson.DeleteBytes(
-			data,
-			fields.Field(i).Tag.Get("json"),
+			data, fields.Field(i).Tag.Get("json"),
 		); err != nil {
 			return err
 		}
 	}
+	// Check what the room version is and prepare the Event struct for
+	// that specific version type.
 	switch m.RoomVersion {
 	case RoomVersionV1, RoomVersionV2:
 	case RoomVersionV3, RoomVersionV4, RoomVersionV5:
 	default:
 		return UnsupportedRoomVersionError{m.RoomVersion}
 	}
+	// Finally, unmarshal the remaining event JSON (less the headers)
+	// into the event struct.
 	if err := json.Unmarshal(data, &e.Event); err != nil {
 		return err
 	}
+	// At this point unmarshalling is complete.
 	return nil
 }
 
 // MarshalJSON implements json.Marshaller
 func (e HeaderedEvent) MarshalJSON() ([]byte, error) {
+	// First marshal the event struct itself.
 	content, err := json.Marshal(e.Event)
 	if err != nil {
 		return []byte{}, err
 	}
+	// Now jump through the fields of the header struct and add them
+	// in separately. This is needed because of the way that Go handles
+	// function overloading on embedded types. Doing this ensures the
+	// least number of changes to event references elsewhere.
 	fields := reflect.TypeOf(e.EventHeader)
 	values := reflect.ValueOf(e.EventHeader)
 	for i := 0; i < fields.NumField(); i++ {
@@ -65,5 +79,6 @@ func (e HeaderedEvent) MarshalJSON() ([]byte, error) {
 			return []byte{}, err
 		}
 	}
+	// Return the newly marshalled JSON.
 	return content, nil
 }

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -27,8 +27,12 @@ func (e *HeaderedEvent) UnmarshalJSON(data []byte) error {
 	switch m.RoomVersion {
 	case RoomVersionV1, RoomVersionV2:
 		fmt.Println("room v1 or v2")
+	case RoomVersionV3, RoomVersionV4, RoomVersionV5:
+		fmt.Println("room v3 or v4 or v5")
+	default:
+		return UnsupportedRoomVersionError{m.RoomVersion}
 	}
-	if err := json.Unmarshal(data, e); err != nil {
+	if err := json.Unmarshal(data, &e.Event); err != nil {
 		return err
 	}
 	return nil

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -11,6 +11,8 @@ import (
 // additional metadata, e.g. room version. IMPORTANT NOTE: All fields in
 // this struct must have a "json:" name tag or otherwise the reflection
 // code for marshalling and unmarshalling headered events will not work.
+// They must be unique and not overlap with a name tag from the Event
+// struct or otherwise panics may occur.
 type EventHeader struct {
 	RoomVersion RoomVersion `json:"room_version"`
 }
@@ -66,8 +68,10 @@ func (e HeaderedEvent) MarshalJSON() ([]byte, error) {
 	}
 	// Now jump through the fields of the header struct and add them
 	// in separately. This is needed because of the way that Go handles
-	// function overloading on embedded types. Doing this ensures the
-	// least number of changes to event references elsewhere.
+	// function overloading on embedded types, since Event also
+	// implements custom marshalling and unmarshalling functions.
+	// Doing this also ensures the least number of changes to Event
+	// references elsewhere.
 	fields := reflect.TypeOf(e.EventHeader)
 	values := reflect.ValueOf(e.EventHeader)
 	for i := 0; i < fields.NumField(); i++ {

--- a/headeredevent_test.go
+++ b/headeredevent_test.go
@@ -2,22 +2,12 @@ package gomatrixserverlib
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 )
 
-func TestUnmarshalHeaderedEvent(t *testing.T) {
+func TestUnmarshalMarshalHeaderedEvent(t *testing.T) {
 	output := HeaderedEvent{}
-	input := `{"room_version": "1", "auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
-
-	if err := json.Unmarshal([]byte(input), &output); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMarshalHeaderedEvent(t *testing.T) {
-	output := HeaderedEvent{}
-	input := `{"room_version": "1", "auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+	input := `{"room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
 
 	if err := json.Unmarshal([]byte(input), &output); err != nil {
 		t.Fatal(err)
@@ -25,9 +15,11 @@ func TestMarshalHeaderedEvent(t *testing.T) {
 
 	headered := output.Event.Headered(RoomVersionV1)
 
-	if j, err := json.MarshalIndent(headered, "", "  "); err == nil {
-		fmt.Println("Marshalled:", string(j))
+	if j, err := json.Marshal(headered); err == nil {
+		if string(j) != input {
+			t.Fatalf("round-trip unmarshal and marshal produced different results")
+		}
 	} else {
-		fmt.Println("Failed to marshal:", j)
+		t.Fatalf("failed to unmarshal: %v", err)
 	}
 }

--- a/headeredevent_test.go
+++ b/headeredevent_test.go
@@ -2,6 +2,7 @@ package gomatrixserverlib
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -11,5 +12,22 @@ func TestUnmarshalHeaderedEvent(t *testing.T) {
 
 	if err := json.Unmarshal([]byte(input), &output); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMarshalHeaderedEvent(t *testing.T) {
+	output := HeaderedEvent{}
+	input := `{"room_version": "1", "auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+
+	if err := json.Unmarshal([]byte(input), &output); err != nil {
+		t.Fatal(err)
+	}
+
+	headered := output.Event.Headered(RoomVersionV1)
+
+	if j, err := json.MarshalIndent(headered, "", "  "); err == nil {
+		fmt.Println("Marshalled:", string(j))
+	} else {
+		fmt.Println("Failed to marshal:", j)
 	}
 }

--- a/headeredevent_test.go
+++ b/headeredevent_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestUnmarshalMarshalHeaderedEvent(t *testing.T) {
 	output := HeaderedEvent{}
-	input := `{"room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+	input := `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
 
 	if err := json.Unmarshal([]byte(input), &output); err != nil {
 		t.Fatal(err)
@@ -17,6 +17,8 @@ func TestUnmarshalMarshalHeaderedEvent(t *testing.T) {
 
 	if j, err := json.Marshal(headered); err == nil {
 		if string(j) != input {
+			t.Logf("got: %s", string(j))
+			t.Logf("expected: %s", input)
 			t.Fatalf("round-trip unmarshal and marshal produced different results")
 		}
 	} else {

--- a/headeredevent_test.go
+++ b/headeredevent_test.go
@@ -1,0 +1,15 @@
+package gomatrixserverlib
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUnmarshalHeaderedEvent(t *testing.T) {
+	output := HeaderedEvent{}
+	input := `{"room_version": "1", "auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+
+	if err := json.Unmarshal([]byte(input), &output); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR implements `HeaderedEvent`, which allows bundling additional metadata like room versions along with an event and having the metadata combined/separated correctly when marshalling to/unmarshalling from JSON.

It also includes some new types and room version descriptions which are used by Dendrite.

This is the first of a series of PRs that will implement room versions.