### PR TITLE
Prevent NewEventFromUntrustedJSON from accepting headered events

### DIFF
--- a/event.go
+++ b/event.go
@@ -263,7 +263,7 @@ func (eb *EventBuilder) Build(
 // This should be used when receiving new events from remote servers.
 func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (result Event, err error) {
 	if r := gjson.GetBytes(eventJSON, "_*"); r.Exists() {
-		err = UnexpectedHeaderedEvent{}
+		err = fmt.Errorf("gomatrixserverlib NewEventFromUntrustedJSON: %w", UnexpectedHeaderedEvent{})
 		return
 	}
 

--- a/event.go
+++ b/event.go
@@ -262,7 +262,7 @@ func (eb *EventBuilder) Build(
 // It also checks the content hashes to ensure the event has not been tampered with.
 // This should be used when receiving new events from remote servers.
 func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (result Event, err error) {
-	if r := gjson.GetBytes(eventJSON, "L_*"); r.Exists() {
+	if r := gjson.GetBytes(eventJSON, "_*"); r.Exists() {
 		err = UnexpectedHeaderedEvent{}
 		return
 	}

--- a/event.go
+++ b/event.go
@@ -262,6 +262,11 @@ func (eb *EventBuilder) Build(
 // It also checks the content hashes to ensure the event has not been tampered with.
 // This should be used when receiving new events from remote servers.
 func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (result Event, err error) {
+	if r := gjson.GetBytes(eventJSON, "L_*"); r.Exists() {
+		err = UnexpectedHeaderedEvent{}
+		return
+	}
+
 	result.roomVersion = roomVersion
 
 	var eventFormat EventFormat

--- a/event_test.go
+++ b/event_test.go
@@ -16,6 +16,7 @@
 package gomatrixserverlib
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -135,5 +136,17 @@ func TestEventPowerLevels(t *testing.T) {
 	want.Defaults()
 	if !reflect.DeepEqual(*got, want) {
 		t.Errorf("power levels: got %+v want %+v", got, want)
+	}
+}
+
+func TestHeaderedEventToNewEventFromUntrustedJSON(t *testing.T) {
+	var event Event
+	j, err := json.Marshal(event.Headered(RoomVersionV1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewEventFromUntrustedJSON(j, RoomVersionV1)
+	if _, ok := err.(UnexpectedHeaderedEvent); !ok {
+		t.Fatal("expected an UnexpectedHeaderedEvent error", err)
 	}
 }

--- a/event_test.go
+++ b/event_test.go
@@ -17,6 +17,7 @@ package gomatrixserverlib
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -150,7 +151,7 @@ func TestHeaderedEventToNewEventFromUntrustedJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = NewEventFromUntrustedJSON(j, RoomVersionV1)
-	if _, ok := err.(UnexpectedHeaderedEvent); !ok {
+	if !errors.Is(err, UnexpectedHeaderedEvent{}) {
 		t.Fatal("expected an UnexpectedHeaderedEvent error but got:", err)
 	}
 }

--- a/event_test.go
+++ b/event_test.go
@@ -140,13 +140,17 @@ func TestEventPowerLevels(t *testing.T) {
 }
 
 func TestHeaderedEventToNewEventFromUntrustedJSON(t *testing.T) {
-	var event Event
+	eventJSON := `{"auth_events":[["$BqcTUuCsN3g6Rj1z:localhost",{"sha256":"QHTrdwE/XVTmAWlxFwHPW7fp3JioRu6OBBRs+FI/at8"}],["$9fmIxbx4IX8w1JVo:localhost",{"sha256":"gee+f1VoNeYGGczs5lwnUO1qeKAh70Hw23ws+YfDYGY"}]],"content":{"ban":50,"events":null,"events_default":0,"invite":0,"kick":50,"redact":50,"state_default":50,"users":null,"users_default":0},"depth":4,"event_id":"$1570trwyGMovM5uU:localhost","hashes":{"sha256":"QvWo2OZufVTMUkPcYQinGVeeHEODWY6RUMaHRxdT31Y"},"origin":"localhost","origin_server_ts":0,"prev_events":[["$QAhQsLNIMdumtpOi:localhost",{"sha256":"RqoKwu8u8qL+wDoka23xvd7t9UoOXLRQse/bK3o9qLE"}]],"prev_state":[],"room_id":"!roomid:localhost","sender":"@userid:localhost","signatures":{"localhost":{"ed25519:auto":"0oPZsvPkbNNVwRrLAP+fEyxFRAIUh0Zn7NPH3LybNC8lMz0GyPtN1bKlTVQYMwZBTXCV795s+CEgoIX+M5gkAQ"}},"state_key":"","type":"m.room.power_levels"}`
+	event, err := NewEventFromTrustedJSON([]byte(eventJSON), false, RoomVersionV1)
+	if err != nil {
+		t.Fatal(err)
+	}
 	j, err := json.Marshal(event.Headered(RoomVersionV1))
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = NewEventFromUntrustedJSON(j, RoomVersionV1)
 	if _, ok := err.(UnexpectedHeaderedEvent); !ok {
-		t.Fatal("expected an UnexpectedHeaderedEvent error", err)
+		t.Fatal("expected an UnexpectedHeaderedEvent error but got:", err)
 	}
 }

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -113,3 +113,9 @@ func (e HeaderedEvent) MarshalJSON() ([]byte, error) {
 	// Return the newly marshalled JSON.
 	return content, nil
 }
+
+type UnexpectedHeaderedEvent struct{}
+
+func (u UnexpectedHeaderedEvent) Error() string {
+	return "unexpected headered event"
+}


### PR DESCRIPTION
This should hopefully help us to avoid bugs like matrix-org/dendrite#1070.