### PR TITLE
Update state res v2 to work using pointers

### DIFF
--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -408,7 +408,11 @@ func TestLexicographicalSorting(t *testing.T) {
 
 func TestReverseTopologicalEventSorting(t *testing.T) {
 	r := stateResolverV2{}
-	base := getBaseStateResV2Graph()
+	graph := getBaseStateResV2Graph()
+	var base []*Event
+	for i := range graph {
+		base = append(base, &graph[i])
+	}
 	input := r.reverseTopologicalOrdering(base, TopologicalOrderByAuthEvents)
 
 	expected := []string{

--- a/stateresolutionv2heaps.go
+++ b/stateresolutionv2heaps.go
@@ -27,7 +27,7 @@ type stateResV2ConflictedPowerLevel struct {
 	powerLevel     int
 	originServerTS int64
 	eventID        string
-	event          Event
+	event          *Event
 }
 
 // A stateResV2ConflictedPowerLevelHeap is used to sort the events using
@@ -90,7 +90,7 @@ type stateResV2ConflictedOther struct {
 	mainlinePosition int
 	originServerTS   int64
 	eventID          string
-	event            Event
+	event            *Event
 }
 
 // A stateResV2ConflictedOtherHeap is used to sort the events using


### PR DESCRIPTION
This updates the state resolution v2 code to primarily juggle pointers around instead of copies of events. Experiments with `pprof` shows that this reduces the allocation footprint of the algorithm by a huge margin.