### PR TITLE
15 second timeout on direct key fetch requests

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -504,6 +504,9 @@ func (d *DirectKeyFetcher) FetchKeys(
 func (d *DirectKeyFetcher) fetchKeysForServer(
 	ctx context.Context, serverName ServerName,
 ) (map[PublicKeyLookupRequest]PublicKeyLookupResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*15)
+	defer cancel()
+
 	keys, err := d.Client.GetServerKeys(ctx, serverName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This restricts direct key fetch requests to 15 seconds, otherwise the worker pool of 64 direct fetchers can be saturated for a long time by fetch requests which are failing due to TCP timeouts or such.