### PR TITLE
Request logging to trace level

### DIFF
--- a/client.go
+++ b/client.go
@@ -379,7 +379,7 @@ func (fc *Client) DoHTTPRequest(ctx context.Context, req *http.Request) (*http.R
 		"out.req.method": req.Method,
 		"out.req.uri":    req.URL,
 	})
-	logger.Info("Outgoing request")
+	logger.Trace("Outgoing request")
 	newCtx := util.ContextWithLogger(ctx, logger)
 
 	start := time.Now()
@@ -393,7 +393,7 @@ func (fc *Client) DoHTTPRequest(ctx context.Context, req *http.Request) (*http.R
 	logger.WithFields(logrus.Fields{
 		"out.req.code":        resp.StatusCode,
 		"out.req.duration_ms": int(time.Since(start) / time.Millisecond),
-	}).Info("Outgoing request returned")
+	}).Trace("Outgoing request returned")
 
 	return resp, nil
 }


### PR DESCRIPTION
This PR reduces the `Outgoing request`/`Outgoing request returned` logging to trace level.

Associated with matrix-org/dendrite#1244.