### PR TITLE
Support code for v2 invites

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -42,12 +42,16 @@ const (
 	MRoomJoinRules = "m.room.join_rules"
 	// MRoomPowerLevels https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-power-levels
 	MRoomPowerLevels = "m.room.power_levels"
+	// MRoomName https://matrix.org/docs/spec/client_server/r0.6.0#m-room-name
+	MRoomName = "m.room.name"
 	// MRoomMember https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-member
 	MRoomMember = "m.room.member"
 	// MRoomThirdPartyInvite https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-third-party-invite
 	MRoomThirdPartyInvite = "m.room.third_party_invite"
 	// MRoomAliases https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-aliases
 	MRoomAliases = "m.room.aliases"
+	// MRoomCanonicalAlias https://matrix.org/docs/spec/client_server/r0.6.0#m-room-canonical-alias
+	MRoomCanonicalAlias = "m.room.canonical_alias"
 	// MRoomHistoryVisibility https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-history-visibility
 	MRoomHistoryVisibility = "m.room.history_visibility"
 	// MRoomRedaction https://matrix.org/docs/spec/client_server/r0.2.0.html#id21

--- a/federationclient.go
+++ b/federationclient.go
@@ -172,6 +172,23 @@ func (ac *FederationClient) SendInvite(
 	return
 }
 
+// SendInviteV2 sends an invite m.room.member event to an invited server to be
+// signed by it. This is used to invite a user that is not on the local server.
+func (ac *FederationClient) SendInviteV2(
+	ctx context.Context, s ServerName, request InviteV2Request,
+) (res RespInvite, err error) {
+	event := request.Event()
+	path := federationPathPrefixV2 + "/invite/" +
+		url.PathEscape(event.RoomID()) + "/" +
+		url.PathEscape(event.EventID())
+	req := NewFederationRequest("PUT", s, path)
+	if err = req.SetContent(request); err != nil {
+		return
+	}
+	err = ac.doRequest(ctx, req, &res)
+	return
+}
+
 // ExchangeThirdPartyInvite sends the builder of a m.room.member event of
 // "invite" membership derived from a response from invites sent by an identity
 // server.

--- a/federationclient.go
+++ b/federationclient.go
@@ -161,7 +161,7 @@ func (ac *FederationClient) SendLeave(
 func (ac *FederationClient) SendInvite(
 	ctx context.Context, s ServerName, event Event,
 ) (res RespInvite, err error) {
-	path := federationPathPrefixV1 + "/invite/" +
+	path := federationPathPrefixV2 + "/invite/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
 	req := NewFederationRequest("PUT", s, path)

--- a/federationclient.go
+++ b/federationclient.go
@@ -161,7 +161,7 @@ func (ac *FederationClient) SendLeave(
 func (ac *FederationClient) SendInvite(
 	ctx context.Context, s ServerName, event Event,
 ) (res RespInvite, err error) {
-	path := federationPathPrefixV2 + "/invite/" +
+	path := federationPathPrefixV1 + "/invite/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
 	req := NewFederationRequest("PUT", s, path)

--- a/headeredevent_test.go
+++ b/headeredevent_test.go
@@ -5,20 +5,21 @@ import (
 	"testing"
 )
 
+const TestHeaderedExampleEvent = `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+
 func TestUnmarshalMarshalHeaderedEvent(t *testing.T) {
 	output := HeaderedEvent{}
-	input := `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
 
-	if err := json.Unmarshal([]byte(input), &output); err != nil {
+	if err := json.Unmarshal([]byte(TestHeaderedExampleEvent), &output); err != nil {
 		t.Fatal(err)
 	}
 
 	headered := output.Event.Headered(RoomVersionV1)
 
 	if j, err := json.Marshal(headered); err == nil {
-		if string(j) != input {
+		if string(j) != TestHeaderedExampleEvent {
 			t.Logf("got: %s", string(j))
-			t.Logf("expected: %s", input)
+			t.Logf("expected: %s", TestHeaderedExampleEvent)
 			t.Fatalf("round-trip unmarshal and marshal produced different results")
 		}
 	} else {

--- a/invitev2.go
+++ b/invitev2.go
@@ -1,0 +1,72 @@
+package gomatrixserverlib
+
+// InviteV2Request and InviteV2StrippedState are defined in
+// https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v2-invite-roomid-eventid
+
+// InviteV2Request is used in a /_matrix/federation/v2/invite request.
+type InviteV2Request struct {
+	fields struct {
+		Event           Event                   `json:"event"`
+		RoomVersion     RoomVersion             `json:"room_version"`
+		InviteRoomState []InviteV2StrippedState `json:"invite_stripped_state"`
+	}
+}
+
+// Event returns the invite event.
+func (i *InviteV2Request) Event() Event {
+	return i.fields.Event
+}
+
+// RoomVersion returns the room version of the invited room.
+func (i *InviteV2Request) RoomVersion() RoomVersion {
+	return i.fields.RoomVersion
+}
+
+// InviteRoomState returns stripped state events for the room, containing
+// enough information for the client to identify the room.
+func (i *InviteV2Request) InviteRoomState() []InviteV2StrippedState {
+	return i.fields.InviteRoomState
+}
+
+// InviteV2Request is used in a /_matrix/federation/v2/invite response.
+type InviteV2Response struct {
+	fields struct {
+		Event Event `json:"event"`
+	}
+}
+
+// Event returns the invite event.
+func (i *InviteV2Response) Event() Event {
+	return i.fields.Event
+}
+
+// InviteV2StrippedState is a cut-down set of fields from room state
+// events that allow the invited server to identify the room.
+type InviteV2StrippedState struct {
+	fields struct {
+		Content  RawJSON `json:"content"`
+		StateKey *string `json:"state_key"`
+		Type     string  `json:"type"`
+		Sender   string  `json:"sender"`
+	}
+}
+
+// Content returns the content of the stripped state.
+func (i *InviteV2StrippedState) Content() RawJSON {
+	return i.fields.Content
+}
+
+// StateKey returns the state key of the stripped state.
+func (i *InviteV2StrippedState) StateKey() *string {
+	return i.fields.StateKey
+}
+
+// Type returns the type of the stripped state.
+func (i *InviteV2StrippedState) Type() string {
+	return i.fields.Type
+}
+
+// Sender returns the sender of the stripped state.
+func (i *InviteV2StrippedState) Sender() string {
+	return i.fields.Sender
+}

--- a/invitev2.go
+++ b/invitev2.go
@@ -43,7 +43,7 @@ func (i InviteV2Request) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.fields)
 }
 
-// // MarshalJSON implements json.Unmarshaller
+// UnmarshalJSON implements json.Unmarshaller
 func (i *InviteV2Request) UnmarshalJSON(data []byte) error {
 	err := json.Unmarshal(data, &i.fields.inviteV2RequestHeaders)
 	if err != nil {
@@ -97,6 +97,11 @@ func NewInviteV2StrippedState(event *Event) (ss InviteV2StrippedState) {
 // MarshalJSON implements json.Marshaller
 func (i InviteV2StrippedState) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.fields)
+}
+
+// UnmarshalJSON implements json.Unmarshaller
+func (i *InviteV2StrippedState) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &i.fields)
 }
 
 // Content returns the content of the stripped state.

--- a/invitev2.go
+++ b/invitev2.go
@@ -94,6 +94,11 @@ func NewInviteV2StrippedState(event *Event) (ss InviteV2StrippedState) {
 	return
 }
 
+// MarshalJSON implements json.Marshaller
+func (i InviteV2StrippedState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.fields)
+}
+
 // Content returns the content of the stripped state.
 func (i *InviteV2StrippedState) Content() RawJSON {
 	return i.fields.Content

--- a/invitev2.go
+++ b/invitev2.go
@@ -14,7 +14,7 @@ func NewInviteV2Request(event *HeaderedEvent, state []InviteV2StrippedState) (
 	request InviteV2Request, err error,
 ) {
 	if event.RoomVersion == "" {
-		err = errors.New("gomatrixserverlib: malformed headered event")
+		err = errors.New("gomatrixserverlib: missing room version from event header")
 		return
 	}
 	request.fields.inviteV2RequestHeaders = inviteV2RequestHeaders{
@@ -52,6 +52,9 @@ func (i *InviteV2Request) UnmarshalJSON(data []byte) error {
 	eventJSON := gjson.GetBytes(data, "event")
 	if !eventJSON.Exists() {
 		return errors.New("gomatrixserverlib: request doesn't contain event")
+	}
+	if i.fields.RoomVersion == "" {
+		return errors.New("gomatrixserverlib: missing room version from event header")
 	}
 	i.fields.Event, err = NewEventFromUntrustedJSON([]byte(eventJSON.String()), i.fields.RoomVersion)
 	return err

--- a/invitev2.go
+++ b/invitev2.go
@@ -1,5 +1,9 @@
 package gomatrixserverlib
 
+import (
+	"encoding/json"
+)
+
 // InviteV2Request and InviteV2StrippedState are defined in
 // https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v2-invite-roomid-eventid
 
@@ -10,6 +14,12 @@ type InviteV2Request struct {
 		RoomVersion     RoomVersion             `json:"room_version"`
 		InviteRoomState []InviteV2StrippedState `json:"invite_stripped_state"`
 	}
+}
+
+// SetContent sets the JSON content for the request.
+// Returns an error if there already is JSON content present on the request.
+func (i *InviteV2Request) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &i.fields)
 }
 
 // Event returns the invite event.
@@ -26,18 +36,6 @@ func (i *InviteV2Request) RoomVersion() RoomVersion {
 // enough information for the client to identify the room.
 func (i *InviteV2Request) InviteRoomState() []InviteV2StrippedState {
 	return i.fields.InviteRoomState
-}
-
-// InviteV2Request is used in a /_matrix/federation/v2/invite response.
-type InviteV2Response struct {
-	fields struct {
-		Event Event `json:"event"`
-	}
-}
-
-// Event returns the invite event.
-func (i *InviteV2Response) Event() Event {
-	return i.fields.Event
 }
 
 // InviteV2StrippedState is a cut-down set of fields from room state

--- a/invitev2.go
+++ b/invitev2.go
@@ -84,6 +84,16 @@ type InviteV2StrippedState struct {
 	}
 }
 
+// NewInviteV2StrippedState creates a stripped state event from a
+// regular state event.
+func NewInviteV2StrippedState(event *Event) (ss InviteV2StrippedState) {
+	ss.fields.Content = event.Content()
+	ss.fields.StateKey = event.StateKey()
+	ss.fields.Type = event.Type()
+	ss.fields.Sender = event.Sender()
+	return
+}
+
 // Content returns the content of the stripped state.
 func (i *InviteV2StrippedState) Content() RawJSON {
 	return i.fields.Content

--- a/invitev2.go
+++ b/invitev2.go
@@ -38,8 +38,12 @@ type InviteV2Request struct {
 	}
 }
 
-// SetContent sets the JSON content for the request.
-// Returns an error if there already is JSON content present on the request.
+// MarshalJSON implements json.Marshaller
+func (i InviteV2Request) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.fields)
+}
+
+// // MarshalJSON implements json.Unmarshaller
 func (i *InviteV2Request) UnmarshalJSON(data []byte) error {
 	err := json.Unmarshal(data, &i.fields.inviteV2RequestHeaders)
 	if err != nil {

--- a/invitev2.go
+++ b/invitev2.go
@@ -30,7 +30,7 @@ type inviteV2RequestHeaders struct {
 	InviteRoomState []InviteV2StrippedState `json:"invite_stripped_state"`
 }
 
-// InviteV2Request is used in a /_matrix/federation/v2/invite request.
+// InviteV2Request is used in the body of a /_matrix/federation/v2/invite request.
 type InviteV2Request struct {
 	fields struct {
 		inviteV2RequestHeaders

--- a/invitev2.go
+++ b/invitev2.go
@@ -6,14 +6,14 @@ package gomatrixserverlib
 // InviteV2Request is used in a /_matrix/federation/v2/invite request.
 type InviteV2Request struct {
 	fields struct {
-		Event           Event                   `json:"event"`
+		Event           RawJSON                 `json:"event"`
 		RoomVersion     RoomVersion             `json:"room_version"`
 		InviteRoomState []InviteV2StrippedState `json:"invite_stripped_state"`
 	}
 }
 
 // Event returns the invite event.
-func (i *InviteV2Request) Event() Event {
+func (i *InviteV2Request) Event() RawJSON {
 	return i.fields.Event
 }
 

--- a/invitev2.go
+++ b/invitev2.go
@@ -10,6 +10,21 @@ import (
 // InviteV2Request and InviteV2StrippedState are defined in
 // https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v2-invite-roomid-eventid
 
+func NewInviteV2Request(event *HeaderedEvent, state []InviteV2StrippedState) (
+	request InviteV2Request, err error,
+) {
+	if event.RoomVersion == "" {
+		err = errors.New("gomatrixserverlib: malformed headered event")
+		return
+	}
+	request.fields.inviteV2RequestHeaders = inviteV2RequestHeaders{
+		RoomVersion:     event.RoomVersion,
+		InviteRoomState: state,
+	}
+	request.fields.Event = event.Unwrap()
+	return
+}
+
 type inviteV2RequestHeaders struct {
 	RoomVersion     RoomVersion             `json:"room_version"`
 	InviteRoomState []InviteV2StrippedState `json:"invite_stripped_state"`

--- a/invitev2_test.go
+++ b/invitev2_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 )
 
+const TestInviteV2ExampleEvent = `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+
 func TestMarshalInviteV2Request(t *testing.T) {
 	output := HeaderedEvent{}
 	expected := `{"room_version":"1","invite_stripped_state":[],"event":{"auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}}`
 
-	if err := json.Unmarshal([]byte(TestHeaderedExampleEvent), &output); err != nil {
+	if err := json.Unmarshal([]byte(TestInviteV2ExampleEvent), &output); err != nil {
 		t.Fatal(err)
 	}
 
@@ -34,7 +36,7 @@ func TestStrippedState(t *testing.T) {
 	output := HeaderedEvent{}
 	expected := `{"content":{"name":"test3"},"state_key":"","type":"m.room.name","sender":"@test:localhost"}`
 
-	if err := json.Unmarshal([]byte(TestHeaderedExampleEvent), &output); err != nil {
+	if err := json.Unmarshal([]byte(TestInviteV2ExampleEvent), &output); err != nil {
 		t.Fatal(err)
 	}
 

--- a/invitev2_test.go
+++ b/invitev2_test.go
@@ -30,3 +30,24 @@ func TestMarshalInviteV2Request(t *testing.T) {
 		t.Fatalf("got %q, expected %q", string(j), expected)
 	}
 }
+
+func TestStrippedState(t *testing.T) {
+	output := HeaderedEvent{}
+	input := `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+	expected := `{"content":{"name":"test3"},"state_key":"","type":"m.room.name","sender":"@test:localhost"}`
+
+	if err := json.Unmarshal([]byte(input), &output); err != nil {
+		t.Fatal(err)
+	}
+
+	stripped := NewInviteV2StrippedState(&output.Event)
+
+	j, err := json.Marshal(stripped)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(j) != expected {
+		t.Fatalf("got %q, expected %q", string(j), expected)
+	}
+}

--- a/invitev2_test.go
+++ b/invitev2_test.go
@@ -7,10 +7,9 @@ import (
 
 func TestMarshalInviteV2Request(t *testing.T) {
 	output := HeaderedEvent{}
-	input := `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
 	expected := `{"room_version":"1","invite_stripped_state":[],"event":{"auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}}`
 
-	if err := json.Unmarshal([]byte(input), &output); err != nil {
+	if err := json.Unmarshal([]byte(TestHeaderedExampleEvent), &output); err != nil {
 		t.Fatal(err)
 	}
 
@@ -33,10 +32,9 @@ func TestMarshalInviteV2Request(t *testing.T) {
 
 func TestStrippedState(t *testing.T) {
 	output := HeaderedEvent{}
-	input := `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
 	expected := `{"content":{"name":"test3"},"state_key":"","type":"m.room.name","sender":"@test:localhost"}`
 
-	if err := json.Unmarshal([]byte(input), &output); err != nil {
+	if err := json.Unmarshal([]byte(TestHeaderedExampleEvent), &output); err != nil {
 		t.Fatal(err)
 	}
 

--- a/invitev2_test.go
+++ b/invitev2_test.go
@@ -1,0 +1,32 @@
+package gomatrixserverlib
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalInviteV2Request(t *testing.T) {
+	output := HeaderedEvent{}
+	input := `{"_room_version":"1","auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}`
+	expected := `{"room_version":"1","invite_stripped_state":[],"event":{"auth_events":[["$oXL79cT7fFxR7dPH:localhost",{"sha256":"abjkiDSg1RkuZrbj2jZoGMlQaaj1Ue3Jhi7I7NlKfXY"}],["$IVUsaSkm1LBAZYYh:localhost",{"sha256":"X7RUj46hM/8sUHNBIFkStbOauPvbDzjSdH4NibYWnko"}],["$VS2QT0EeArZYi8wf:localhost",{"sha256":"k9eM6utkCH8vhLW9/oRsH74jOBS/6RVK42iGDFbylno"}]],"content":{"name":"test3"},"depth":7,"event_id":"$yvN1b43rlmcOs5fY:localhost","hashes":{"sha256":"Oh1mwI1jEqZ3tgJ+V1Dmu5nOEGpCE4RFUqyJv2gQXKs"},"origin":"localhost","origin_server_ts":1510854416361,"prev_events":[["$FqI6TVvWpcbcnJ97:localhost",{"sha256":"upCsBqUhNUgT2/+zkzg8TbqdQpWWKQnZpGJc6KcbUC4"}]],"prev_state":[],"room_id":"!19Mp0U9hjajeIiw1:localhost","sender":"@test:localhost","signatures":{"localhost":{"ed25519:u9kP":"5IzSuRXkxvbTp0vZhhXYZeOe+619iG3AybJXr7zfNn/4vHz4TH7qSJVQXSaHHvcTcDodAKHnTG1WDulgO5okAQ"}},"state_key":"","type":"m.room.name"}}`
+
+	if err := json.Unmarshal([]byte(input), &output); err != nil {
+		t.Fatal(err)
+	}
+
+	headered := output.Event.Headered(RoomVersionV1)
+
+	inviteReq, err := NewInviteV2Request(&headered, []InviteV2StrippedState{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	j, err := json.Marshal(inviteReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(j) != expected {
+		t.Fatalf("got %q, expected %q", string(j), expected)
+	}
+}

--- a/request.go
+++ b/request.go
@@ -27,6 +27,7 @@ type FederationRequest struct {
 		Origin      ServerName                      `json:"origin"`
 		RequestURI  string                          `json:"uri"`
 		Signatures  map[ServerName]map[KeyID]string `json:"signatures,omitempty"`
+		RoomVersion RoomVersion                     `json:"room_version,omitempty"`
 	}
 }
 

--- a/request.go
+++ b/request.go
@@ -27,7 +27,6 @@ type FederationRequest struct {
 		Origin      ServerName                      `json:"origin"`
 		RequestURI  string                          `json:"uri"`
 		Signatures  map[ServerName]map[KeyID]string `json:"signatures,omitempty"`
-		RoomVersion RoomVersion                     `json:"room_version,omitempty"`
 	}
 }
 
@@ -79,11 +78,6 @@ func (r *FederationRequest) Origin() ServerName {
 // RequestURI returns the path and query sections of the HTTP request URL.
 func (r *FederationRequest) RequestURI() string {
 	return r.fields.RequestURI
-}
-
-// RoomVersion returns the room version from the request, if set.
-func (r *FederationRequest) RoomVersion() RoomVersion {
-	return r.fields.RoomVersion
 }
 
 // Sign the matrix request with an ed25519 key.

--- a/request.go
+++ b/request.go
@@ -81,6 +81,11 @@ func (r *FederationRequest) RequestURI() string {
 	return r.fields.RequestURI
 }
 
+// RoomVersion returns the room version from the request, if set.
+func (r *FederationRequest) RoomVersion() RoomVersion {
+	return r.fields.RoomVersion
+}
+
 // Sign the matrix request with an ed25519 key.
 // Uses the algorithm specified https://matrix.org/docs/spec/server_server/unstable.html#request-authentication
 // Updates the request with the signature in place.


### PR DESCRIPTION
This PR adds support code for supporting the [`/_matrix/federation/v2/invite`](https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v2-invite-roomid-eventid) endpoint.

Maybe it is better to put this stuff into `federationtypes.go` or something, or name it better? Or is it OK as-is?