### PR TITLE
Make sure we're trying next key fetchers if needed

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -204,9 +204,14 @@ func (k KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) 
 		fetcherLogger.WithField("num_keys_fetched", len(keysFetched)).
 			Info("Got keys from fetcher")
 
+		// For the keys that we successfully fetched, don't try again
+		for resp := range keysFetched {
+			delete(keyRequests, resp)
+		}
+
+		// If we didn't receive back the number of keys we expected,
+		// give the remaining keys another go with the next key fetcher
 		if len(keyRequests) != len(keysFetched) {
-			// We didn't receive back the number of keys we expected so
-			// give it another go with the next key fetcher
 			continue
 		}
 

--- a/keyring.go
+++ b/keyring.go
@@ -209,9 +209,9 @@ func (k KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) 
 			delete(keyRequests, resp)
 		}
 
-		// If we didn't receive back the number of keys we expected,
-		// give the remaining keys another go with the next key fetcher
-		if len(keyRequests) != len(keysFetched) {
+		// If we still have outstanding requests that weren't satisfied
+		// then try them with the next key fetcher
+		if len(keyRequests) > 0 {
 			continue
 		}
 


### PR DESCRIPTION
This improves multi-key-fetcher configurations so that we will continue to ask all of the fetchers for keys that we haven't received back.