### PR TITLE
Allow enforcing X.509 certificate validity (MSC1711)

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,12 +48,12 @@ type UserInfo struct {
 }
 
 // NewClient makes a new Client (with default timeout)
-func NewClient(enforceX509 bool) *Client {
-	return NewClientWithTimeout(requestTimeout, newFederationTripper(enforceX509))
+func NewClient(skipVerify bool) *Client {
+	return NewClientWithTimeout(requestTimeout, newFederationTripper(skipVerify))
 }
 
 // NewClientWithTransport makes a new Client with an existing transport
-func NewClientWithTransport(enforceX509 bool, transport http.RoundTripper) *Client {
+func NewClientWithTransport(skipVerify bool, transport http.RoundTripper) *Client {
 	return NewClientWithTimeout(requestTimeout, transport)
 }
 
@@ -74,10 +74,10 @@ type federationTripper struct {
 	skipVerify      bool
 }
 
-func newFederationTripper(enforceX509 bool) *federationTripper {
+func newFederationTripper(skipVerify bool) *federationTripper {
 	return &federationTripper{
 		transports: make(map[string]http.RoundTripper),
-		skipVerify: enforceX509,
+		skipVerify: skipVerify,
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -96,8 +96,7 @@ func (f *federationTripper) getTransport(tlsServerName string) (transport http.R
 	if transport, ok = f.transports[tlsServerName]; !ok {
 		transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
-				ServerName: tlsServerName,
-				// TODO: Remove this when we enforce MSC1711.
+				ServerName:         tlsServerName,
 				InsecureSkipVerify: f.skipVerify,
 			},
 		}

--- a/client.go
+++ b/client.go
@@ -71,13 +71,13 @@ type federationTripper struct {
 	// transports maps an TLS server name with an HTTP transport.
 	transports      map[string]http.RoundTripper
 	transportsMutex sync.Mutex
-	enforceX509     bool
+	skipVerify      bool
 }
 
 func newFederationTripper(enforceX509 bool) *federationTripper {
 	return &federationTripper{
-		transports:  make(map[string]http.RoundTripper),
-		enforceX509: enforceX509,
+		transports: make(map[string]http.RoundTripper),
+		skipVerify: enforceX509,
 	}
 }
 
@@ -98,7 +98,7 @@ func (f *federationTripper) getTransport(tlsServerName string) (transport http.R
 			TLSClientConfig: &tls.Config{
 				ServerName: tlsServerName,
 				// TODO: Remove this when we enforce MSC1711.
-				InsecureSkipVerify: f.enforceX509,
+				InsecureSkipVerify: f.skipVerify,
 			},
 		}
 

--- a/federationclient.go
+++ b/federationclient.go
@@ -25,10 +25,10 @@ type FederationClient struct {
 // NewFederationClient makes a new FederationClient
 func NewFederationClient(
 	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
-	enforceX509 bool,
+	skipVerify bool,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           *NewClient(enforceX509),
+		Client:           *NewClient(skipVerify),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,
@@ -39,10 +39,10 @@ func NewFederationClient(
 // transport.
 func NewFederationClientWithTransport(
 	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
-	enforceX509 bool, transport *http.Transport,
+	skipVerify bool, transport *http.Transport,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           *NewClientWithTransport(enforceX509, transport),
+		Client:           *NewClientWithTransport(skipVerify, transport),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,

--- a/federationclient.go
+++ b/federationclient.go
@@ -25,9 +25,10 @@ type FederationClient struct {
 // NewFederationClient makes a new FederationClient
 func NewFederationClient(
 	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
+	enforceX509 bool,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           *NewClient(),
+		Client:           *NewClient(enforceX509),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,
@@ -37,10 +38,11 @@ func NewFederationClient(
 // NewFederationClientWithTransport makes a new FederationClient with a custom
 // transport.
 func NewFederationClientWithTransport(
-	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey, transport *http.Transport,
+	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
+	enforceX509 bool, transport *http.Transport,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           *NewClientWithTransport(transport),
+		Client:           *NewClientWithTransport(enforceX509, transport),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,

--- a/federationclient_test.go
+++ b/federationclient_test.go
@@ -51,8 +51,8 @@ func TestSendJoinFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to marshal RespSendJoin: %s", err)
 	}
-	fc := gomatrixserverlib.NewFederationClient(serverName, keyID, privateKey)
-	fc.Client = *gomatrixserverlib.NewClientWithTransport(&roundTripper{
+	fc := gomatrixserverlib.NewFederationClient(serverName, keyID, privateKey, false)
+	fc.Client = *gomatrixserverlib.NewClientWithTransport(false, &roundTripper{
 		fn: func(req *http.Request) (*http.Response, error) {
 			if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v2/send_join") {
 				return &http.Response{

--- a/federationclient_test.go
+++ b/federationclient_test.go
@@ -51,8 +51,8 @@ func TestSendJoinFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to marshal RespSendJoin: %s", err)
 	}
-	fc := gomatrixserverlib.NewFederationClient(serverName, keyID, privateKey, false)
-	fc.Client = *gomatrixserverlib.NewClientWithTransport(false, &roundTripper{
+	fc := gomatrixserverlib.NewFederationClient(serverName, keyID, privateKey, true)
+	fc.Client = *gomatrixserverlib.NewClientWithTransport(true, &roundTripper{
 		fn: func(req *http.Request) (*http.Response, error) {
 			if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v2/send_join") {
 				return &http.Response{


### PR DESCRIPTION
This makes skipping certificate validation optional so that we can sort matrix-org/dendrite#760.