### PR TITLE
Add RespInviteV2

### DIFF
--- a/federationtypes.go
+++ b/federationtypes.go
@@ -600,5 +600,5 @@ type respInviteFields struct {
 // RespInvite is the content of a response to PUT /_matrix/federation/v2/invite/{roomID}/{eventID}
 type RespInviteV2 struct {
 	// The invite event signed by recipient server.
-	Event Event
+	Event Event `json:"event"`
 }

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -596,3 +596,9 @@ func (r *RespInvite) UnmarshalJSON(data []byte) error {
 type respInviteFields struct {
 	Event Event `json:"event"`
 }
+
+// RespInvite is the content of a response to PUT /_matrix/federation/v2/invite/{roomID}/{eventID}
+type RespInviteV2 struct {
+	// The invite event signed by recipient server.
+	Event Event
+}


### PR DESCRIPTION
This adds a separate `RespInviteV2` struct, since v2 invites don't have the `[200, ...]` response tuple like v1 invites do.