### PR TITLE
Fix SendInviteV2 response type

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -176,7 +176,7 @@ func (ac *FederationClient) SendInvite(
 // signed by it. This is used to invite a user that is not on the local server.
 func (ac *FederationClient) SendInviteV2(
 	ctx context.Context, s ServerName, request InviteV2Request,
-) (res RespInvite, err error) {
+) (res RespInviteV2, err error) {
 	event := request.Event()
 	path := federationPathPrefixV2 + "/invite/" +
 		url.PathEscape(event.RoomID()) + "/" +


### PR DESCRIPTION
This uses `RespInviteV2` instead of `RespInvite` for `SendInviteV2`.