### PR TITLE
Fix check on ExpiredTS

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -42,8 +42,8 @@ type PublicKeyLookupResult struct {
 // WasValidAt checks if this signing key is valid for an event signed at the
 // given timestamp.
 func (r PublicKeyLookupResult) WasValidAt(atTs Timestamp, strictValidityChecking bool) bool {
-	if r.ExpiredTS != PublicKeyNotExpired && atTs >= r.ExpiredTS {
-		return false
+	if r.ExpiredTS != PublicKeyNotExpired {
+		return atTs >= r.ExpiredTS
 	}
 	if strictValidityChecking {
 		if r.ValidUntilTS == PublicKeyNotValid {

--- a/keyring.go
+++ b/keyring.go
@@ -43,7 +43,7 @@ type PublicKeyLookupResult struct {
 // given timestamp.
 func (r PublicKeyLookupResult) WasValidAt(atTs Timestamp, strictValidityChecking bool) bool {
 	if r.ExpiredTS != PublicKeyNotExpired {
-		return atTs >= r.ExpiredTS
+		return atTs < r.ExpiredTS
 	}
 	if strictValidityChecking {
 		if r.ValidUntilTS == PublicKeyNotValid {

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -147,17 +147,18 @@ func TestStrictCheckingKeyValidity(t *testing.T) {
 func TestExpiredTS(t *testing.T) {
 	// Check that we respect the ExpiredTS properly.
 	publicKeyLookup := PublicKeyLookupResult{
-		ExpiredTS: AsTimestamp(time.Now().Add(time.Hour * 24 * 5)),
+		ExpiredTS: 1000,
 	}
-	shouldPass := AsTimestamp(time.Now().Add(time.Hour * 24 * 1))
-	shouldFail := AsTimestamp(time.Now().Add(time.Hour * 24 * 10))
+	shouldPass := Timestamp(999)
+	shouldFail := Timestamp(1000)
 
 	// This test should pass because it is less than ExpiredTS.
 	if !publicKeyLookup.WasValidAt(shouldPass, true) {
 		t.Fatalf("valid test should have passed")
 	}
 
-	// This test should fail because it is greater than ExpiredTS.
+	// This test should fail because it is equal to or
+	// greater than ExpiredTS.
 	if publicKeyLookup.WasValidAt(shouldFail, true) {
 		t.Fatalf("invalid test should have failed")
 	}

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -144,6 +144,25 @@ func TestStrictCheckingKeyValidity(t *testing.T) {
 	}
 }
 
+func TestExpiredTS(t *testing.T) {
+	// Check that we respect the ExpiredTS properly.
+	publicKeyLookup := PublicKeyLookupResult{
+		ExpiredTS: AsTimestamp(time.Now().Add(time.Hour * 24 * 5)),
+	}
+	shouldPass := AsTimestamp(time.Now().Add(time.Hour * 24 * 1))
+	shouldFail := AsTimestamp(time.Now().Add(time.Hour * 24 * 10))
+
+	// This test should pass because it is less than ExpiredTS.
+	if !publicKeyLookup.WasValidAt(shouldPass, true) {
+		t.Fatalf("valid test should have passed")
+	}
+
+	// This test should fail because it is greater than ExpiredTS.
+	if publicKeyLookup.WasValidAt(shouldFail, true) {
+		t.Fatalf("invalid test should have failed")
+	}
+}
+
 func TestVerifyJSONsFailureWithoutStrictChecking(t *testing.T) {
 	// Check that trying to verify the server key JSON works.
 	k := KeyRing{nil, &testKeyDatabase{}}


### PR DESCRIPTION
If `ExpiredTS` is set then we should really return true if the supplied `atTS` is less than the expired time.