### PR TITLE
Update validity check

### DIFF
--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -263,11 +263,17 @@ func VerifyEventSignatures(ctx context.Context, events []Event, keyRing JSONVeri
 			}
 		}
 
+		strictValidityChecking, err := event.roomVersion.StrictValidityChecking()
+		if err != nil {
+			return nil, err
+		}
+
 		for domain := range domains {
 			v := VerifyJSONRequest{
-				Message:    redactedJSON,
-				AtTS:       event.OriginServerTS(),
-				ServerName: domain,
+				Message:                redactedJSON,
+				AtTS:                   event.OriginServerTS(),
+				ServerName:             domain,
+				StrictValidityChecking: strictValidityChecking,
 			}
 			verificationMap[evtIdx] = append(verificationMap[evtIdx], len(toVerify))
 			toVerify = append(toVerify, v)

--- a/eventversion.go
+++ b/eventversion.go
@@ -110,9 +110,9 @@ func (v RoomVersion) EventIDFormat() (EventIDFormat, error) {
 	return 0, UnsupportedRoomVersionError{v}
 }
 
-// EnforceSignatureChecks returns true if the given room version calls for
+// StrictValidityChecking returns true if the given room version calls for
 // strict signature checking (room version 5 and onward) or false otherwise.
-func (v RoomVersion) EnforceSignatureChecks() (bool, error) {
+func (v RoomVersion) StrictValidityChecking() (bool, error) {
 	if r, ok := roomVersionMeta[v]; ok {
 		return r.enforceSignatureChecks, nil
 	}

--- a/keyring.go
+++ b/keyring.go
@@ -42,13 +42,13 @@ type PublicKeyLookupResult struct {
 // WasValidAt checks if this signing key is valid for an event signed at the
 // given timestamp.
 func (r PublicKeyLookupResult) WasValidAt(atTs Timestamp) bool {
-	if r.ExpiredTS != PublicKeyNotExpired && atTs >= r.ExpiredTS {
-		return false
+	if r.ValidUntilTS != PublicKeyNotValid && atTs < r.ValidUntilTS {
+		return true
 	}
-	if r.ValidUntilTS == PublicKeyNotValid || atTs > r.ValidUntilTS {
-		return false
+	if r.ExpiredTS != PublicKeyNotExpired && atTs < r.ExpiredTS {
+		return true
 	}
-	return true
+	return false
 }
 
 // A KeyFetcher is a way of fetching public keys in bulk.

--- a/keyring.go
+++ b/keyring.go
@@ -42,13 +42,15 @@ type PublicKeyLookupResult struct {
 // WasValidAt checks if this signing key is valid for an event signed at the
 // given timestamp.
 func (r PublicKeyLookupResult) WasValidAt(atTs Timestamp, strictValidityChecking bool) bool {
-	if r.ExpiredTS != PublicKeyNotExpired && atTs < r.ExpiredTS {
-		return true
+	if r.ExpiredTS != PublicKeyNotExpired && atTs >= r.ExpiredTS {
+		return false
 	}
-	if strictValidityChecking && r.ValidUntilTS != PublicKeyNotValid && atTs <= r.ValidUntilTS {
-		return true
+	if strictValidityChecking {
+		if r.ValidUntilTS == PublicKeyNotValid || atTs > r.ValidUntilTS {
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 // A KeyFetcher is a way of fetching public keys in bulk.

--- a/keyring.go
+++ b/keyring.go
@@ -42,7 +42,7 @@ type PublicKeyLookupResult struct {
 // WasValidAt checks if this signing key is valid for an event signed at the
 // given timestamp.
 func (r PublicKeyLookupResult) WasValidAt(atTs Timestamp) bool {
-	if r.ValidUntilTS != PublicKeyNotValid && atTs < r.ValidUntilTS {
+	if r.ValidUntilTS != PublicKeyNotValid && atTs <= r.ValidUntilTS {
 		return true
 	}
 	if r.ExpiredTS != PublicKeyNotExpired && atTs < r.ExpiredTS {

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -88,9 +88,10 @@ func TestVerifyJSONsSuccess(t *testing.T) {
 	// Check that trying to verify the server key JSON works.
 	k := KeyRing{nil, &testKeyDatabase{}}
 	results, err := k.VerifyJSONs(context.Background(), []VerifyJSONRequest{{
-		ServerName: "localhost:8800",
-		Message:    []byte(testKeys),
-		AtTS:       1493142432964,
+		ServerName:             "localhost:8800",
+		Message:                []byte(testKeys),
+		AtTS:                   1493142432964,
+		StrictValidityChecking: true,
 	}})
 	if err != nil {
 		t.Fatal(err)
@@ -104,9 +105,10 @@ func TestVerifyJSONsUnknownServerFails(t *testing.T) {
 	// Check that trying to verify JSON for an unknown server fails.
 	k := KeyRing{nil, &testKeyDatabase{}}
 	results, err := k.VerifyJSONs(context.Background(), []VerifyJSONRequest{{
-		ServerName: "unknown:8800",
-		Message:    []byte(testKeys),
-		AtTS:       1493142432964,
+		ServerName:             "unknown:8800",
+		Message:                []byte(testKeys),
+		AtTS:                   1493142432964,
+		StrictValidityChecking: true,
 	}})
 	if err != nil {
 		t.Fatal(err)
@@ -121,9 +123,10 @@ func TestVerifyJSONsDistantFutureFails(t *testing.T) {
 	distantFuture := Timestamp(2000000000000)
 	k := KeyRing{nil, &testKeyDatabase{}}
 	results, err := k.VerifyJSONs(context.Background(), []VerifyJSONRequest{{
-		ServerName: "unknown:8800",
-		Message:    []byte(testKeys),
-		AtTS:       distantFuture,
+		ServerName:             "unknown:8800",
+		Message:                []byte(testKeys),
+		AtTS:                   distantFuture,
+		StrictValidityChecking: true,
 	}})
 	if err != nil {
 		t.Fatal(err)
@@ -137,9 +140,10 @@ func TestVerifyJSONsFetcherError(t *testing.T) {
 	// Check that if the database errors then the attempt to verify JSON fails.
 	k := KeyRing{nil, &erroringKeyDatabase{}}
 	results, err := k.VerifyJSONs(context.Background(), []VerifyJSONRequest{{
-		ServerName: "localhost:8800",
-		Message:    []byte(testKeys),
-		AtTS:       1493142432964,
+		ServerName:             "localhost:8800",
+		Message:                []byte(testKeys),
+		AtTS:                   1493142432964,
+		StrictValidityChecking: true,
 	}})
 	if err != error(&testErrorFetch) || results != nil {
 		t.Fatalf("VerifyJSONs(): Wanted (nil, <some error>) got (%#v, %q)", results, err)

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -101,6 +101,40 @@ func TestVerifyJSONsSuccess(t *testing.T) {
 	}
 }
 
+func TestVerifyJSONsFailureWithStrictChecking(t *testing.T) {
+	// Check that trying to verify the server key JSON works.
+	k := KeyRing{nil, &testKeyDatabase{}}
+	results, err := k.VerifyJSONs(context.Background(), []VerifyJSONRequest{{
+		ServerName:             "localhost:8800",
+		Message:                []byte(testKeys),
+		AtTS:                   1493142433964,
+		StrictValidityChecking: true,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 1 && results[0].Error == nil {
+		t.Fatal("VerifyJSON() should have failed but didn't")
+	}
+}
+
+func TestVerifyJSONsFailureWithoutStrictChecking(t *testing.T) {
+	// Check that trying to verify the server key JSON works.
+	k := KeyRing{nil, &testKeyDatabase{}}
+	results, err := k.VerifyJSONs(context.Background(), []VerifyJSONRequest{{
+		ServerName:             "localhost:8800",
+		Message:                []byte(testKeys),
+		AtTS:                   1493142433964,
+		StrictValidityChecking: false,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Error != nil {
+		t.Fatalf("VerifyJSON(): Wanted [{Error: nil}] got %#v", results)
+	}
+}
+
 func TestVerifyJSONsUnknownServerFails(t *testing.T) {
 	// Check that trying to verify JSON for an unknown server fails.
 	k := KeyRing{nil, &testKeyDatabase{}}

--- a/request.go
+++ b/request.go
@@ -216,9 +216,10 @@ func VerifyHTTPRequest(
 	}
 
 	results, err := keys.VerifyJSONs(req.Context(), []VerifyJSONRequest{{
-		ServerName: request.Origin(),
-		AtTS:       AsTimestamp(now),
-		Message:    toVerify,
+		ServerName:             request.Origin(),
+		AtTS:                   AsTimestamp(now),
+		Message:                toVerify,
+		StrictValidityChecking: true,
 	}})
 	if err != nil {
 		message := "Error authenticating request"

--- a/request_test.go
+++ b/request_test.go
@@ -79,7 +79,7 @@ func TestVerifyGetRequest(t *testing.T) {
 		hr, time.Unix(1493142432, 96400), "localhost:44033", KeyRing{nil, &testKeyDatabase{}},
 	)
 	if request == nil {
-		t.Errorf("Wanted non-nil request got nil. (request was %#v, response was %#v)", hr, jsonResp)
+		t.Fatalf("Wanted non-nil request got nil. (request was %#v, response was %#v)", hr, jsonResp)
 	}
 
 	if request.Method() != "GET" {
@@ -138,7 +138,7 @@ func TestVerifyPutRequest(t *testing.T) {
 		hr, time.Unix(1493142432, 96400), "localhost:44033", KeyRing{nil, &testKeyDatabase{}},
 	)
 	if request == nil {
-		t.Errorf("Wanted non-nil request got nil. (request was %#v, response was %#v)", hr, jsonResp)
+		t.Fatalf("Wanted non-nil request got nil. (request was %#v, response was %#v)", hr, jsonResp)
 	}
 
 	if request.Method() != "PUT" {


### PR DESCRIPTION
This signature checking so that strict validity checking can be optional (as is needed for room versions 1-4) whilst maintaining it for federation HTTP requests and allowing us to use it for room version 5.

It also fixes some potential panics in tests.