### PR TITLE
breaking: Modify the API for ReverseTopologicalOrdering and LoadAndVerify

### DIFF
--- a/backfill.go
+++ b/backfill.go
@@ -6,6 +6,12 @@ import (
 )
 
 // BackfillRequester contains the necessary functions to perform backfill requests from one server to another.
+//
+// It requires a StateProvider in order to perform PDU checks on received events, notably the step
+// "Passes authorization rules based on the state at the event, otherwise it is rejected.". The BackfillRequester
+// will always call functions on the StateProvider in topological order, starting with the earliest event and
+// rolling forwards. This allows implementations to make optimisations for subsequent events, rather than
+// constantly deferring to federation requests.
 type BackfillRequester interface {
 	StateProvider
 	// ServersAtEvent is called when trying to determine which server to request from.
@@ -60,7 +66,8 @@ func RequestBackfill(ctx context.Context, b BackfillRequester, keyRing JSONVerif
 		if err != nil {
 			continue // try the next server
 		}
-		loadResults, err := loader.LoadAndVerify(ctx, txn.PDUs)
+		// topologically sort the events so implementations of 'get state at event' can do optimisations
+		loadResults, err := loader.LoadAndVerify(ctx, txn.PDUs, OrderingPrevEvents)
 		if err != nil {
 			continue // try the next server
 		}

--- a/backfill.go
+++ b/backfill.go
@@ -67,7 +67,7 @@ func RequestBackfill(ctx context.Context, b BackfillRequester, keyRing JSONVerif
 			continue // try the next server
 		}
 		// topologically sort the events so implementations of 'get state at event' can do optimisations
-		loadResults, err := loader.LoadAndVerify(ctx, txn.PDUs, OrderingPrevEvents)
+		loadResults, err := loader.LoadAndVerify(ctx, txn.PDUs, TopologicalOrderByPrevEvents)
 		if err != nil {
 			continue // try the next server
 		}

--- a/backfill_test.go
+++ b/backfill_test.go
@@ -11,13 +11,15 @@ import (
 )
 
 type testBackfillRequester struct {
-	servers             []ServerName
-	backfillFn          func(server ServerName, roomID string, fromEventIDs []string, limit int) (*Transaction, error)
-	authEventsToProvide [][]byte
-	stateIDsAtEvent     map[string][]string
+	servers                         []ServerName
+	backfillFn                      func(server ServerName, roomID string, fromEventIDs []string, limit int) (*Transaction, error)
+	authEventsToProvide             [][]byte
+	stateIDsAtEvent                 map[string][]string
+	callOrderForStateIDsBeforeEvent []string // event IDs called
 }
 
 func (t *testBackfillRequester) StateIDsBeforeEvent(ctx context.Context, roomID, atEventID string) ([]string, error) {
+	t.callOrderForStateIDsBeforeEvent = append(t.callOrderForStateIDsBeforeEvent, atEventID)
 	return t.stateIDsAtEvent[atEventID], nil
 }
 func (t *testBackfillRequester) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID, atEventID string, eventIDs []string) (map[string]*Event, error) {
@@ -116,11 +118,83 @@ func TestRequestBackfillMultipleServers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RequestBackfill got error: %s", err)
 	}
-	if len(result) != len(testBackfillEvents) {
-		t.Fatalf("RequestBackfill got %d events, want %d", len(result), len(testBackfillEvents))
+
+	assertUnsortedEqual(t, result, testBackfillEvents)
+}
+
+// The purpose of this test is to ensure that the BackfillRequester calls StateProvider functions in
+// topological order, regardless of how they are transmitted by the remote server.
+func TestRequestBackfillTopologicalSort(t *testing.T) {
+	ctx := context.Background()
+	testRoomID := "!roomid:baba.is.you"
+	serverA := ServerName("baba.is.you")
+	// currently we have no way of checking that the events returned link back to the from event, so anything works here.
+	testFromEventIDs := []string{"foo"}
+	testLimit := 4
+	wantOrder := []string{
+		"$WCraVpPZe5TtHAqs:baba.is.you", "$fnwGrQEpiOIUoDU2:baba.is.you", "$xOJZshi3NeKKJiCf:baba.is.you", "$4Kp0G1yWZ6tNpeI7:baba.is.you",
+	}
+	// Mix the order up
+	testBackfillEvents := [][]byte{
+		[]byte(`{"auth_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}],["$fnwGrQEpiOIUoDU2:baba.is.you",{"sha256":"gUr26K5Tt7GQlNs8BlUup92gOzAZHbT8WNEobkrEIqk"}]],"content":{"body":"Test Message"},"depth":2,"event_id":"$xOJZshi3NeKKJiCf:baba.is.you","hashes":{"sha256":"lu5fF5HE090AXdu/+NpJ/RjRVRk/2tWCUozUc5t7Ru4"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[["$fnwGrQEpiOIUoDU2:baba.is.you",{"sha256":"gUr26K5Tt7GQlNs8BlUup92gOzAZHbT8WNEobkrEIqk"}]],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"5KoVSLOBesqH9vciKXDExdu95lKFDtK1I72Hq1GG/UeEsH9jx7wL3V4jGYSKDnX2aLYp/VPiBQje7DFjde+hDQ"}},"type":"m.room.message"}`),
+		// join event in the middle
+		[]byte(`{"auth_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}]],"content":{"membership":"join"},"depth":1,"event_id":"$fnwGrQEpiOIUoDU2:baba.is.you","hashes":{"sha256":"DqOjdFgvFQ3V/jvQW2j3ygHL4D+t7/LaIPZ/tHTDZtI"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}]],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"qBWLb42zicQVsbh333YrcKpHfKokcUOM/ytldGlrgSdXqDEDDxvpcFlfadYnyvj3Z/GjA2XZkqKHanNEh575Bw"}},"state_key":"@userid:baba.is.you","type":"m.room.member"}`),
+		[]byte(`{"auth_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}],["$fnwGrQEpiOIUoDU2:baba.is.you",{"sha256":"gUr26K5Tt7GQlNs8BlUup92gOzAZHbT8WNEobkrEIqk"}]],"content":{"body":"Test Message"},"depth":3,"event_id":"$4Kp0G1yWZ6tNpeI7:baba.is.you","hashes":{"sha256":"B+MjcGZRh72iaGOgyNbIxgFkHDJo6NO8NQDgiKDKDBA"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[["$xOJZshi3NeKKJiCf:baba.is.you",{"sha256":"5PGENImHC863Yz9sO6IJX+bIQthZFI2RMhFZyFy+bC0"}]],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"rP+Ybp17GPCqQBrTQ3yz+q6PihdaMWvNY3SngV8aDLHv8wdDlH4ULGnjsB+Az7trqYdCE3rZVo9M7Hy5tOObDg"}},"type":"m.room.message"}`),
+		// create event is last
+		[]byte(`{"auth_events":[],"content":{"creator":"@userid:baba.is.you"},"depth":0,"event_id":"$WCraVpPZe5TtHAqs:baba.is.you","hashes":{"sha256":"EehWNbKy+oDOMC0vIvYl1FekdDxMNuabXKUVzV7DG74"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"08aF4/bYWKrdGPFdXmZCQU6IrOE1ulpevmWBM3kiShJPAbRbZ6Awk7buWkIxlMF6kX3kb4QpbAlZfHLQgncjCw"}},"state_key":"","type":"m.room.create"}`),
+	}
+	keyRing := &testNopJSONVerifier{}
+	tbr := &testBackfillRequester{
+		servers:             []ServerName{serverA},
+		authEventsToProvide: testBackfillEvents,
+		stateIDsAtEvent: map[string][]string{
+			"$4Kp0G1yWZ6tNpeI7:baba.is.you": {"$fnwGrQEpiOIUoDU2:baba.is.you", "$WCraVpPZe5TtHAqs:baba.is.you"},
+			"$xOJZshi3NeKKJiCf:baba.is.you": {"$fnwGrQEpiOIUoDU2:baba.is.you", "$WCraVpPZe5TtHAqs:baba.is.you"},
+			"$fnwGrQEpiOIUoDU2:baba.is.you": {"$WCraVpPZe5TtHAqs:baba.is.you"},
+			"$WCraVpPZe5TtHAqs:baba.is.you": nil,
+		},
+		backfillFn: func(server ServerName, roomID string, fromEventIDs []string, limit int) (*Transaction, error) {
+			if roomID != testRoomID {
+				return nil, fmt.Errorf("bad room id: %s", roomID)
+			}
+			if server == serverA {
+				// server A returns events 1 and 3.
+				return &Transaction{
+					Origin:         serverA,
+					OriginServerTS: AsTimestamp(time.Now()),
+					PDUs: []json.RawMessage{
+						testBackfillEvents[0], testBackfillEvents[1], testBackfillEvents[2], testBackfillEvents[3],
+					},
+				}, nil
+			}
+			return nil, fmt.Errorf("bad server name: %s", server)
+		},
+	}
+	result, err := RequestBackfill(ctx, tbr, keyRing, testRoomID, RoomVersionV1, testFromEventIDs, testLimit)
+	if err != nil {
+		t.Fatalf("RequestBackfill got error: %s", err)
+	}
+	assertUnsortedEqual(t, result, testBackfillEvents)
+
+	if len(tbr.callOrderForStateIDsBeforeEvent) != 4 {
+		t.Fatalf("Expected StateProvider.StateIDsBeforeEvent called 4 times, called %d times", len(tbr.callOrderForStateIDsBeforeEvent))
+	}
+	for i := 0; i < len(tbr.callOrderForStateIDsBeforeEvent); i++ {
+		if tbr.callOrderForStateIDsBeforeEvent[i] != wantOrder[i] {
+			t.Errorf("call %d of StateProvider.StateIDsBeforeEvent called with %s, want %s",
+				i+1, tbr.callOrderForStateIDsBeforeEvent[i], wantOrder[i],
+			)
+		}
+	}
+
+}
+
+func assertUnsortedEqual(t *testing.T, result []HeaderedEvent, want [][]byte) {
+	if len(result) != len(want) {
+		t.Fatalf("RequestBackfill got %d events, want %d", len(result), len(want))
 	}
 	// We expect to see 0,1,2,3 in the response.
-	sortedWant := sortByteSlices(testBackfillEvents)
+	sortedWant := sortByteSlices(want)
 	sort.Sort(sortedWant)
 	var got [][]byte
 	for _, e := range result {

--- a/backfill_test.go
+++ b/backfill_test.go
@@ -158,7 +158,6 @@ func TestRequestBackfillTopologicalSort(t *testing.T) {
 				return nil, fmt.Errorf("bad room id: %s", roomID)
 			}
 			if server == serverA {
-				// server A returns events 1 and 3.
 				return &Transaction{
 					Origin:         serverA,
 					OriginServerTS: AsTimestamp(time.Now()),
@@ -193,7 +192,6 @@ func assertUnsortedEqual(t *testing.T, result []HeaderedEvent, want [][]byte) {
 	if len(result) != len(want) {
 		t.Fatalf("RequestBackfill got %d events, want %d", len(result), len(want))
 	}
-	// We expect to see 0,1,2,3 in the response.
 	sortedWant := sortByteSlices(want)
 	sort.Sort(sortedWant)
 	var got [][]byte

--- a/load.go
+++ b/load.go
@@ -61,7 +61,7 @@ func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMe
 	events = ReverseTopologicalOrdering(events, sortOrder)
 	// assign the errors to the end of the slice
 	for i := 0; i < len(errs); i++ {
-		results[len(results)-i-1] = EventLoadResult{
+		results[len(results)-len(errs)+i] = EventLoadResult{
 			Error: errs[i],
 		}
 	}

--- a/load.go
+++ b/load.go
@@ -42,7 +42,7 @@ func NewEventsLoader(roomVer RoomVersion, keyRing JSONVerifier, stateProvider St
 // The order of the returned events depends on `sortOrder`. The events are reverse topologically sorted by the ordering specified. However
 // in order to sort the events the events must be loaded which could fail. For those events which fail to be loaded, they will
 // be put at the end of the returned slice.
-func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMessage, sortOrder Ordering) ([]EventLoadResult, error) {
+func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMessage, sortOrder TopologicalOrder) ([]EventLoadResult, error) {
 	results := make([]EventLoadResult, len(rawEvents))
 
 	// 1. Is a valid event, otherwise it is dropped.

--- a/load.go
+++ b/load.go
@@ -39,23 +39,38 @@ func NewEventsLoader(roomVer RoomVersion, keyRing JSONVerifier, stateProvider St
 // LoadAndVerify loads untrusted events and verifies them.
 // Checks performed are outlined at https://matrix.org/docs/spec/server_server/latest#checks-performed-on-receipt-of-a-pdu
 // The length of the returned slice will always equal the length of rawEvents.
-func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMessage) ([]EventLoadResult, error) {
+// The order of the returned events depends on `sortOrder`. The events are reverse topologically sorted by the ordering specified. However
+// in order to sort the events the events must be loaded which could fail. For those events which fail to be loaded, they will
+// be put at the end of the returned slice.
+func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMessage, sortOrder Ordering) ([]EventLoadResult, error) {
 	results := make([]EventLoadResult, len(rawEvents))
 
 	// 1. Is a valid event, otherwise it is dropped.
 	// 3. Passes hash checks, otherwise it is redacted before being processed further.
-	events := make([]Event, len(rawEvents))
-	for i, rawEv := range rawEvents {
+	events := make([]Event, 0, len(rawEvents))
+	errs := make([]error, 0, len(rawEvents))
+	for _, rawEv := range rawEvents {
 		event, err := NewEventFromUntrustedJSON(rawEv, l.roomVer)
 		if err != nil {
-			results[i] = EventLoadResult{
-				Error: err,
-			}
+			errs = append(errs, err)
 			continue
 		}
-		// zero values are fine as VerifyEventSignatures will catch them, more important to keep the ordering
-		events[i] = event
+		events = append(events, event)
 	}
+
+	events = ReverseTopologicalOrdering(events, sortOrder)
+	// assign the errors to the end of the slice
+	for i := 0; i < len(errs); i++ {
+		results[len(results)-i-1] = EventLoadResult{
+			Error: errs[i],
+		}
+	}
+	// at this point, the three slices look something like:
+	// results: [ _ , _ , _ , err1 , err2 ]
+	// errs: [ err1, err2 ]
+	// events [ ev1, ev2, ev3 ]
+	// so we can directly index from events into results from now on.
+
 	// 2. Passes signature checks, otherwise it is dropped.
 	failures, err := VerifyEventSignatures(ctx, events, l.keyRing)
 	if err != nil {

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -17,8 +17,18 @@ package gomatrixserverlib
 import (
 	"container/heap"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strconv"
+)
+
+// Ordering represents how to sort a list of events, used primarily in ReverseTopologicalOrdering
+type Ordering int
+
+// Sort events by prev_events or auth_events
+const (
+	OrderingPrevEvents Ordering = iota + 1
+	OrderingAuthEvents
 )
 
 type stateResolverV2 struct {
@@ -106,13 +116,13 @@ func ResolveStateConflictsV2(
 	// authing them. The successfully authed events will form the initial partial
 	// state. We will then keep the successfully authed unconflicted events so that
 	// they can be reapplied later.
-	unconflicted = r.reverseTopologicalOrdering(unconflicted)
+	unconflicted = r.reverseTopologicalOrdering(unconflicted, OrderingAuthEvents)
 	r.applyEvents(unconflicted)
 
 	// Then order the conflicted power level events topologically and then also
 	// auth those too. The successfully authed events will be layered on top of
 	// the partial state.
-	conflictedControlEvents = r.reverseTopologicalOrdering(conflictedControlEvents)
+	conflictedControlEvents = r.reverseTopologicalOrdering(conflictedControlEvents, OrderingAuthEvents)
 	r.authAndApplyEvents(conflictedControlEvents)
 
 	// Then generate the mainline of power level events, order the remaining state
@@ -161,22 +171,22 @@ func ResolveStateConflictsV2(
 // using Kahn's algorithm in order to topologically order them. The
 // result array of events will be sorted so that "earlier" events appear
 // first.
-func ReverseTopologicalOrdering(events []Event) (result []Event) {
+func ReverseTopologicalOrdering(events []Event, order Ordering) (result []Event) {
 	r := stateResolverV2{}
-	return r.reverseTopologicalOrdering(events)
+	return r.reverseTopologicalOrdering(events, order)
 }
 
 // HeaderedReverseTopologicalOrdering takes a set of input events and sorts
 // them using Kahn's algorithm in order to topologically order them. The
 // result array of events will be sorted so that "earlier" events appear
 // first.
-func HeaderedReverseTopologicalOrdering(events []HeaderedEvent) (result []HeaderedEvent) {
+func HeaderedReverseTopologicalOrdering(events []HeaderedEvent, order Ordering) (result []HeaderedEvent) {
 	r := stateResolverV2{}
 	var evs []Event
 	for _, e := range events {
 		evs = append(evs, e.Unwrap())
 	}
-	evs = r.reverseTopologicalOrdering(evs)
+	evs = r.reverseTopologicalOrdering(evs, order)
 	for _, e := range evs {
 		result = append(result, e.Headered(e.roomVersion))
 	}
@@ -424,10 +434,20 @@ func (r *stateResolverV2) wrapOtherEventsForSort(events []Event) []stateResV2Con
 // reverseTopologicalOrdering takes a set of input events, prepares them using
 // wrapPowerLevelEventsForSort and then starts the Kahn's algorithm in order to
 // topologically sort them. The result that is returned is correctly ordered.
-func (r *stateResolverV2) reverseTopologicalOrdering(events []Event) (result []Event) {
-	block := r.wrapPowerLevelEventsForSort(events)
-	for _, s := range kahnsAlgorithmUsingAuthEvents(block) {
-		result = append(result, s.event)
+func (r *stateResolverV2) reverseTopologicalOrdering(events []Event, order Ordering) (result []Event) {
+	switch order {
+	case OrderingAuthEvents:
+		block := r.wrapPowerLevelEventsForSort(events)
+		for _, s := range kahnsAlgorithmUsingAuthEvents(block) {
+			result = append(result, s.event)
+		}
+	case OrderingPrevEvents:
+		block := r.wrapOtherEventsForSort(events)
+		for _, s := range kahnsAlgorithmUsingPrevEvents(block) {
+			result = append(result, s.event)
+		}
+	default:
+		panic(fmt.Sprintf("gomatrixserverlib.reverseTopologicalOrdering unknown Ordering %d", order))
 	}
 	return
 }
@@ -572,6 +592,101 @@ resetNoIncoming:
 	// If we have stray events left over then add them into the result.
 	if len(eventMap) > 0 {
 		var remaining stateResV2ConflictedPowerLevelHeap
+		for _, event := range eventMap {
+			heap.Push(&remaining, event)
+		}
+		sort.Sort(sort.Reverse(remaining))
+		graph = append(remaining, graph...)
+	}
+
+	// The graph is complete at this point!
+	//sort.Sort(sort.Reverse(stateResV2ConflictedPowerLevelHeap(graph)))
+	return graph
+}
+
+// kahnsAlgorithmByAuthEvents is, predictably, an implementation of Kahn's
+// algorithm that uses auth events to topologically sort the input list of
+// events. This works through each event, counting how many incoming prev event
+// dependencies it has, and then adding them into the graph as the dependencies
+// are resolved.
+func kahnsAlgorithmUsingPrevEvents(events []stateResV2ConflictedOther) (
+	graph []stateResV2ConflictedOther,
+) {
+	eventMap := make(map[string]stateResV2ConflictedOther)
+	inDegree := make(map[string]int)
+
+	for _, event := range events {
+		// For each event that we have been given, add it to the event map so that
+		// we can easily refer back to it by event ID later.
+		eventMap[event.eventID] = event
+
+		// If we haven't encountered this event ID yet, also start with a zero count
+		// of incoming auth event dependencies.
+		if _, ok := inDegree[event.eventID]; !ok {
+			inDegree[event.eventID] = 0
+		}
+
+		// Find each of the auth events that this event depends on and make a note
+		// for each auth event that there's an additional incoming dependency.
+		for _, auth := range event.event.PrevEventIDs() {
+			if _, ok := inDegree[auth]; !ok {
+				// We don't know about this event yet - set an initial value.
+				inDegree[auth] = 1
+			} else {
+				// We've already encountered this event so increment instead.
+				inDegree[auth]++
+			}
+		}
+	}
+
+	// Now we need to work out which events don't have any incoming auth event
+	// dependencies. These will be placed into the graph first. Remove the event
+	// from the event map as this prevents us from processing it a second time.
+	var noIncoming stateResV2ConflictedOtherHeap
+	heap.Init(&noIncoming)
+	for eventID, count := range inDegree {
+		if count == 0 {
+			heap.Push(&noIncoming, eventMap[eventID])
+			delete(eventMap, eventID)
+		}
+	}
+
+	var event stateResV2ConflictedOther
+resetNoIncoming:
+	for noIncoming.Len() > 0 {
+		// Pop the first event ID off the list of events which have no incoming
+		// auth event dependencies.
+		event = heap.Pop(&noIncoming).(stateResV2ConflictedOther)
+
+		// Since there are no incoming dependencies to resolve, we can now add this
+		// event into the graph.
+		graph = append([]stateResV2ConflictedOther{event}, graph...)
+		//graph = append(graph, event)
+
+		// Now we should look at the outgoing auth dependencies that this event has.
+		// Since this event is now in the graph, the event's outgoing auth
+		// dependencies are no longer valid - those map to incoming dependencies on
+		// the auth events, so let's update those.
+		for _, auth := range event.event.PrevEventIDs() {
+			inDegree[auth]--
+
+			// If we see, by updating the incoming dependencies, that the auth event
+			// no longer has any incoming dependencies, then it should also be added
+			// into the graph on the next pass. In turn, this will also mean that we
+			// process the outgoing dependencies of this auth event.
+			if inDegree[auth] == 0 {
+				if _, ok := eventMap[auth]; ok {
+					heap.Push(&noIncoming, eventMap[auth])
+					delete(eventMap, auth)
+					goto resetNoIncoming
+				}
+			}
+		}
+	}
+
+	// If we have stray events left over then add them into the result.
+	if len(eventMap) > 0 {
+		var remaining stateResV2ConflictedOtherHeap
 		for _, event := range eventMap {
 			heap.Push(&remaining, event)
 		}

--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -409,7 +409,7 @@ func TestLexicographicalSorting(t *testing.T) {
 func TestReverseTopologicalEventSorting(t *testing.T) {
 	r := stateResolverV2{}
 	base := getBaseStateResV2Graph()
-	input := r.reverseTopologicalOrdering(base, OrderingAuthEvents)
+	input := r.reverseTopologicalOrdering(base, TopologicalOrderByAuthEvents)
 
 	expected := []string{
 		"$CREATE:example.com", "$IMA:example.com", "$IPOWER:example.com",

--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -409,7 +409,7 @@ func TestLexicographicalSorting(t *testing.T) {
 func TestReverseTopologicalEventSorting(t *testing.T) {
 	r := stateResolverV2{}
 	base := getBaseStateResV2Graph()
-	input := r.reverseTopologicalOrdering(base)
+	input := r.reverseTopologicalOrdering(base, OrderingAuthEvents)
 
 	expected := []string{
 		"$CREATE:example.com", "$IMA:example.com", "$IPOWER:example.com",


### PR DESCRIPTION
They now both require an `Ordering` which is usually `OrderingAuthEvents`
except in the case of backfilling, where we use `OrderingPrevEvents`.
We need to sort by prev_events for backfilling so we can make optimisations
and not call `/state_ids` repeatedly, as well as work out the state at
that event for snapshots/PDU checks.