### PR TITLE
Adjust DirectKeyFetcher

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -195,12 +195,12 @@ func (k KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) 
 
 	// TODO: we should distinguish here between expired keys, and those we don't have.
 	// If the key has expired, it's no use re-requesting it.
-	//now := AsTimestamp(time.Now())
 	keysFetched := map[PublicKeyLookupRequest]PublicKeyLookupResult{}
 	for req, res := range keysFromDatabase {
-		//if (now <= res.ValidUntilTS && res.ExpiredTS == PublicKeyNotExpired) || res.ExpiredTS != PublicKeyNotExpired {
-		//	delete(keyRequests, req)
-		//}
+		if res.ExpiredTS != PublicKeyNotExpired {
+			// Don't bother re-requesting keys that are marked as expired.
+			delete(keyRequests, req)
+		}
 		keysFetched[req] = res
 	}
 

--- a/keyring.go
+++ b/keyring.go
@@ -222,8 +222,8 @@ func (k KeyRing) VerifyJSONs(ctx context.Context, requests []VerifyJSONRequest) 
 		// a verification using our keys.
 		k.checkUsingKeys(requests, results, keyIDs, keysFetched)
 
-		// If we can verify using the keys from the database, don't make a
-		// federation call.
+		// If we run into any errors when verifying using the keys that we
+		// have then we can hit federation and check for updated keys.
 		for _, r := range results {
 			if r.Error != nil {
 				doFederationHit = true


### PR DESCRIPTION
This will:

- increase logging a bit when things go wrong fetching keys
- not re-request keys that are expired
- still allow updates that are past the validity to be returned, as `checkUsingKeys` will yell if there's a problem with them