### PR TITLE
Use MaxInt32 instead of MaxUint32

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -121,7 +121,7 @@ func DefaultEventFilter() EventFilter {
 // is provided in the request
 func DefaultStateFilter() StateFilter {
 	return StateFilter{
-		Limit:                   math.MaxUint32,
+		Limit:                   math.MaxInt32,
 		NotSenders:              nil,
 		NotTypes:                nil,
 		Senders:                 nil,


### PR DESCRIPTION
A subtle bug where the code was returning a constant for unsigned int where it should have been signed. (See L54 of `filter.go` for the type definition.)