### PR TITLE
Responsibility for marking room versions supported/stable

### DIFF
--- a/eventversion.go
+++ b/eventversion.go
@@ -44,32 +44,42 @@ const (
 	StateResV2                              // state resolution v2
 )
 
-var roomVersionMeta = map[RoomVersion]roomVersion{
-	"1": roomVersion{
+var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
+	RoomVersionV1: {
+		Supported:              true,
+		Stable:                 true,
 		stateResAlgorithm:      StateResV1,
 		eventFormat:            EventFormatV1,
 		eventIDFormat:          EventIDFormatV1,
 		enforceSignatureChecks: false,
 	},
-	"2": roomVersion{
+	RoomVersionV2: {
+		Supported:              true,
+		Stable:                 true,
 		stateResAlgorithm:      StateResV2,
 		eventFormat:            EventFormatV1,
 		eventIDFormat:          EventIDFormatV1,
 		enforceSignatureChecks: false,
 	},
-	"3": roomVersion{
+	RoomVersionV3: {
+		Supported:              true,
+		Stable:                 true,
 		stateResAlgorithm:      StateResV2,
 		eventFormat:            EventFormatV2,
 		eventIDFormat:          EventIDFormatV2,
 		enforceSignatureChecks: false,
 	},
-	"4": roomVersion{
+	RoomVersionV4: {
+		Supported:              true,
+		Stable:                 true,
 		stateResAlgorithm:      StateResV2,
 		eventFormat:            EventFormatV2,
 		eventIDFormat:          EventIDFormatV3,
 		enforceSignatureChecks: false,
 	},
-	"5": roomVersion{
+	RoomVersionV5: {
+		Supported:              true,
+		Stable:                 true,
 		stateResAlgorithm:      StateResV2,
 		eventFormat:            EventFormatV2,
 		eventIDFormat:          EventIDFormatV3,
@@ -77,9 +87,51 @@ var roomVersionMeta = map[RoomVersion]roomVersion{
 	},
 }
 
-// roomVersion contains information about a given room version, e.g. which
+// RoomVersions returns information about room versions currently
+// implemented by this commit of gomatrixserverlib.
+func RoomVersions() map[RoomVersion]RoomVersionDescription {
+	return roomVersionMeta
+}
+
+// SupportedRoomVersions returns a map of descriptions for room
+// versions that are marked as supported.
+func SupportedRoomVersions() map[RoomVersion]RoomVersionDescription {
+	versions := make(map[RoomVersion]RoomVersionDescription)
+	for id, version := range RoomVersions() {
+		if version.Supported {
+			versions[id] = version
+		}
+	}
+	return versions
+}
+
+// StableRoomVersions returns a map of descriptions for room
+// versions that are marked as stable.
+func StableRoomVersions() map[RoomVersion]RoomVersionDescription {
+	versions := make(map[RoomVersion]RoomVersionDescription)
+	for id, version := range RoomVersions() {
+		if version.Supported && version.Stable {
+			versions[id] = version
+		}
+	}
+	return versions
+}
+
+// RoomVersionDescription contains information about a given room version, e.g. which
 // state resolution algorithm or event ID format to use.
-type roomVersion struct {
+// RoomVersionDescription contains information about a room version,
+// namely whether it is marked as supported or stable in this server
+// version, along with the state resolution algorith, event ID etc
+// formats used.
+//
+// A version is supported if the server has some support for rooms
+// that are this version. A version is marked as stable or unstable
+// in order to hint whether the version should be used to clients
+// calling the /capabilities endpoint.
+// https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-capabilities
+type RoomVersionDescription struct {
+	Supported              bool
+	Stable                 bool
 	stateResAlgorithm      StateResAlgorithm
 	eventFormat            EventFormat
 	eventIDFormat          EventIDFormat

--- a/eventversion.go
+++ b/eventversion.go
@@ -121,7 +121,7 @@ func StableRoomVersions() map[RoomVersion]RoomVersionDescription {
 // state resolution algorithm or event ID format to use.
 // RoomVersionDescription contains information about a room version,
 // namely whether it is marked as supported or stable in this server
-// version, along with the state resolution algorith, event ID etc
+// version, along with the state resolution algorithm, event ID etc
 // formats used.
 //
 // A version is supported if the server has some support for rooms

--- a/eventversion.go
+++ b/eventversion.go
@@ -130,12 +130,12 @@ func StableRoomVersions() map[RoomVersion]RoomVersionDescription {
 // calling the /capabilities endpoint.
 // https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-capabilities
 type RoomVersionDescription struct {
-	Supported              bool
-	Stable                 bool
 	stateResAlgorithm      StateResAlgorithm
 	eventFormat            EventFormat
 	eventIDFormat          EventIDFormat
 	enforceSignatureChecks bool
+	Supported              bool
+	Stable                 bool
 }
 
 // StateResAlgorithm returns the state resolution for the given room version.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -22,7 +22,7 @@ cd "$tmpdir"
 git checkout-index -a
 
 echo "Installing lint search engine..."
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
 echo "Testing..."
 go test ./...

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -22,7 +22,7 @@ cd "$tmpdir"
 git checkout-index -a
 
 echo "Installing lint search engine..."
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
 
 echo "Testing..."
 go test ./...

--- a/stateresolution.go
+++ b/stateresolution.go
@@ -343,11 +343,7 @@ func ResolveConflicts(
 		// Append the events if there is already a conflicted list for
 		// this tuple key, create it if not.
 		tuple := stateKeyTuple{event.Type(), *event.StateKey()}
-		if _, ok := eventMap[tuple]; ok {
-			eventMap[tuple] = append(eventMap[tuple], event)
-		} else {
-			eventMap[tuple] = []Event{event}
-		}
+		eventMap[tuple] = append(eventMap[tuple], event)
 	}
 
 	// Split out the events in the map into conflicted and unconflicted


### PR DESCRIPTION
Since gomatrixserverlib ultimately implements all of the logic related to specific room versions, it makes sense that it should also own the information about which versions are supported/stable. 