### PR TITLE
Try to prevent nil prev_events/auth_events again

### DIFF
--- a/event.go
+++ b/event.go
@@ -194,6 +194,8 @@ func (eb *EventBuilder) Build(
 				resPrevEvents = append(resPrevEvents, prevEvent.EventID)
 			}
 			event.PrevEvents = resPrevEvents
+		case nil:
+			event.PrevEvents = []string{}
 		}
 		switch authEvents := event.AuthEvents.(type) {
 		case []string:
@@ -204,6 +206,8 @@ func (eb *EventBuilder) Build(
 				resAuthEvents = append(resAuthEvents, authEvent.EventID)
 			}
 			event.AuthEvents = resAuthEvents
+		case nil:
+			event.AuthEvents = []string{}
 		}
 	}
 


### PR DESCRIPTION
This does a bit more to ensure `auth_events` and `prev_events` are never `null`, and is a part of the fix in matrix-org/dendrite#951.