### PR TITLE
Check for JSON floats when enforcing canonical JSON

### DIFF
--- a/json.go
+++ b/json.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"sort"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/tidwall/gjson"
@@ -65,6 +66,10 @@ func verifyEnforcedCanonicalJSON(input []byte) error {
 			return true
 		}
 		if value.Num < -9007199254740991 || value.Num > 9007199254740991 {
+			valid = false
+			return false
+		}
+		if value.Num != 0 && strings.ContainsRune(value.Raw, '.') {
 			valid = false
 			return false
 		}

--- a/json_test.go
+++ b/json_test.go
@@ -44,6 +44,19 @@ func TestJSONIntegerRanges(t *testing.T) {
 	}
 }
 
+func TestJSONFloats(t *testing.T) {
+	// This value is in range so it should be fine with both room versions
+	input := `{"foo": 1.1}`
+	if _, err := EnforcedCanonicalJSON([]byte(input), RoomVersionV1); err != nil {
+		// Room version 1 allows this value
+		t.Errorf("should be valid")
+	}
+	if _, err := EnforcedCanonicalJSON([]byte(input), RoomVersionV6); err == nil {
+		// Room version 6 forbids this value
+		t.Errorf("should be invalid")
+	}
+}
+
 func testSortJSON(t *testing.T, input, want string) {
 	got := SortJSON([]byte(input), nil)
 


### PR DESCRIPTION
This checks for apparently-forbidden float values when enforcing canonical JSON in room version 6.