### PR TITLE
Pass pointers to events rather than copying them

### DIFF
--- a/appservice.go
+++ b/appservice.go
@@ -18,5 +18,5 @@ package gomatrixserverlib
 // ApplicationServiceTransaction is the transaction that is sent off to an
 // application service.
 type ApplicationServiceTransaction struct {
-	Events []Event `json:"events"`
+	Events []*Event `json:"events"`
 }

--- a/clientevent.go
+++ b/clientevent.go
@@ -46,7 +46,7 @@ func ToClientEvents(serverEvs []*Event, format EventFormat) []ClientEvent {
 }
 
 // ToClientEvents converts server events to client events.
-func HeaderedToClientEvents(serverEvs []HeaderedEvent, format EventFormat) []ClientEvent {
+func HeaderedToClientEvents(serverEvs []*HeaderedEvent, format EventFormat) []ClientEvent {
 	evs := make([]ClientEvent, len(serverEvs))
 	for i, se := range serverEvs {
 		evs[i] = HeaderedToClientEvent(se, format)
@@ -73,7 +73,7 @@ func ToClientEvent(se *Event, format EventFormat) ClientEvent {
 }
 
 // ToClientEvent converts a single server event to a client event.
-func HeaderedToClientEvent(se HeaderedEvent, format EventFormat) ClientEvent {
+func HeaderedToClientEvent(se *HeaderedEvent, format EventFormat) ClientEvent {
 	ce := ClientEvent{
 		Content:        RawJSON(se.Content()),
 		Sender:         se.Sender(),

--- a/clientevent.go
+++ b/clientevent.go
@@ -37,7 +37,7 @@ type ClientEvent struct {
 }
 
 // ToClientEvents converts server events to client events.
-func ToClientEvents(serverEvs []Event, format EventFormat) []ClientEvent {
+func ToClientEvents(serverEvs []*Event, format EventFormat) []ClientEvent {
 	evs := make([]ClientEvent, len(serverEvs))
 	for i, se := range serverEvs {
 		evs[i] = ToClientEvent(se, format)
@@ -55,7 +55,7 @@ func HeaderedToClientEvents(serverEvs []HeaderedEvent, format EventFormat) []Cli
 }
 
 // ToClientEvent converts a single server event to a client event.
-func ToClientEvent(se Event, format EventFormat) ClientEvent {
+func ToClientEvent(se *Event, format EventFormat) ClientEvent {
 	ce := ClientEvent{
 		Content:        RawJSON(se.Content()),
 		Sender:         se.Sender(),

--- a/event.go
+++ b/event.go
@@ -313,8 +313,6 @@ func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (resul
 				return
 			}
 		}
-
-		eventJSON = redactedJSON
 	}
 
 	err = result.CheckFields()

--- a/event.go
+++ b/event.go
@@ -415,30 +415,30 @@ func (e *Event) Redact() Event {
 
 // SetUnsigned sets the unsigned key of the event.
 // Returns a copy of the event with the "unsigned" key set.
-func (e *Event) SetUnsigned(unsigned interface{}) (Event, error) {
+func (e *Event) SetUnsigned(unsigned interface{}) (*Event, error) {
+	result := *e
 	var eventAsMap map[string]RawJSON
 	var err error
 	if err = json.Unmarshal(e.eventJSON, &eventAsMap); err != nil {
-		return Event{}, err
+		return nil, err
 	}
 	unsignedJSON, err := json.Marshal(unsigned)
 	if err != nil {
-		return Event{}, err
+		return nil, err
 	}
 	eventAsMap["unsigned"] = unsignedJSON
 	eventJSON, err := json.Marshal(eventAsMap)
 	if err != nil {
-		return Event{}, err
+		return nil, err
 	}
 	if eventJSON, err = CanonicalJSON(eventJSON); err != nil {
-		return Event{}, err
+		return nil, err
 	}
 	if err = e.updateUnsignedFields(unsignedJSON); err != nil {
-		return Event{}, err
+		return nil, err
 	}
-	result := *e
 	result.eventJSON = eventJSON
-	return result, nil
+	return &result, nil
 }
 
 // SetUnsignedField takes a path and value to insert into the unsigned dict of

--- a/event.go
+++ b/event.go
@@ -317,8 +317,6 @@ func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (resul
 		eventJSON = redactedJSON
 	}
 
-	result.eventJSON = eventJSON
-
 	err = result.CheckFields()
 	return
 }
@@ -330,7 +328,6 @@ func NewEventFromTrustedJSON(eventJSON []byte, redacted bool, roomVersion RoomVe
 	result = &Event{}
 	result.roomVersion = roomVersion
 	result.redacted = redacted
-	result.eventJSON = eventJSON
 	if err = result.populateFieldsFromJSON(eventJSON); err != nil {
 		return nil, err
 	}
@@ -348,6 +345,7 @@ func (e *Event) populateFieldsFromJSON(eventJSON []byte) error {
 
 	switch eventFormat {
 	case EventFormatV1:
+		e.eventJSON = eventJSON
 		// Unmarshal the event fields.
 		fields := eventFormatV1Fields{}
 		if err := json.Unmarshal(eventJSON, &fields); err != nil {
@@ -362,6 +360,7 @@ func (e *Event) populateFieldsFromJSON(eventJSON []byte) error {
 		if eventJSON, err = sjson.DeleteBytes(eventJSON, "event_id"); err != nil {
 			return err
 		}
+		e.eventJSON = eventJSON
 		// Unmarshal the event fields.
 		fields := eventFormatV2Fields{}
 		if err := json.Unmarshal(eventJSON, &fields); err != nil {

--- a/eventauth.go
+++ b/eventauth.go
@@ -155,7 +155,7 @@ func StateNeededForEventBuilder(builder *EventBuilder) (result StateNeeded, err 
 
 // StateNeededForAuth returns the event types and state_keys needed to authenticate an event.
 // This takes a list of events to facilitate bulk processing when doing auth checks as part of state conflict resolution.
-func StateNeededForAuth(events []Event) (result StateNeeded) {
+func StateNeededForAuth(events []*Event) (result StateNeeded) {
 	for _, event := range events {
 		// Extract the 'content' object from the event if it is m.room.member as we need to know 'membership'
 		var content *MemberContent
@@ -323,7 +323,7 @@ func errorf(message string, args ...interface{}) error {
 // Allowed checks whether an event is allowed by the auth events.
 // It returns a NotAllowed error if the event is not allowed.
 // If there was an error loading the auth events then it returns that error.
-func Allowed(event Event, authEvents AuthEventProvider) error {
+func Allowed(event *Event, authEvents AuthEventProvider) error {
 	switch event.Type() {
 	case MRoomCreate:
 		return createEventAllowed(event)
@@ -342,7 +342,7 @@ func Allowed(event Event, authEvents AuthEventProvider) error {
 
 // createEventAllowed checks whether the m.room.create event is allowed.
 // It returns an error if the event is not allowed.
-func createEventAllowed(event Event) error {
+func createEventAllowed(event *Event) error {
 	if !event.StateKeyEquals("") {
 		return errorf("create event state key is not empty: %v", event.StateKey())
 	}
@@ -365,7 +365,7 @@ func createEventAllowed(event Event) error {
 
 // memberEventAllowed checks whether the m.room.member event is allowed.
 // Membership events have different authentication rules to ordinary events.
-func memberEventAllowed(event Event, authEvents AuthEventProvider) error {
+func memberEventAllowed(event *Event, authEvents AuthEventProvider) error {
 	allower, err := newMembershipAllower(authEvents, event)
 	if err != nil {
 		return err
@@ -375,7 +375,7 @@ func memberEventAllowed(event Event, authEvents AuthEventProvider) error {
 
 // aliasEventAllowed checks whether the m.room.aliases event is allowed.
 // Alias events have different authentication rules to ordinary events.
-func aliasEventAllowed(event Event, authEvents AuthEventProvider) error {
+func aliasEventAllowed(event *Event, authEvents AuthEventProvider) error {
 	// The alias events have different auth rules to ordinary events.
 	// In particular we allow any server to send a m.room.aliases event without checking if the sender is in the room.
 	// This allows server admins to update the m.room.aliases event for their server when they change the aliases on their server.
@@ -413,7 +413,7 @@ func aliasEventAllowed(event Event, authEvents AuthEventProvider) error {
 // powerLevelsEventAllowed checks whether the m.room.power_levels event is allowed.
 // It returns an error if the event is not allowed or if there was a problem
 // loading the auth events needed.
-func powerLevelsEventAllowed(event Event, authEvents AuthEventProvider) error {
+func powerLevelsEventAllowed(event *Event, authEvents AuthEventProvider) error {
 	allower, err := newEventAllower(authEvents, event.Sender())
 	if err != nil {
 		return err
@@ -631,7 +631,7 @@ func checkUserLevels(senderLevel int64, senderID string, oldPowerLevels, newPowe
 // membership) on the event.
 // It returns an error if the event is not allowed or if there was a problem
 // loading the auth events needed.
-func redactEventAllowed(event Event, authEvents AuthEventProvider) error {
+func redactEventAllowed(event *Event, authEvents AuthEventProvider) error {
 	allower, err := newEventAllower(authEvents, event.Sender())
 	if err != nil {
 		return err
@@ -689,7 +689,7 @@ func redactEventAllowed(event Event, authEvents AuthEventProvider) error {
 // checks for events.
 // It returns an error if the event is not allowed or if there was a
 // problem loading the auth events needed.
-func defaultEventAllowed(event Event, authEvents AuthEventProvider) error {
+func defaultEventAllowed(event *Event, authEvents AuthEventProvider) error {
 	allower, err := newEventAllower(authEvents, event.Sender())
 	if err != nil {
 		return err
@@ -726,7 +726,7 @@ func newEventAllower(authEvents AuthEventProvider, senderID string) (e eventAllo
 
 // commonChecks does the checks that are applied to all events types other than
 // m.room.create, m.room.member, or m.room.alias.
-func (e *eventAllower) commonChecks(event Event) error {
+func (e *eventAllower) commonChecks(event *Event) error {
 	if event.RoomID() != e.create.roomID {
 		return errorf("create event has different roomID: %q != %q", event.RoomID(), e.create.roomID)
 	}
@@ -795,7 +795,7 @@ type membershipAllower struct {
 
 // newMembershipAllower loads the information needed to authenticate the m.room.member event
 // from the auth events.
-func newMembershipAllower(authEvents AuthEventProvider, event Event) (m membershipAllower, err error) { // nolint: gocyclo
+func newMembershipAllower(authEvents AuthEventProvider, event *Event) (m membershipAllower, err error) { // nolint: gocyclo
 	stateKey := event.StateKey()
 	if stateKey == nil {
 		err = errorf("m.room.member must be a state event")
@@ -836,7 +836,7 @@ func newMembershipAllower(authEvents AuthEventProvider, event Event) (m membersh
 }
 
 // membershipAllowed checks whether the membership event is allowed
-func (m *membershipAllower) membershipAllowed(event Event) error { // nolint: gocyclo
+func (m *membershipAllower) membershipAllowed(event *Event) error { // nolint: gocyclo
 	if m.create.roomID != event.RoomID() {
 		return errorf("create event has different roomID: %q != %q", event.RoomID(), m.create.roomID)
 	}

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -49,11 +49,11 @@ func stateNeededEquals(a, b StateNeeded) bool {
 	return true
 }
 
-type testEventList []Event
+type testEventList []*Event
 
 func (tel *testEventList) UnmarshalJSON(data []byte) error {
 	var eventJSONs []RawJSON
-	var events []Event
+	var events []*Event
 	if err := json.Unmarshal(data, &eventJSONs); err != nil {
 		return err
 	}
@@ -213,12 +213,11 @@ func (tae *testAuthEvents) Create() (*Event, error) {
 	if len(tae.CreateJSON) == 0 {
 		return nil, nil
 	}
-	var event Event
 	event, err := NewEventFromTrustedJSON(tae.CreateJSON, false, RoomVersionV1)
 	if err != nil {
 		return nil, err
 	}
-	return &event, nil
+	return event, nil
 }
 
 func (tae *testAuthEvents) JoinRules() (*Event, error) {
@@ -229,7 +228,7 @@ func (tae *testAuthEvents) JoinRules() (*Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &event, nil
+	return event, nil
 }
 
 func (tae *testAuthEvents) PowerLevels() (*Event, error) {
@@ -240,7 +239,7 @@ func (tae *testAuthEvents) PowerLevels() (*Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &event, nil
+	return event, nil
 }
 
 func (tae *testAuthEvents) Member(stateKey string) (*Event, error) {
@@ -251,7 +250,7 @@ func (tae *testAuthEvents) Member(stateKey string) (*Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &event, nil
+	return event, nil
 }
 
 func (tae *testAuthEvents) ThirdPartyInvite(stateKey string) (*Event, error) {
@@ -262,7 +261,7 @@ func (tae *testAuthEvents) ThirdPartyInvite(stateKey string) (*Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &event, nil
+	return event, nil
 }
 
 type testCase struct {
@@ -1013,9 +1012,9 @@ func TestAuthEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestAuthEvents: failed to create power_levels event: %s", err)
 	}
-	a := NewAuthEvents([]*Event{&power})
+	a := NewAuthEvents([]*Event{power})
 	var e *Event
-	if e, err = a.PowerLevels(); err != nil || e != &power {
+	if e, err = a.PowerLevels(); err != nil || e != power {
 		t.Errorf("TestAuthEvents: failed to get same power_levels event")
 	}
 	create, err := NewEventFromTrustedJSON(RawJSON(`{
@@ -1031,10 +1030,10 @@ func TestAuthEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestAuthEvents: failed to create create event: %s", err)
 	}
-	if err = a.AddEvent(&create); err != nil {
+	if err = a.AddEvent(create); err != nil {
 		t.Errorf("TestAuthEvents: Failed to AddEvent: %s", err)
 	}
-	if e, err = a.Create(); err != nil || e != &create {
+	if e, err = a.Create(); err != nil || e != create {
 		t.Errorf("TestAuthEvents: failed to get same create event")
 	}
 }

--- a/eventcontent.go
+++ b/eventcontent.go
@@ -150,12 +150,12 @@ func NewMemberContentFromAuthEvents(authEvents AuthEventProvider, userID string)
 		c.Membership = Leave
 		return
 	}
-	return NewMemberContentFromEvent(*memberEvent)
+	return NewMemberContentFromEvent(memberEvent)
 }
 
 // NewMemberContentFromEvent parse the member content from an event.
 // Returns an error if the content couldn't be parsed.
-func NewMemberContentFromEvent(event Event) (c MemberContent, err error) {
+func NewMemberContentFromEvent(event *Event) (c MemberContent, err error) {
 	if err = json.Unmarshal(event.Content(), &c); err != nil {
 		err = errorf("unparsable member event content: %s", err.Error())
 		return
@@ -279,7 +279,7 @@ func NewPowerLevelContentFromAuthEvents(authEvents AuthEventProvider, creatorUse
 		return
 	}
 	if powerLevelsEvent != nil {
-		return NewPowerLevelContentFromEvent(*powerLevelsEvent)
+		return NewPowerLevelContentFromEvent(powerLevelsEvent)
 	}
 
 	// If there are no power levels then fall back to defaults.
@@ -317,7 +317,7 @@ func (c *PowerLevelContent) Defaults() {
 }
 
 // NewPowerLevelContentFromEvent loads the power level content from an event.
-func NewPowerLevelContentFromEvent(event Event) (c PowerLevelContent, err error) {
+func NewPowerLevelContentFromEvent(event *Event) (c PowerLevelContent, err error) {
 	// Set the levels to their default values.
 	c.Defaults()
 

--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -210,7 +210,7 @@ func verifyEventSignature(signingName string, keyID KeyID, publicKey ed25519.Pub
 // signatures from the server that sent it.
 //
 // returns an array with either an error or nil for each event.
-func VerifyEventSignatures(ctx context.Context, events []Event, keyRing JSONVerifier) ([]error, error) { // nolint: gocyclo
+func VerifyEventSignatures(ctx context.Context, events []*Event, keyRing JSONVerifier) ([]error, error) { // nolint: gocyclo
 	// we will end up doing at least as many verifications as we have events.
 	// some events require multiple verifications, as they are signed by multiple
 	// servers.
@@ -298,7 +298,7 @@ func VerifyEventSignatures(ctx context.Context, events []Event, keyRing JSONVeri
 // signatures from the server that sent it.
 //
 // returns an error if any event fails verifications
-func VerifyAllEventSignatures(ctx context.Context, events []Event, keyRing JSONVerifier) error {
+func VerifyAllEventSignatures(ctx context.Context, events []*Event, keyRing JSONVerifier) error {
 	verificationErrors, err := VerifyEventSignatures(ctx, events, keyRing)
 	if err != nil {
 		return err

--- a/eventcrypto_test.go
+++ b/eventcrypto_test.go
@@ -370,7 +370,7 @@ func TestVerifyAllEventSignatures(t *testing.T) {
 		t.Error(err)
 	}
 
-	events := []Event{event}
+	events := []*Event{event}
 	if err = VerifyAllEventSignatures(context.Background(), events, &verifier); err != nil {
 		t.Fatal(err)
 	}
@@ -428,7 +428,7 @@ func TestVerifyAllEventSignaturesForInvite(t *testing.T) {
 		t.Error(err)
 	}
 
-	events := []Event{event}
+	events := []*Event{event}
 	if err = VerifyAllEventSignatures(context.Background(), events, &verifier); err != nil {
 		t.Fatal(err)
 	}

--- a/federationclient.go
+++ b/federationclient.go
@@ -108,7 +108,7 @@ func (ac *FederationClient) MakeJoin(
 // This is used to join a room the local server isn't a member of.
 // See https://matrix.org/docs/spec/server_server/unstable.html#joining-rooms
 func (ac *FederationClient) SendJoin(
-	ctx context.Context, s ServerName, event Event, roomVersion RoomVersion,
+	ctx context.Context, s ServerName, event *Event, roomVersion RoomVersion,
 ) (res RespSendJoin, err error) {
 	res.RespState.roomVersion = roomVersion
 	path := federationPathPrefixV2 + "/send_join/" +
@@ -143,7 +143,7 @@ func (ac *FederationClient) MakeLeave(
 // This is used to reject a remote invite.
 // See https://matrix.org/docs/spec/server_server/r0.1.1.html#put-matrix-federation-v1-send-leave-roomid-eventid
 func (ac *FederationClient) SendLeave(
-	ctx context.Context, s ServerName, event Event,
+	ctx context.Context, s ServerName, event *Event,
 ) (err error) {
 	path := federationPathPrefixV2 + "/send_leave/" +
 		url.PathEscape(event.RoomID()) + "/" +
@@ -159,7 +159,7 @@ func (ac *FederationClient) SendLeave(
 // SendInvite sends an invite m.room.member event to an invited server to be
 // signed by it. This is used to invite a user that is not on the local server.
 func (ac *FederationClient) SendInvite(
-	ctx context.Context, s ServerName, event Event,
+	ctx context.Context, s ServerName, event *Event,
 ) (res RespInvite, err error) {
 	path := federationPathPrefixV1 + "/invite/" +
 		url.PathEscape(event.RoomID()) + "/" +

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -231,7 +231,7 @@ func (r *RespState) UnmarshalJSON(data []byte) error {
 // Each event will only appear once in the output list.
 // Returns an error if there are missing auth events or if there is
 // a cycle in the auth events.
-func (r RespState) Events() ([]Event, error) {
+func (r RespState) Events() ([]*Event, error) {
 	if len(r.StateEvents) == 0 {
 		r.StateEvents = []*Event{}
 	}
@@ -249,7 +249,7 @@ func (r RespState) Events() ([]Event, error) {
 
 	queued := map[*Event]bool{}
 	outputted := map[*Event]bool{}
-	var result []Event
+	var result []*Event
 	for _, event := range eventsByID {
 		if outputted[event] {
 			// If we've already written the event then we can skip it.
@@ -292,7 +292,7 @@ func (r RespState) Events() ([]Event, error) {
 			// If we've processed all the auth events for the event on top of
 			// the stack then we can append it to the result and try processing
 			// the item below it in the stack.
-			result = append(result, *top)
+			result = append(result, top)
 			outputted[top] = true
 			stack = stack[:len(stack)-1]
 		}
@@ -504,7 +504,7 @@ func checkAllowedByAuthEvents(event *Event, eventsByID map[string]*Event) error 
 // RespInvite is the content of a response to PUT /_matrix/federation/v1/invite/{roomID}/{eventID}
 type RespInvite struct {
 	// The invite event signed by recipient server.
-	Event Event
+	Event *Event
 }
 
 // MarshalJSON implements json.Marshaller
@@ -534,5 +534,5 @@ func (r *RespInvite) UnmarshalJSON(data []byte) error {
 }
 
 type respInviteFields struct {
-	Event Event `json:"event"`
+	Event *Event `json:"event"`
 }

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -24,23 +24,22 @@ type EventHeader struct {
 // when marshalling into JSON and will be separated out when unmarshalling.
 type HeaderedEvent struct {
 	EventHeader
-	Event
+	*Event
 }
 
 // Unwrap extracts the event object from the headered event.
-func (e *HeaderedEvent) Unwrap() Event {
+func (e *HeaderedEvent) Unwrap() *Event {
 	if e.RoomVersion == "" {
 		// TODO: Perhaps return an error here instead of panicing
 		panic("gomatrixserverlib: malformed HeaderedEvent doesn't contain room version")
 	}
-	event := e.Event
-	event.roomVersion = e.RoomVersion
-	return event
+	e.Event.roomVersion = e.RoomVersion
+	return e.Event
 }
 
 // UnwrapEventHeaders unwraps an array of headered events.
-func UnwrapEventHeaders(in []HeaderedEvent) []Event {
-	result := make([]Event, len(in))
+func UnwrapEventHeaders(in []*HeaderedEvent) []*Event {
+	result := make([]*Event, len(in))
 	for i := range in {
 		result[i] = in[i].Event
 	}
@@ -56,6 +55,7 @@ func (e *HeaderedEvent) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	e.EventHeader = m
+	e.Event = &Event{}
 	// Now strip any of the header fields from the JSON input data.
 	fields := reflect.TypeOf(e.EventHeader)
 	for i := 0; i < fields.NumField(); i++ {

--- a/stateresolution_test.go
+++ b/stateresolution_test.go
@@ -18,17 +18,17 @@ func TestConflictEventSorter(t *testing.T) {
 	f1.Depth = 1
 	f2.Depth = 2
 	f3.Depth = 2
-	input := []Event{
-		{roomVersion: RoomVersionV1, fields: f1},
-		{roomVersion: RoomVersionV1, fields: f2},
-		{roomVersion: RoomVersionV1, fields: f3},
+	input := []*Event{
+		&Event{roomVersion: RoomVersionV1, fields: f1},
+		&Event{roomVersion: RoomVersionV1, fields: f2},
+		&Event{roomVersion: RoomVersionV1, fields: f3},
 	}
 
 	got := sortConflictedEventsByDepthAndSHA1(input)
 	want := []conflictedEvent{
-		{depth: 1, event: &input[0]},
-		{depth: 2, event: &input[2]},
-		{depth: 2, event: &input[1]},
+		{depth: 1, event: input[0]},
+		{depth: 2, event: input[2]},
+		{depth: 2, event: input[1]},
 	}
 	copy(want[0].eventIDSHA1[:], sha1OfEventID1A)
 	copy(want[1].eventIDSHA1[:], sha1OfEventID3B)

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -22,8 +22,8 @@ import (
 )
 
 type stateResolverV2 struct {
-	authEventMap              map[string]Event             // Map of all provided auth events
-	powerLevelMainline        []Event                      // Power level events in mainline ordering
+	authEventMap              map[string]*Event            // Map of all provided auth events
+	powerLevelMainline        []*Event                     // Power level events in mainline ordering
 	powerLevelMainlinePos     map[string]int               // Power level event positions in mainline
 	resolvedCreate            *Event                       // Resolved create event
 	resolvedPowerLevels       *Event                       // Resolved power level event
@@ -31,7 +31,7 @@ type stateResolverV2 struct {
 	resolvedThirdPartyInvites map[string]*Event            // Resolved third party invite events
 	resolvedMembers           map[string]*Event            // Resolved member events
 	resolvedOthers            map[string]map[string]*Event // Resolved other events
-	result                    []Event                      // Final list of resolved events
+	result                    []*Event                     // Final list of resolved events
 }
 
 // Create implements AuthEventProvider
@@ -63,11 +63,11 @@ func (r *stateResolverV2) Member(key string) (*Event, error) {
 // keys and works out which event should be used for each state event. This
 // function returns the resolved state, including unconflicted state events.
 func ResolveStateConflictsV2(
-	conflicted, unconflicted []Event,
-	authEvents, authDifference []Event,
-) []Event {
-	var conflictedControlEvents []Event
-	var conflictedOthers []Event
+	conflicted, unconflicted []*Event,
+	authEvents, authDifference []*Event,
+) []*Event {
+	var conflictedControlEvents []*Event
+	var conflictedOthers []*Event
 	r := stateResolverV2{
 		authEventMap:              eventMapFromEvents(authEvents),
 		powerLevelMainlinePos:     make(map[string]int),
@@ -79,7 +79,7 @@ func ResolveStateConflictsV2(
 	// This is a quick helper function to determine if an event already belongs to
 	// the unconflicted set. If it does then we shouldn't add it back into the
 	// conflicted set later.
-	isUnconflicted := func(event Event) bool {
+	isUnconflicted := func(event *Event) bool {
 		for _, v := range unconflicted {
 			if event.EventID() == v.EventID() {
 				return true
@@ -134,23 +134,23 @@ func ResolveStateConflictsV2(
 	// Now that we have our final state, populate the result array with the
 	// resolved state and return it.
 	if r.resolvedCreate != nil {
-		r.result = append(r.result, *r.resolvedCreate)
+		r.result = append(r.result, r.resolvedCreate)
 	}
 	if r.resolvedJoinRules != nil {
-		r.result = append(r.result, *r.resolvedJoinRules)
+		r.result = append(r.result, r.resolvedJoinRules)
 	}
 	if r.resolvedPowerLevels != nil {
-		r.result = append(r.result, *r.resolvedPowerLevels)
+		r.result = append(r.result, r.resolvedPowerLevels)
 	}
 	for _, member := range r.resolvedMembers {
-		r.result = append(r.result, *member)
+		r.result = append(r.result, member)
 	}
 	for _, invite := range r.resolvedThirdPartyInvites {
-		r.result = append(r.result, *invite)
+		r.result = append(r.result, invite)
 	}
 	for _, other := range r.resolvedOthers {
 		for _, event := range other {
-			r.result = append(r.result, *event)
+			r.result = append(r.result, event)
 		}
 	}
 
@@ -161,7 +161,7 @@ func ResolveStateConflictsV2(
 // using Kahn's algorithm in order to topologically order them. The
 // result array of events will be sorted so that "earlier" events appear
 // first.
-func ReverseTopologicalOrdering(events []Event) (result []Event) {
+func ReverseTopologicalOrdering(events []*Event) (result []*Event) {
 	r := stateResolverV2{}
 	return r.reverseTopologicalOrdering(events)
 }
@@ -169,7 +169,7 @@ func ReverseTopologicalOrdering(events []Event) (result []Event) {
 // isControlEvent returns true if the event meets the criteria for being classed
 // as a "control" event for reverse topological sorting. If not then the event
 // will be mainline sorted.
-func isControlEvent(e Event) bool {
+func isControlEvent(e *Event) bool {
 	switch e.Type() {
 	case MRoomPowerLevels:
 		// Power level events are control events.
@@ -210,14 +210,14 @@ func isControlEvent(e Event) bool {
 // ordering and working our way back to the room creation. Note that we populate
 // the result here in reverse, so that the room creation is at the beginning of
 // the list, rather than the end.
-func (r *stateResolverV2) createPowerLevelMainline() []Event {
-	var mainline []Event
+func (r *stateResolverV2) createPowerLevelMainline() []*Event {
+	var mainline []*Event
 
 	// Define our iterator function.
-	var iter func(event Event)
-	iter = func(event Event) {
+	var iter func(event *Event)
+	iter = func(event *Event) {
 		// Append this event to the beginning of the mainline.
-		mainline = append([]Event{event}, mainline...)
+		mainline = append([]*Event{event}, mainline...)
 		// Work through all of the auth event IDs that this event refers to.
 		for _, authEventID := range event.AuthEventIDs() {
 			// Check that we actually have the auth event in our map - we need this so
@@ -236,7 +236,7 @@ func (r *stateResolverV2) createPowerLevelMainline() []Event {
 	// Begin the sequence from the currently resolved power level event from the
 	// topological ordering.
 	if r.resolvedPowerLevels != nil {
-		iter(*r.resolvedPowerLevels)
+		iter(r.resolvedPowerLevels)
 	}
 
 	return mainline
@@ -248,12 +248,12 @@ func (r *stateResolverV2) createPowerLevelMainline() []Event {
 // createPowerLevelMainline. This function returns three things: the event that
 // was found in the mainline, the position in the mainline of the found event
 // and the number of steps it took to reach the mainline.
-func (r *stateResolverV2) getFirstPowerLevelMainlineEvent(event Event) (
-	mainlineEvent Event, mainlinePosition int, steps int,
+func (r *stateResolverV2) getFirstPowerLevelMainlineEvent(event *Event) (
+	mainlineEvent *Event, mainlinePosition int, steps int,
 ) {
 	// Define a function that the iterator can use to determine whether the event
 	// is in the mainline set or not.
-	isInMainline := func(searchEvent Event) (bool, int) {
+	isInMainline := func(searchEvent *Event) (bool, int) {
 		// If we already know the mainline position then return it.
 		if pos, ok := r.powerLevelMainlinePos[searchEvent.EventID()]; ok {
 			return true, pos
@@ -263,8 +263,8 @@ func (r *stateResolverV2) getFirstPowerLevelMainlineEvent(event Event) (
 	}
 
 	// Define our iterator function.
-	var iter func(event Event)
-	iter = func(event Event) {
+	var iter func(event *Event)
+	iter = func(event *Event) {
 		// In much the same way as we do in createPowerLevelMainline, we loop
 		// through the event's auth events, checking that it exists in our supplied
 		// auth event map and finding power level events.
@@ -305,7 +305,7 @@ func (r *stateResolverV2) getFirstPowerLevelMainlineEvent(event Event) (
 // also apply them on top of the partial state. If they fail auth checks then
 // the event is ignored and dropped. Returns two lists - the first contains the
 // accepted (authed) events and the second contains the rejected events.
-func (r *stateResolverV2) authAndApplyEvents(events []Event) {
+func (r *stateResolverV2) authAndApplyEvents(events []*Event) {
 	for _, event := range events {
 		// Check if the event is allowed based on the current partial state. If the
 		// event isn't allowed then simply ignore it and process the next one.
@@ -314,39 +314,39 @@ func (r *stateResolverV2) authAndApplyEvents(events []Event) {
 		}
 		// Apply the newly authed event to the partial state. We need to do this
 		// here so that the next loop will have partial state to auth against.
-		r.applyEvents([]Event{event})
+		r.applyEvents([]*Event{event})
 	}
 }
 
 // applyEvents applies the events on top of the partial state.
-func (r *stateResolverV2) applyEvents(events []Event) {
+func (r *stateResolverV2) applyEvents(events []*Event) {
 	for _, e := range events {
 		event := e
 		switch event.Type() {
 		case MRoomCreate:
 			// Room creation events are only valid with an empty state key.
 			if event.StateKey() == nil || *event.StateKey() == "" {
-				r.resolvedCreate = &event
+				r.resolvedCreate = event
 			}
 		case MRoomPowerLevels:
 			// Power level events are only valid with an empty state key.
 			if event.StateKey() == nil || *event.StateKey() == "" {
-				r.resolvedPowerLevels = &event
+				r.resolvedPowerLevels = event
 			}
 		case MRoomJoinRules:
 			// Join rule events are only valid with an empty state key.
 			if event.StateKey() == nil || *event.StateKey() == "" {
-				r.resolvedJoinRules = &event
+				r.resolvedJoinRules = event
 			}
 		case MRoomThirdPartyInvite:
 			// Third party invite events are only valid with a non-empty state key.
 			if event.StateKey() != nil && *event.StateKey() != "" {
-				r.resolvedThirdPartyInvites[*event.StateKey()] = &event
+				r.resolvedThirdPartyInvites[*event.StateKey()] = event
 			}
 		case MRoomMember:
 			// Membership events are only valid with a non-empty state key.
 			if event.StateKey() != nil && *event.StateKey() != "" {
-				r.resolvedMembers[*event.StateKey()] = &event
+				r.resolvedMembers[*event.StateKey()] = event
 			}
 		default:
 			// Doesn't match one of the core state types so store it by type and state
@@ -354,15 +354,15 @@ func (r *stateResolverV2) applyEvents(events []Event) {
 			if _, ok := r.resolvedOthers[event.Type()]; !ok {
 				r.resolvedOthers[event.Type()] = make(map[string]*Event)
 			}
-			r.resolvedOthers[event.Type()][*event.StateKey()] = &event
+			r.resolvedOthers[event.Type()][*event.StateKey()] = event
 		}
 	}
 }
 
 // eventMapFromEvents takes a list of events and returns a map, where the key
 // for each value is the event ID.
-func eventMapFromEvents(events []Event) map[string]Event {
-	r := make(map[string]Event)
+func eventMapFromEvents(events []*Event) map[string]*Event {
+	r := make(map[string]*Event)
 	for _, e := range events {
 		if _, ok := r[e.EventID()]; !ok {
 			r[e.EventID()] = e
@@ -374,7 +374,7 @@ func eventMapFromEvents(events []Event) map[string]Event {
 // wrapPowerLevelEventsForSort takes the input power level events and wraps them
 // in stateResV2ConflictedPowerLevel structs so that we have the necessary
 // information pre-calculated ahead of sorting.
-func (r *stateResolverV2) wrapPowerLevelEventsForSort(events []Event) []stateResV2ConflictedPowerLevel {
+func (r *stateResolverV2) wrapPowerLevelEventsForSort(events []*Event) []stateResV2ConflictedPowerLevel {
 	block := make([]stateResV2ConflictedPowerLevel, len(events))
 	for i, event := range events {
 		block[i] = stateResV2ConflictedPowerLevel{
@@ -390,7 +390,7 @@ func (r *stateResolverV2) wrapPowerLevelEventsForSort(events []Event) []stateRes
 // wrapOtherEventsForSort takes the input non-power level events and wraps them
 // in stateResV2ConflictedPowerLevel structs so that we have the necessary
 // information pre-calculated ahead of sorting.
-func (r *stateResolverV2) wrapOtherEventsForSort(events []Event) []stateResV2ConflictedOther {
+func (r *stateResolverV2) wrapOtherEventsForSort(events []*Event) []stateResV2ConflictedOther {
 	block := make([]stateResV2ConflictedOther, len(events))
 	for i, event := range events {
 		_, pos, _ := r.getFirstPowerLevelMainlineEvent(event)
@@ -407,7 +407,7 @@ func (r *stateResolverV2) wrapOtherEventsForSort(events []Event) []stateResV2Con
 // reverseTopologicalOrdering takes a set of input events, prepares them using
 // wrapPowerLevelEventsForSort and then starts the Kahn's algorithm in order to
 // topologically sort them. The result that is returned is correctly ordered.
-func (r *stateResolverV2) reverseTopologicalOrdering(events []Event) (result []Event) {
+func (r *stateResolverV2) reverseTopologicalOrdering(events []*Event) (result []*Event) {
 	block := r.wrapPowerLevelEventsForSort(events)
 	for _, s := range kahnsAlgorithmUsingAuthEvents(block) {
 		result = append(result, s.event)
@@ -418,7 +418,7 @@ func (r *stateResolverV2) reverseTopologicalOrdering(events []Event) (result []E
 // mainlineOrdering takes a set of input events, prepares them using
 // wrapOtherEventsForSort and then sorts them based on mainline ordering. The
 // result that is returned is correctly ordered.
-func (r *stateResolverV2) mainlineOrdering(events []Event) (result []Event) {
+func (r *stateResolverV2) mainlineOrdering(events []*Event) (result []*Event) {
 	block := r.wrapOtherEventsForSort(events)
 	sort.Sort(stateResV2ConflictedOtherHeap(block))
 	for _, s := range block {
@@ -430,7 +430,7 @@ func (r *stateResolverV2) mainlineOrdering(events []Event) (result []Event) {
 // getPowerLevelFromAuthEvents tries to determine the effective power level of
 // the sender at the time that of the given event, based on the auth events.
 // This is used in the Kahn's algorithm tiebreak.
-func (r *stateResolverV2) getPowerLevelFromAuthEvents(event Event) (pl int) {
+func (r *stateResolverV2) getPowerLevelFromAuthEvents(event *Event) (pl int) {
 	for _, authID := range event.AuthEventIDs() {
 		// First check and see if we have the auth event in the auth map, if not
 		// then we cannot deduce the real effective power level.

--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -31,14 +31,14 @@ var emptyStateKey = ""
 
 // separate takes a list of events and works out which events are conflicted and
 // which are unconflicted.
-func separate(events []Event) (conflicted, unconflicted []Event) {
+func separate(events []*Event) (conflicted, unconflicted []*Event) {
 	// The stack maps event type -> event state key -> list of state events.
-	stack := make(map[string]map[string][]Event)
+	stack := make(map[string]map[string][]*Event)
 	// Prepare the map.
 	for _, event := range events {
 		// If we haven't encountered an entry of this type yet, create an entry.
 		if _, ok := stack[event.Type()]; !ok {
-			stack[event.Type()] = make(map[string][]Event)
+			stack[event.Type()] = make(map[string][]*Event)
 		}
 		// Work out the state key in a crash-proof manner.
 		statekey := ""
@@ -77,9 +77,9 @@ func separate(events []Event) (conflicted, unconflicted []Event) {
 	return
 }
 
-func getBaseStateResV2Graph() []Event {
-	return []Event{
-		{
+func getBaseStateResV2Graph() []*Event {
+	return []*Event{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -93,7 +93,7 @@ func getBaseStateResV2Graph() []Event {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -113,7 +113,7 @@ func getBaseStateResV2Graph() []Event {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -134,7 +134,7 @@ func getBaseStateResV2Graph() []Event {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -156,7 +156,7 @@ func getBaseStateResV2Graph() []Event {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -178,7 +178,7 @@ func getBaseStateResV2Graph() []Event {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -209,7 +209,7 @@ func TestStateResolutionBase(t *testing.T) {
 		"$IMA:example.com", "$IMB:example.com", "$IMC:example.com",
 	}
 
-	runStateResolutionV2(t, []Event{}, expected)
+	runStateResolutionV2(t, []*Event{}, expected)
 }
 
 func TestStateResolutionBanVsPowerLevel(t *testing.T) {
@@ -219,8 +219,8 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 		"$MB:example.com",
 	}
 
-	runStateResolutionV2(t, []Event{
-		{
+	runStateResolutionV2(t, []*Event{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -245,7 +245,7 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -270,7 +270,7 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -292,7 +292,7 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -324,8 +324,8 @@ func TestStateResolutionJoinRuleEvasion(t *testing.T) {
 		"$IMZ:example.com",
 	}
 
-	runStateResolutionV2(t, []Event{
-		{
+	runStateResolutionV2(t, []*Event{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -347,7 +347,7 @@ func TestStateResolutionJoinRuleEvasion(t *testing.T) {
 				},
 			},
 		},
-		{
+		&Event{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
 				eventFields: eventFields{
@@ -439,7 +439,7 @@ func TestReverseTopologicalEventSorting(t *testing.T) {
 	}
 }
 
-func runStateResolutionV2(t *testing.T, additional []Event, expected []string) {
+func runStateResolutionV2(t *testing.T, additional []*Event, expected []string) {
 	input := append(getBaseStateResV2Graph(), additional...)
 	conflicted, unconflicted := separate(input)
 

--- a/stateresolutionv2heaps.go
+++ b/stateresolutionv2heaps.go
@@ -27,7 +27,7 @@ type stateResV2ConflictedPowerLevel struct {
 	powerLevel     int
 	originServerTS int64
 	eventID        string
-	event          Event
+	event          *Event
 }
 
 // A stateResV2ConflictedPowerLevelHeap is used to sort the events using
@@ -90,7 +90,7 @@ type stateResV2ConflictedOther struct {
 	mainlinePosition int
 	originServerTS   int64
 	eventID          string
-	event            Event
+	event            *Event
 }
 
 // A stateResV2ConflictedOtherHeap is used to sort the events using


### PR DESCRIPTION
This updates the gomatrixserverlib API to deal with pointers to events, to reduce problems where duplicate `Event` objects (when passed by value/through value receivers) would have underlying shared `interface{}` contents. It also should just reduce memory usage a little.

This also fixes a bug or two, like with redacting events and generating event IDs.

Merge this before matrix-org/dendrite#950.