### PR TITLE
Fix json.Unmarshal(nil) errors

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -152,7 +152,8 @@ func (ac *FederationClient) SendLeave(
 	if err = req.SetContent(event); err != nil {
 		return
 	}
-	err = ac.doRequest(ctx, req, nil)
+	res := struct{}{}
+	err = ac.doRequest(ctx, req, &res)
 	return
 }
 
@@ -204,7 +205,8 @@ func (ac *FederationClient) ExchangeThirdPartyInvite(
 	if err = req.SetContent(builder); err != nil {
 		return
 	}
-	err = ac.doRequest(ctx, req, nil)
+	res := struct{}{}
+	err = ac.doRequest(ctx, req, &res)
 	return
 }
 


### PR DESCRIPTION
This fixes errors in `SendLeave` and `ExchangeThirdPartyInvite` where a successful but empty response fails because of a `json.Unmarshal(nil)` error.