### PR TITLE
SendRespJoin checks

### DIFF
--- a/federationtypes.go
+++ b/federationtypes.go
@@ -238,7 +238,67 @@ func (r RespState) Events() ([]Event, error) {
 	if len(r.AuthEvents) == 0 {
 		r.AuthEvents = []Event{}
 	}
-	return ReverseTopologicalOrdering(append(r.StateEvents, r.AuthEvents...)), nil
+	eventsByID := map[string]*Event{}
+	// Collect a map of event reference to event
+	for i := range r.StateEvents {
+		eventsByID[r.StateEvents[i].EventID()] = &r.StateEvents[i]
+	}
+	for i := range r.AuthEvents {
+		eventsByID[r.AuthEvents[i].EventID()] = &r.AuthEvents[i]
+	}
+
+	queued := map[*Event]bool{}
+	outputted := map[*Event]bool{}
+	var result []Event
+	for _, event := range eventsByID {
+		if outputted[event] {
+			// If we've already written the event then we can skip it.
+			continue
+		}
+
+		// The code below does a depth first scan through the auth events
+		// looking for events that can be appended to the output.
+
+		// We use an explicit stack rather than using recursion so
+		// that we can check we aren't creating cycles.
+		stack := []*Event{event}
+
+	LoopProcessTopOfStack:
+		for len(stack) > 0 {
+			top := stack[len(stack)-1]
+			// Check if we can output the top of the stack.
+			// We can output it if we have outputted all of its auth_events.
+			for _, ref := range top.AuthEvents() {
+				authEvent := eventsByID[ref.EventID]
+				if authEvent == nil {
+					return nil, MissingAuthEventError{ref.EventID, top.EventID()}
+				}
+				if outputted[authEvent] {
+					continue
+				}
+				if queued[authEvent] {
+					return nil, fmt.Errorf(
+						"gomatrixserverlib: auth event cycle for ID %q",
+						ref.EventID,
+					)
+				}
+				// If we haven't visited the auth event yet then we need to
+				// process it before processing the event currently on top of
+				// the stack.
+				stack = append(stack, authEvent)
+				queued[authEvent] = true
+				continue LoopProcessTopOfStack
+			}
+			// If we've processed all the auth events for the event on top of
+			// the stack then we can append it to the result and try processing
+			// the item below it in the stack.
+			result = append(result, *top)
+			outputted[top] = true
+			stack = stack[:len(stack)-1]
+		}
+	}
+
+	return result, nil
 }
 
 // Check that a response to /state is valid.

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -432,13 +432,6 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	eventsByID := map[string]*Event{}
 	authEvents := NewAuthEvents(nil)
 
-	for i, event := range ReverseTopologicalOrdering(r.AuthEvents) {
-		eventsByID[event.EventID()] = &r.AuthEvents[i]
-		if err := authEvents.AddEvent(&r.AuthEvents[i]); err != nil {
-			return err
-		}
-	}
-
 	for i, event := range ReverseTopologicalOrdering(r.StateEvents) {
 		eventsByID[event.EventID()] = &r.StateEvents[i]
 		if err := authEvents.AddEvent(&r.StateEvents[i]); err != nil {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -495,9 +495,9 @@ func checkAllowedByAuthEvents(event Event, eventsByID map[string]*Event) error {
 			if err := authEvents.AddEvent(authEvent); err != nil {
 				return err
 			}
-			if err := addAuthEvents(authEvent); err != nil {
-				return err
-			}
+			//		if err := addAuthEvents(authEvent); err != nil {
+			//			return err
+			//		}
 		}
 		return nil
 	}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -430,7 +430,7 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	}
 
 	eventsByID := map[string]*Event{}
-	stateEvents := NewAuthEvents(nil)
+	authEventProvider := NewAuthEvents(nil)
 
 	// Since checkAllowedByAuthEvents needs to be able to look up any of the
 	// auth events by ID only, we will build a map which contains references
@@ -449,7 +449,7 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	// to check specifically that the join event is allowed by the supplied
 	// state (and not by former auth events).
 	for i := range r.StateEvents {
-		if err := stateEvents.AddEvent(&r.StateEvents[i]); err != nil {
+		if err := authEventProvider.AddEvent(&r.StateEvents[i]); err != nil {
 			return err
 		}
 	}
@@ -460,7 +460,7 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	}
 
 	// Now check that the join event is valid against the supplied state.
-	if err := Allowed(joinEvent, &stateEvents); err != nil {
+	if err := Allowed(joinEvent, &authEventProvider); err != nil {
 		return fmt.Errorf(
 			"gomatrixserverlib: event with ID %q is not allowed by the supplied state: %s",
 			joinEvent.EventID(), err.Error(),

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -487,24 +487,14 @@ type RespProfile struct {
 func checkAllowedByAuthEvents(event Event, eventsByID map[string]*Event) error {
 	authEvents := NewAuthEvents(nil)
 
-	var addAuthEvents func(e *Event) error
-	addAuthEvents = func(e *Event) error {
-		for _, ae := range e.AuthEventIDs() {
-			authEvent, ok := eventsByID[ae]
-			if !ok {
-				return MissingAuthEventError{ae, event.EventID()}
-			}
-			if err := authEvents.AddEvent(authEvent); err != nil {
-				return err
-			}
-			//		if err := addAuthEvents(authEvent); err != nil {
-			//			return err
-			//		}
+	for _, ae := range event.AuthEventIDs() {
+		authEvent, ok := eventsByID[ae]
+		if !ok {
+			return MissingAuthEventError{ae, event.EventID()}
 		}
-		return nil
-	}
-	if err := addAuthEvents(&event); err != nil {
-		return err
+		if err := authEvents.AddEvent(authEvent); err != nil {
+			return err
+		}
 	}
 
 	if err := Allowed(event, &authEvents); err != nil {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -432,6 +432,10 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	authEventsByID := map[string]*Event{}
 	stateEvents := NewAuthEvents(nil)
 
+	for i, event := range r.AuthEvents {
+		authEventsByID[event.EventID()] = &r.AuthEvents[i]
+	}
+
 	for i, event := range r.StateEvents {
 		authEventsByID[event.EventID()] = &r.StateEvents[i]
 	}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -429,17 +429,25 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 		return err
 	}
 
-	stateEventsByID := map[string]*Event{}
+	eventsByID := map[string]*Event{}
 	authEvents := NewAuthEvents(nil)
+
 	for i, event := range r.StateEvents {
-		stateEventsByID[event.EventID()] = &r.StateEvents[i]
+		eventsByID[event.EventID()] = &r.StateEvents[i]
 		if err := authEvents.AddEvent(&r.StateEvents[i]); err != nil {
 			return err
 		}
 	}
 
+	for i, event := range r.AuthEvents {
+		eventsByID[event.EventID()] = &r.AuthEvents[i]
+		if err := authEvents.AddEvent(&r.AuthEvents[i]); err != nil {
+			return err
+		}
+	}
+
 	// Now check that the join event is valid against its auth events.
-	if err := checkAllowedByAuthEvents(joinEvent, stateEventsByID); err != nil {
+	if err := checkAllowedByAuthEvents(joinEvent, eventsByID); err != nil {
 		return err
 	}
 

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -432,16 +432,16 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	eventsByID := map[string]*Event{}
 	authEvents := NewAuthEvents(nil)
 
-	for i, event := range r.StateEvents {
-		eventsByID[event.EventID()] = &r.StateEvents[i]
-		if err := authEvents.AddEvent(&r.StateEvents[i]); err != nil {
+	for i, event := range ReverseTopologicalOrdering(r.AuthEvents) {
+		eventsByID[event.EventID()] = &r.AuthEvents[i]
+		if err := authEvents.AddEvent(&r.AuthEvents[i]); err != nil {
 			return err
 		}
 	}
 
-	for i, event := range r.AuthEvents {
-		eventsByID[event.EventID()] = &r.AuthEvents[i]
-		if err := authEvents.AddEvent(&r.AuthEvents[i]); err != nil {
+	for i, event := range ReverseTopologicalOrdering(r.StateEvents) {
+		eventsByID[event.EventID()] = &r.StateEvents[i]
+		if err := authEvents.AddEvent(&r.StateEvents[i]); err != nil {
 			return err
 		}
 	}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -238,67 +238,7 @@ func (r RespState) Events() ([]Event, error) {
 	if len(r.AuthEvents) == 0 {
 		r.AuthEvents = []Event{}
 	}
-	eventsByID := map[string]*Event{}
-	// Collect a map of event reference to event
-	for i := range r.StateEvents {
-		eventsByID[r.StateEvents[i].EventID()] = &r.StateEvents[i]
-	}
-	for i := range r.AuthEvents {
-		eventsByID[r.AuthEvents[i].EventID()] = &r.AuthEvents[i]
-	}
-
-	queued := map[*Event]bool{}
-	outputted := map[*Event]bool{}
-	var result []Event
-	for _, event := range eventsByID {
-		if outputted[event] {
-			// If we've already written the event then we can skip it.
-			continue
-		}
-
-		// The code below does a depth first scan through the auth events
-		// looking for events that can be appended to the output.
-
-		// We use an explicit stack rather than using recursion so
-		// that we can check we aren't creating cycles.
-		stack := []*Event{event}
-
-	LoopProcessTopOfStack:
-		for len(stack) > 0 {
-			top := stack[len(stack)-1]
-			// Check if we can output the top of the stack.
-			// We can output it if we have outputted all of its auth_events.
-			for _, ref := range top.AuthEvents() {
-				authEvent := eventsByID[ref.EventID]
-				if authEvent == nil {
-					return nil, MissingAuthEventError{ref.EventID, top.EventID()}
-				}
-				if outputted[authEvent] {
-					continue
-				}
-				if queued[authEvent] {
-					return nil, fmt.Errorf(
-						"gomatrixserverlib: auth event cycle for ID %q",
-						ref.EventID,
-					)
-				}
-				// If we haven't visited the auth event yet then we need to
-				// process it before processing the event currently on top of
-				// the stack.
-				stack = append(stack, authEvent)
-				queued[authEvent] = true
-				continue LoopProcessTopOfStack
-			}
-			// If we've processed all the auth events for the event on top of
-			// the stack then we can append it to the result and try processing
-			// the item below it in the stack.
-			result = append(result, *top)
-			outputted[top] = true
-			stack = stack[:len(stack)-1]
-		}
-	}
-
-	return result, nil
+	return ReverseTopologicalOrdering(append(r.StateEvents, r.AuthEvents...)), nil
 }
 
 // Check that a response to /state is valid.

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -432,7 +432,7 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	eventsByID := map[string]*Event{}
 	authEvents := NewAuthEvents(nil)
 
-	for i, event := range ReverseTopologicalOrdering(r.StateEvents) {
+	for i, event := range r.StateEvents {
 		eventsByID[event.EventID()] = &r.StateEvents[i]
 		if err := authEvents.AddEvent(&r.StateEvents[i]); err != nil {
 			return err

--- a/filter.go
+++ b/filter.go
@@ -14,7 +14,10 @@
 
 package gomatrixserverlib
 
-import "errors"
+import (
+	"errors"
+	"math"
+)
 
 // Filter is used by clients to specify how the server should filter responses to e.g. sync requests
 // Specified by: https://matrix.org/docs/spec/client_server/r0.5.0.html#filtering
@@ -118,7 +121,7 @@ func DefaultEventFilter() EventFilter {
 // is provided in the request
 func DefaultStateFilter() StateFilter {
 	return StateFilter{
-		Limit:                   20,
+		Limit:                   math.MaxUint32,
 		NotSenders:              nil,
 		NotTypes:                nil,
 		Senders:                 nil,


### PR DESCRIPTION
This PR primarily does two things:

- It ensures that the auth and state events are handled properly for `SendRespJoin`, and ensuring that we're checking if the event is allowed against the correct set of auth events.
- It increases `DefaultStateFilter()` to return `math.MaxUint32` limits rather than 20, since this stopped us from ever seeing full room state.