### PR TITLE
add peek constant

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -34,7 +34,7 @@ const (
 	Leave = "leave"
 	// Invite is the string constant "invite"
 	Invite = "invite"
-	// Peek is the string constant "peek"
+	// NOTSPEC: Peek is the string constant "peek" (MSC2753, used as the label in the sync block)
 	Peek = "peek"
 	// Public is the string constant "public"
 	Public = "public"

--- a/eventauth.go
+++ b/eventauth.go
@@ -34,6 +34,8 @@ const (
 	Leave = "leave"
 	// Invite is the string constant "invite"
 	Invite = "invite"
+	// Peek is the string constant "peek"
+	Peek = "peek"
 	// Public is the string constant "public"
 	Public = "public"
 	// MRoomCreate https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-create


### PR DESCRIPTION
needed for peeking (even though it's not technically a membership state, we use it in dendrite as the key for the appropriate sync section for [MSC2753](https://github.com/matrix-org/matrix-doc/pull/2753) style peeking)