### PR TITLE
BackfillClient, FederatedStateClient

### DIFF
--- a/authstate.go
+++ b/authstate.go
@@ -15,9 +15,18 @@ type StateProvider interface {
 	StateBeforeEvent(ctx context.Context, roomVer RoomVersion, event HeaderedEvent, eventIDs []string) (map[string]*Event, error)
 }
 
+type FederatedStateClient interface {
+	LookupState(
+		ctx context.Context, s ServerName, roomID, eventID string, roomVersion RoomVersion,
+	) (res RespState, err error)
+	LookupStateIDs(
+		ctx context.Context, s ServerName, roomID, eventID string,
+	) (res RespStateIDs, err error)
+}
+
 // FederatedStateProvider is an implementation of StateProvider which solely uses federation requests to retrieve events.
 type FederatedStateProvider struct {
-	FedClient *FederationClient
+	FedClient FederatedStateClient
 	// The remote server to ask.
 	Server ServerName
 	// Set to true to remember the auth event IDs for the room at various states

--- a/backfill.go
+++ b/backfill.go
@@ -5,6 +5,14 @@ import (
 	"fmt"
 )
 
+// BackfillClient contains the necessary functions from the federation client to perform a backfill request
+// from another homeserver.
+type BackfillClient interface {
+	// Backfill performs a backfill request to the given server.
+	// https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-backfill-roomid
+	Backfill(ctx context.Context, server ServerName, roomID string, fromEventIDs []string, limit int) (*Transaction, error)
+}
+
 // BackfillRequester contains the necessary functions to perform backfill requests from one server to another.
 //
 // It requires a StateProvider in order to perform PDU checks on received events, notably the step
@@ -14,15 +22,12 @@ import (
 // constantly deferring to federation requests.
 type BackfillRequester interface {
 	StateProvider
+	BackfillClient
 	// ServersAtEvent is called when trying to determine which server to request from.
 	// It returns a list of servers which can be queried for backfill requests. These servers
 	// will be servers that are in the room already. The entries at the beginning are preferred servers
 	// and will be tried first. An empty list will fail the request.
 	ServersAtEvent(ctx context.Context, roomID, eventID string) []ServerName
-	// Backfill performs a backfill request to the given server.
-	// https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-backfill-roomid
-	Backfill(ctx context.Context, server ServerName, roomID string, fromEventIDs []string, limit int) (*Transaction, error)
-
 	ProvideEvents(roomVer RoomVersion, eventIDs []string) ([]Event, error)
 }
 

--- a/backfill.go
+++ b/backfill.go
@@ -10,7 +10,7 @@ import (
 type BackfillClient interface {
 	// Backfill performs a backfill request to the given server.
 	// https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-backfill-roomid
-	Backfill(ctx context.Context, server ServerName, roomID string, fromEventIDs []string, limit int) (*Transaction, error)
+	Backfill(ctx context.Context, server ServerName, roomID string, limit int, fromEventIDs []string) (*Transaction, error)
 }
 
 // BackfillRequester contains the necessary functions to perform backfill requests from one server to another.
@@ -67,7 +67,7 @@ func RequestBackfill(ctx context.Context, b BackfillRequester, keyRing JSONVerif
 			return nil, fmt.Errorf("gomatrixserverlib: RequestBackfill context cancelled %w", ctx.Err())
 		}
 		// fetch some events, and try a different server if it fails
-		txn, err := b.Backfill(ctx, s, roomID, fromEventIDs, limit)
+		txn, err := b.Backfill(ctx, s, roomID, limit, fromEventIDs)
 		if err != nil {
 			continue // try the next server
 		}

--- a/backfill.go
+++ b/backfill.go
@@ -10,7 +10,7 @@ import (
 type BackfillClient interface {
 	// Backfill performs a backfill request to the given server.
 	// https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-backfill-roomid
-	Backfill(ctx context.Context, server ServerName, roomID string, limit int, fromEventIDs []string) (*Transaction, error)
+	Backfill(ctx context.Context, server ServerName, roomID string, limit int, fromEventIDs []string) (Transaction, error)
 }
 
 // BackfillRequester contains the necessary functions to perform backfill requests from one server to another.

--- a/backfill_test.go
+++ b/backfill_test.go
@@ -28,8 +28,12 @@ func (t *testBackfillRequester) StateBeforeEvent(ctx context.Context, roomVer Ro
 func (t *testBackfillRequester) ServersAtEvent(ctx context.Context, roomID, eventID string) []ServerName {
 	return t.servers
 }
-func (t *testBackfillRequester) Backfill(ctx context.Context, server ServerName, roomID string, limit int, fromEventIDs []string) (*Transaction, error) {
-	return t.backfillFn(server, roomID, fromEventIDs, limit)
+func (t *testBackfillRequester) Backfill(ctx context.Context, server ServerName, roomID string, limit int, fromEventIDs []string) (Transaction, error) {
+	txn, err := t.backfillFn(server, roomID, fromEventIDs, limit)
+	if err != nil {
+		return Transaction{}, err
+	}
+	return *txn, nil
 }
 func (t *testBackfillRequester) ProvideEvents(roomVer RoomVersion, eventIDs []string) (result []Event, err error) {
 	eventMap := make(map[string]Event)

--- a/backfill_test.go
+++ b/backfill_test.go
@@ -28,7 +28,7 @@ func (t *testBackfillRequester) StateBeforeEvent(ctx context.Context, roomVer Ro
 func (t *testBackfillRequester) ServersAtEvent(ctx context.Context, roomID, eventID string) []ServerName {
 	return t.servers
 }
-func (t *testBackfillRequester) Backfill(ctx context.Context, server ServerName, roomID string, fromEventIDs []string, limit int) (*Transaction, error) {
+func (t *testBackfillRequester) Backfill(ctx context.Context, server ServerName, roomID string, limit int, fromEventIDs []string) (*Transaction, error) {
 	return t.backfillFn(server, roomID, fromEventIDs, limit)
 }
 func (t *testBackfillRequester) ProvideEvents(roomVer RoomVersion, eventIDs []string) (result []Event, err error) {


### PR DESCRIPTION
This adds two new interfaces to allow us to use the federation sender API as the client for backfill and federated state.

It also fixes two disparate definitions for `Backfill`.