### PR TITLE
Use AuthChainProvider for Check etc

### DIFF
--- a/authchain.go
+++ b/authchain.go
@@ -54,7 +54,7 @@ func VerifyEventAuthChain(ctx context.Context, eventToVerify HeaderedEvent, prov
 			eventsToVerify = append(eventsToVerify, newEvents...) // verify these events too
 		}
 		// verify the event
-		if err := checkAllowedByAuthEvents(curr, eventsByID); err != nil {
+		if err := checkAllowedByAuthEvents(curr, eventsByID, nil); err != nil {
 			return fmt.Errorf("gomatrixserverlib: VerifyEventAuthChain %v failed auth check: %w", curr.EventID(), err)
 		}
 		// add to the verified list

--- a/authchain.go
+++ b/authchain.go
@@ -54,7 +54,7 @@ func VerifyEventAuthChain(ctx context.Context, eventToVerify HeaderedEvent, prov
 			eventsToVerify = append(eventsToVerify, newEvents...) // verify these events too
 		}
 		// verify the event
-		if err := checkAllowedByAuthEvents(curr, eventsByID, nil); err != nil {
+		if err := checkAllowedByAuthEvents(curr, eventsByID, provideEvents); err != nil {
 			return fmt.Errorf("gomatrixserverlib: VerifyEventAuthChain %v failed auth check: %w", curr.EventID(), err)
 		}
 		// add to the verified list

--- a/authstate.go
+++ b/authstate.go
@@ -106,7 +106,7 @@ func VerifyAuthRulesAtState(ctx context.Context, sp StateProvider, eventToVerify
 	if ctx.Err() != nil {
 		return fmt.Errorf("gomatrixserverlib.VerifyAuthRulesAtState: context cancelled: %w", ctx.Err())
 	}
-	if err := checkAllowedByAuthEvents(eventToVerify.Unwrap(), roomState); err != nil {
+	if err := checkAllowedByAuthEvents(eventToVerify.Unwrap(), roomState, nil); err != nil {
 		return fmt.Errorf(
 			"gomatrixserverlib.VerifyAuthRulesAtState: event %s is not allowed at state %s : %w",
 			eventToVerify.EventID(), eventToVerify.EventID(), err,

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -601,10 +601,15 @@ func checkAllowedByAuthEvents(event Event, eventsByID map[string]*Event, missing
 			if missingAuth != nil {
 				// If we have a AuthChainProvider then ask it for the missing event.
 				if ev, err := missingAuth(event.roomVersion, []string{ae}); err == nil && len(ev) > 0 {
-					// It claims to have returned an event - populate the eventsByID
-					// map so that we can retry with the new event.
+					// It claims to have returned events - populate the eventsByID
+					// map and the authEvents provider so that we can retry with the
+					// new events.
 					for _, e := range ev {
-						eventsByID[e.EventID()] = &e
+						if err := authEvents.AddEvent(&e); err == nil {
+							eventsByID[e.EventID()] = &e
+						} else {
+							eventsByID[e.EventID()] = nil
+						}
 					}
 				} else {
 					// It claims to have not returned an event - put a nil into the

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -370,6 +370,10 @@ func (r RespState) Events() ([]Event, error) {
 	return result, nil
 }
 
+// MissingAuthEventHandler is a function signature which can be provided to
+// RespState.Check(), RespSendJoin.Check() and checkAllowedByAuthEvents. If
+// an auth event comes up missing during the checks, the MissingAuthEventHandler
+// will be called (if provided) to try and retrieve the missing event.
 type MissingAuthEventHandler func(eventID string) (*Event, error)
 
 // Check that a response to /state is valid.

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -374,7 +374,7 @@ func (r RespState) Events() ([]Event, error) {
 // RespState.Check(), RespSendJoin.Check() and checkAllowedByAuthEvents. If
 // an auth event comes up missing during the checks, the MissingAuthEventHandler
 // will be called (if provided) to try and retrieve the missing event.
-type MissingAuthEventHandler func(eventID string) (*Event, error)
+type MissingAuthEventHandler func(eventID string, roomVersion RoomVersion) (*Event, error)
 
 // Check that a response to /state is valid.
 func (r RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth MissingAuthEventHandler) error {
@@ -606,7 +606,7 @@ func checkAllowedByAuthEvents(event Event, eventsByID map[string]*Event, missing
 			// We don't have an entry in the eventsByID map - neither an event nor nil.
 			if missingAuth != nil {
 				// If we have a MissingAuthEventHandler then ask it for the missing event.
-				if ev, err := missingAuth(ae); err == nil {
+				if ev, err := missingAuth(ae, event.roomVersion); err == nil {
 					// It claims to have returned an event - populate the eventsByID
 					// map so that we can retry with the new event.
 					eventsByID[ae] = ev


### PR DESCRIPTION
This uses `AuthChainProvider` as an optional parameter to:
- `RespState.Check()`
- `RespSendJoin.Check()`
- `checkAllowedByAuthEvents()`

The idea here is that the above functions don't just give up entirely if they hit a missing auth event, but instead can delegate to the provided function to *attempt* to retrieve the missing event. This means that we don't have to return to the caller and repeat the entire set of checks for each missing auth event.

If an `AuthChainProvider` isn't supplied then a `MissingAuthEventError` will be returned as usual.