### PR TITLE
Rejig StateProvider API

### DIFF
--- a/authstate.go
+++ b/authstate.go
@@ -14,7 +14,7 @@ type StateProvider interface {
 	StateIDsBeforeEvent(ctx context.Context, event HeaderedEvent) ([]string, error)
 	// StateBeforeEvent returns the state of the room before the given event. `eventIDs` will be populated with the output
 	// of StateIDsAtEvent to aid in event retrieval.
-	StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID string, event HeaderedEvent, eventIDs []string) (map[string]*Event, error)
+	StateBeforeEvent(ctx context.Context, roomVer RoomVersion, event HeaderedEvent, eventIDs []string) (map[string]*Event, error)
 }
 
 // FederatedStateProvider is an implementation of StateProvider which solely uses federation requests to retrieve events.
@@ -26,9 +26,9 @@ type FederatedStateProvider struct {
 	AuthEventsOnly bool
 }
 
-// StateIDsAtEvent implements StateProvider
-func (p *FederatedStateProvider) StateIDsAtEvent(ctx context.Context, roomID, atEventID string) ([]string, error) {
-	res, err := p.FedClient.LookupStateIDs(ctx, p.Server, roomID, atEventID)
+// StateIDsBeforeEvent implements StateProvider
+func (p *FederatedStateProvider) StateIDsBeforeEvent(ctx context.Context, event HeaderedEvent) ([]string, error) {
+	res, err := p.FedClient.LookupStateIDs(ctx, p.Server, event.RoomID(), event.EventID())
 	if err != nil {
 		return nil, err
 	}
@@ -38,9 +38,9 @@ func (p *FederatedStateProvider) StateIDsAtEvent(ctx context.Context, roomID, at
 	return util.UniqueStrings(append(res.AuthEventIDs, res.StateEventIDs...)), nil
 }
 
-// StateAtEvent implements StateProvider
-func (p *FederatedStateProvider) StateAtEvent(ctx context.Context, roomVer RoomVersion, roomID, atEventID string, eventIDs []string) (map[string]*Event, error) {
-	res, err := p.FedClient.LookupState(ctx, p.Server, roomID, atEventID, roomVer)
+// StateBeforeEvent implements StateProvider
+func (p *FederatedStateProvider) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, event HeaderedEvent, eventIDs []string) (map[string]*Event, error) {
+	res, err := p.FedClient.LookupState(ctx, p.Server, event.RoomID(), event.EventID(), roomVer)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func VerifyAuthRulesAtState(ctx context.Context, sp StateProvider, eventToVerify
 	}
 
 	// slow path: fetch the events at this state and check auth
-	roomState, err := sp.StateBeforeEvent(ctx, eventToVerify.roomVersion, eventToVerify.RoomID(), eventToVerify, stateIDs)
+	roomState, err := sp.StateBeforeEvent(ctx, eventToVerify.roomVersion, eventToVerify, stateIDs)
 	if err != nil {
 		return fmt.Errorf("gomatrixserverlib.VerifyAuthRulesAtState: cannot get state at event %s: %w", eventToVerify.EventID(), err)
 	}

--- a/authstate.go
+++ b/authstate.go
@@ -11,10 +11,10 @@ import (
 type StateProvider interface {
 	// StateIDsBeforeEvent returns a list of state event IDs for the event ID provided, which represent the entire
 	// room state before that event.
-	StateIDsBeforeEvent(ctx context.Context, roomID, atEventID string) ([]string, error)
+	StateIDsBeforeEvent(ctx context.Context, event HeaderedEvent) ([]string, error)
 	// StateBeforeEvent returns the state of the room before the given event. `eventIDs` will be populated with the output
 	// of StateIDsAtEvent to aid in event retrieval.
-	StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID, atEventID string, eventIDs []string) (map[string]*Event, error)
+	StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID string, event HeaderedEvent, eventIDs []string) (map[string]*Event, error)
 }
 
 // FederatedStateProvider is an implementation of StateProvider which solely uses federation requests to retrieve events.
@@ -57,12 +57,10 @@ func (p *FederatedStateProvider) StateAtEvent(ctx context.Context, roomVer RoomV
 	return result, nil
 }
 
-// VerifyAuthRulesAtState will check that the auth_events in the given event are valid at the state provided by another event.
+// VerifyAuthRulesAtState will check that the auth_events in the given event are valid at the state of the room before that event.
 //
-// This implements Step 5 and 6 of https://matrix.org/docs/spec/server_server/latest#checks-performed-on-receipt-of-a-pdu
-// depending on what the value of `stateAtEvent` is.
+// This implements Step 5 of https://matrix.org/docs/spec/server_server/latest#checks-performed-on-receipt-of-a-pdu
 // "Passes authorization rules based on the state at the event, otherwise it is rejected."
-// "Passes authorization rules based on the current state of the room, otherwise it is "soft failed"."
 //
 // If `allowValidation` is true:
 // This check initially attempts to validate that the auth_events are in the target room state, and if they are it will short-circuit
@@ -70,10 +68,10 @@ func (p *FederatedStateProvider) StateAtEvent(ctx context.Context, roomVer RoomV
 // no auth_events are required and this function will short-circuit and allow it.
 //
 //
-func VerifyAuthRulesAtState(ctx context.Context, sp StateProvider, eventToVerify HeaderedEvent, stateAtEvent string, allowValidation bool) error {
-	stateIDs, err := sp.StateIDsBeforeEvent(ctx, eventToVerify.RoomID(), stateAtEvent)
+func VerifyAuthRulesAtState(ctx context.Context, sp StateProvider, eventToVerify HeaderedEvent, allowValidation bool) error {
+	stateIDs, err := sp.StateIDsBeforeEvent(ctx, eventToVerify)
 	if err != nil {
-		return fmt.Errorf("gomatrixserverlib.VerifyAuthRulesAtState: cannot fetch state IDs at event %s: %w", stateAtEvent, err)
+		return fmt.Errorf("gomatrixserverlib.VerifyAuthRulesAtState: cannot fetch state IDs before event %s: %w", eventToVerify.EventID(), err)
 	}
 
 	if allowValidation {
@@ -100,9 +98,9 @@ func VerifyAuthRulesAtState(ctx context.Context, sp StateProvider, eventToVerify
 	}
 
 	// slow path: fetch the events at this state and check auth
-	roomState, err := sp.StateBeforeEvent(ctx, eventToVerify.roomVersion, eventToVerify.RoomID(), stateAtEvent, stateIDs)
+	roomState, err := sp.StateBeforeEvent(ctx, eventToVerify.roomVersion, eventToVerify.RoomID(), eventToVerify, stateIDs)
 	if err != nil {
-		return fmt.Errorf("gomatrixserverlib.VerifyAuthRulesAtState: cannot get state at event %s: %w", stateAtEvent, err)
+		return fmt.Errorf("gomatrixserverlib.VerifyAuthRulesAtState: cannot get state at event %s: %w", eventToVerify.EventID(), err)
 	}
 	if ctx.Err() != nil {
 		return fmt.Errorf("gomatrixserverlib.VerifyAuthRulesAtState: context cancelled: %w", ctx.Err())
@@ -110,7 +108,7 @@ func VerifyAuthRulesAtState(ctx context.Context, sp StateProvider, eventToVerify
 	if err := checkAllowedByAuthEvents(eventToVerify.Unwrap(), roomState); err != nil {
 		return fmt.Errorf(
 			"gomatrixserverlib.VerifyAuthRulesAtState: event %s is not allowed at state %s : %w",
-			eventToVerify.EventID(), stateAtEvent, err,
+			eventToVerify.EventID(), eventToVerify.EventID(), err,
 		)
 	}
 	return nil

--- a/authstate_test.go
+++ b/authstate_test.go
@@ -10,10 +10,10 @@ type TestStateProvider struct {
 	Events   []Event
 }
 
-func (p *TestStateProvider) StateIDsBeforeEvent(ctx context.Context, roomID, atEventID string) ([]string, error) {
+func (p *TestStateProvider) StateIDsBeforeEvent(ctx context.Context, atEvent HeaderedEvent) ([]string, error) {
 	return p.StateIDs, nil
 }
-func (p *TestStateProvider) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID, atEventID string, eventIDs []string) (map[string]*Event, error) {
+func (p *TestStateProvider) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID string, atEvent HeaderedEvent, eventIDs []string) (map[string]*Event, error) {
 	result := make(map[string]*Event, len(p.Events))
 	for i := range p.Events {
 		result[p.Events[i].EventID()] = &p.Events[i]
@@ -41,7 +41,7 @@ func TestVerifyAuthRulesAtStateValidate(t *testing.T) {
 		t.Fatalf("Failed to load test event: %s", err)
 	}
 
-	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), eventToVerify.EventID(), true)
+	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), true)
 	if err != nil {
 		t.Fatalf("VerifyAuthRulesAtState expect no error, got %s", err)
 	}
@@ -69,7 +69,7 @@ func TestVerifyAuthRulesAtStateVerify(t *testing.T) {
 		t.Fatalf("Failed to load test event: %s", err)
 	}
 
-	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), eventToVerify.EventID(), false)
+	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), false)
 	if err != nil {
 		t.Fatalf("VerifyAuthRulesAtState expect no error, got %s", err)
 	}
@@ -98,12 +98,12 @@ func TestVerifyAuthRulesAtStateVerifyFailure(t *testing.T) {
 		t.Fatalf("Failed to load test event: %s", err)
 	}
 
-	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), eventToVerify.EventID(), false)
+	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), false)
 	if err == nil {
 		t.Fatalf("VerifyAuthRulesAtState expected error, got none")
 	}
 	// conversely the check should PASS if validation is enabled, as validation assumes Allowed checks were already run
-	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), eventToVerify.EventID(), true)
+	err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), true)
 	if err != nil {
 		t.Fatalf("VerifyAuthRulesAtState expect no error, got %s", err)
 	}
@@ -133,7 +133,7 @@ func TestVerifyAuthRulesAtStateBadAuthRuleButValidState(t *testing.T) {
 	}
 	// this should still pass with or without validation checks
 	for _, b := range []bool{true, false} {
-		err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), eventToVerify.EventID(), b)
+		err = VerifyAuthRulesAtState(ctx, tsp, eventToVerify.Headered(RoomVersionV1), b)
 		if err == nil {
 			t.Fatalf("VerifyAuthRulesAtState expected error, got none")
 		}

--- a/authstate_test.go
+++ b/authstate_test.go
@@ -13,7 +13,7 @@ type TestStateProvider struct {
 func (p *TestStateProvider) StateIDsBeforeEvent(ctx context.Context, atEvent HeaderedEvent) ([]string, error) {
 	return p.StateIDs, nil
 }
-func (p *TestStateProvider) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID string, atEvent HeaderedEvent, eventIDs []string) (map[string]*Event, error) {
+func (p *TestStateProvider) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, event HeaderedEvent, eventIDs []string) (map[string]*Event, error) {
 	result := make(map[string]*Event, len(p.Events))
 	for i := range p.Events {
 		result[p.Events[i].EventID()] = &p.Events[i]

--- a/backfill_test.go
+++ b/backfill_test.go
@@ -22,7 +22,7 @@ func (t *testBackfillRequester) StateIDsBeforeEvent(ctx context.Context, atEvent
 	t.callOrderForStateIDsBeforeEvent = append(t.callOrderForStateIDsBeforeEvent, atEvent.EventID())
 	return t.stateIDsAtEvent[atEvent.EventID()], nil
 }
-func (t *testBackfillRequester) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID string, atEvent HeaderedEvent, eventIDs []string) (map[string]*Event, error) {
+func (t *testBackfillRequester) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, event HeaderedEvent, eventIDs []string) (map[string]*Event, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 func (t *testBackfillRequester) ServersAtEvent(ctx context.Context, roomID, eventID string) []ServerName {

--- a/backfill_test.go
+++ b/backfill_test.go
@@ -18,11 +18,11 @@ type testBackfillRequester struct {
 	callOrderForStateIDsBeforeEvent []string // event IDs called
 }
 
-func (t *testBackfillRequester) StateIDsBeforeEvent(ctx context.Context, roomID, atEventID string) ([]string, error) {
-	t.callOrderForStateIDsBeforeEvent = append(t.callOrderForStateIDsBeforeEvent, atEventID)
-	return t.stateIDsAtEvent[atEventID], nil
+func (t *testBackfillRequester) StateIDsBeforeEvent(ctx context.Context, atEvent HeaderedEvent) ([]string, error) {
+	t.callOrderForStateIDsBeforeEvent = append(t.callOrderForStateIDsBeforeEvent, atEvent.EventID())
+	return t.stateIDsAtEvent[atEvent.EventID()], nil
 }
-func (t *testBackfillRequester) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID, atEventID string, eventIDs []string) (map[string]*Event, error) {
+func (t *testBackfillRequester) StateBeforeEvent(ctx context.Context, roomVer RoomVersion, roomID string, atEvent HeaderedEvent, eventIDs []string) (map[string]*Event, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 func (t *testBackfillRequester) ServersAtEvent(ctx context.Context, roomID, eventID string) []ServerName {

--- a/load.go
+++ b/load.go
@@ -100,7 +100,7 @@ func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMe
 		}
 
 		// 5. Passes authorization rules based on the state at the event, otherwise it is rejected.
-		if err := VerifyAuthRulesAtState(ctx, l.stateProvider, h, h.EventID(), true); err != nil {
+		if err := VerifyAuthRulesAtState(ctx, l.stateProvider, h, true); err != nil {
 			if results[i].Error == nil { // could have failed earlier
 				results[i] = EventLoadResult{
 					Error: err,


### PR DESCRIPTION
- Step 6 cannot reuse the same code path as it requires the state AFTER the latest room state
- We need the entire `Event` for rolling forward state.