### PR TITLE
Parallelise direct key fetcher

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -403,7 +403,7 @@ func (d *DirectKeyFetcher) FetchKeys(
 			serverResults, err := d.fetchKeysForServer(ctx, server)
 			if err != nil {
 				// TODO: Should we actually be erroring here? or should we just drop those keys from the result map?
-				return
+				continue
 			}
 			resultsMutex.Lock()
 			for req, keys := range serverResults {

--- a/keyring.go
+++ b/keyring.go
@@ -409,10 +409,10 @@ func (d *DirectKeyFetcher) FetchKeys(
 				return
 			}
 			resultsMutex.Lock()
-			defer resultsMutex.Unlock()
 			for req, keys := range serverResults {
 				results[req] = keys
 			}
+			resultsMutex.Unlock()
 		}
 	}
 

--- a/keyring.go
+++ b/keyring.go
@@ -397,9 +397,9 @@ func (d *DirectKeyFetcher) FetchKeys(
 	close(pending)
 
 	// Define our worker.
-	worker := func() {
+	worker := func(ch <-chan ServerName) {
 		defer wait.Done()
-		for server := range pending {
+		for server := range ch {
 			serverResults, err := d.fetchKeysForServer(ctx, server)
 			if err != nil {
 				// TODO: Should we actually be erroring here? or should we just drop those keys from the result map?
@@ -415,7 +415,7 @@ func (d *DirectKeyFetcher) FetchKeys(
 
 	// Start the workers.
 	for i := 0; i < numWorkers; i++ {
-		go worker()
+		go worker(pending)
 	}
 
 	// Wait for the workers to finish before returning


### PR DESCRIPTION
This spawns goroutines per server for the direct key fetcher and waits for results to return using a wait group. The result is that fetching keys in big rooms now doesn't take forever (a maximum of 30 seconds since that appears to be our outbound timeout) and this reduces the chance that the requestor context expires before we finish:
```
Apr 16 15:41:58 photon-machine docker-compose[3829]: dendrite_monolith | time="2020-04-16T15:41:58.284643563Z" level=info msg="Checking event signatures for 7677 events of room state" func="Check\n\t" file=" [/go/pkg/mod/github.com/matrix-org/gomatrixserverlib@v0.0.0-20200416153646-47a0f63244a5/federationtypes.go:332]" req.id=4sPgj4M4LH8x req.method=POST req.path="/_matrix/client/r0/join/!BAXLHOFjvDKUeLafmO:matrix.org" user_id="@neilalexander:dendrite.neilalexander.dev"
Apr 16 15:42:00 photon-machine docker-compose[3829]: dendrite_monolith | time="2020-04-16T15:42:00.434945429Z" level=info msg="Requesting keys from fetcher" func="func1\n\t" file=" [/go/pkg/mod/github.com/matrix-org/gomatrixserverlib@v0.0.0-20200416153646-47a0f63244a5/keyring.go:196]" fetcher=DirectKeyFetcher num_key_requests=194 req.id=4sPgj4M4LH8x req.method=POST req.path="/_matrix/client/r0/join/!BAXLHOFjvDKUeLafmO:matrix.org" user_id="@neilalexander:dendrite.neilalexander.dev"
...
Apr 16 15:42:30 photon-machine docker-compose[3829]: dendrite_monolith | time="2020-04-16T15:42:30.637662978Z" level=info msg="Got keys from fetcher" func="func1\n\t" file=" [/go/pkg/mod/github.com/matrix-org/gomatrixserverlib@v0.0.0-20200416153646-47a0f63244a5/keyring.go:204]" fetcher=DirectKeyFetcher num_keys_fetched=137 req.id=4sPgj4M4LH8x req.method=POST req.path="/_matrix/client/r0/join/!BAXLHOFjvDKUeLafmO:matrix.org" user_id="@neilalexander:dendrite.neilalexander.dev"
```