### PR TITLE
Use PathEscape again for path components

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -96,8 +96,8 @@ func (ac *FederationClient) MakeJoin(
 		versionQueryString = "?" + strings.Join(vqs, "&")
 	}
 	path := federationPathPrefixV1 + "/make_join/" +
-		url.QueryEscape(roomID) + "/" +
-		url.QueryEscape(userID) + versionQueryString
+		url.PathEscape(roomID) + "/" +
+		url.PathEscape(userID) + versionQueryString
 	req := NewFederationRequest("GET", s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
@@ -112,8 +112,8 @@ func (ac *FederationClient) SendJoin(
 ) (res RespSendJoin, err error) {
 	res.RespState.roomVersion = roomVersion
 	path := federationPathPrefixV2 + "/send_join/" +
-		url.QueryEscape(event.RoomID()) + "/" +
-		url.QueryEscape(event.EventID())
+		url.PathEscape(event.RoomID()) + "/" +
+		url.PathEscape(event.EventID())
 	req := NewFederationRequest("PUT", s, path)
 	if err = req.SetContent(event); err != nil {
 		return
@@ -131,8 +131,8 @@ func (ac *FederationClient) MakeLeave(
 	ctx context.Context, s ServerName, roomID, userID string,
 ) (res RespMakeLeave, err error) {
 	path := federationPathPrefixV1 + "/make_leave/" +
-		url.QueryEscape(roomID) + "/" +
-		url.QueryEscape(userID)
+		url.PathEscape(roomID) + "/" +
+		url.PathEscape(userID)
 	req := NewFederationRequest("GET", s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
@@ -146,8 +146,8 @@ func (ac *FederationClient) SendLeave(
 	ctx context.Context, s ServerName, event Event,
 ) (err error) {
 	path := federationPathPrefixV2 + "/send_leave/" +
-		url.QueryEscape(event.RoomID()) + "/" +
-		url.QueryEscape(event.EventID())
+		url.PathEscape(event.RoomID()) + "/" +
+		url.PathEscape(event.EventID())
 	req := NewFederationRequest("PUT", s, path)
 	if err = req.SetContent(event); err != nil {
 		return
@@ -162,8 +162,8 @@ func (ac *FederationClient) SendInvite(
 	ctx context.Context, s ServerName, event Event,
 ) (res RespInvite, err error) {
 	path := federationPathPrefixV1 + "/invite/" +
-		url.QueryEscape(event.RoomID()) + "/" +
-		url.QueryEscape(event.EventID())
+		url.PathEscape(event.RoomID()) + "/" +
+		url.PathEscape(event.EventID())
 	req := NewFederationRequest("PUT", s, path)
 	if err = req.SetContent(event); err != nil {
 		return
@@ -180,8 +180,8 @@ func (ac *FederationClient) SendInviteV2(
 	res.roomVersion = request.RoomVersion()
 	event := request.Event()
 	path := federationPathPrefixV2 + "/invite/" +
-		url.QueryEscape(event.RoomID()) + "/" +
-		url.QueryEscape(event.EventID())
+		url.PathEscape(event.RoomID()) + "/" +
+		url.PathEscape(event.EventID())
 	req := NewFederationRequest("PUT", s, path)
 	if err = req.SetContent(request); err != nil {
 		return
@@ -199,7 +199,7 @@ func (ac *FederationClient) ExchangeThirdPartyInvite(
 	ctx context.Context, s ServerName, builder EventBuilder,
 ) (err error) {
 	path := federationPathPrefixV1 + "/exchange_third_party_invite/" +
-		url.QueryEscape(builder.RoomID)
+		url.PathEscape(builder.RoomID)
 	req := NewFederationRequest("PUT", s, path)
 	if err = req.SetContent(builder); err != nil {
 		return
@@ -215,7 +215,7 @@ func (ac *FederationClient) LookupState(
 ) (res RespState, err error) {
 	res.roomVersion = roomVersion
 	path := federationPathPrefixV1 + "/state/" +
-		url.QueryEscape(roomID) +
+		url.PathEscape(roomID) +
 		"?event_id=" +
 		url.QueryEscape(eventID)
 	req := NewFederationRequest("GET", s, path)
@@ -229,7 +229,7 @@ func (ac *FederationClient) LookupStateIDs(
 	ctx context.Context, s ServerName, roomID, eventID string,
 ) (res RespStateIDs, err error) {
 	path := federationPathPrefixV1 + "/state_ids/" +
-		url.QueryEscape(roomID) +
+		url.PathEscape(roomID) +
 		"?event_id=" +
 		url.QueryEscape(eventID)
 	req := NewFederationRequest("GET", s, path)
@@ -246,7 +246,7 @@ func (ac *FederationClient) LookupMissingEvents(
 ) (res RespMissingEvents, err error) {
 	res.roomVersion = roomVersion
 	path := federationPathPrefixV1 + "/get_missing_events/" +
-		url.QueryEscape(roomID)
+		url.PathEscape(roomID)
 	req := NewFederationRequest("POST", s, path)
 	if err = req.SetContent(missing); err != nil {
 		return
@@ -323,7 +323,7 @@ func (ac *FederationClient) LookupProfile(
 func (ac *FederationClient) GetEvent(
 	ctx context.Context, s ServerName, eventID string,
 ) (res Transaction, err error) {
-	path := federationPathPrefixV1 + "/event/" + url.QueryEscape(eventID)
+	path := federationPathPrefixV1 + "/event/" + url.PathEscape(eventID)
 	req := NewFederationRequest("GET", s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
@@ -334,7 +334,7 @@ func (ac *FederationClient) GetEvent(
 func (ac *FederationClient) GetEventAuth(
 	ctx context.Context, s ServerName, roomID, eventID string,
 ) (res RespEventAuth, err error) {
-	path := federationPathPrefixV1 + "/event_auth/" + url.QueryEscape(roomID) + "/" + url.QueryEscape(eventID)
+	path := federationPathPrefixV1 + "/event_auth/" + url.PathEscape(roomID) + "/" + url.PathEscape(eventID)
 	req := NewFederationRequest("GET", s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return


### PR DESCRIPTION
Reverts #181 and fixes a couple of other places after further investigation and reading the correct RFC this time.