### PR TITLE
Don't cause panics when trimming failed auth/state events

### DIFF
--- a/federationtypes.go
+++ b/federationtypes.go
@@ -438,13 +438,23 @@ func (r RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth 
 	// For all of the events that weren't verified, remove them
 	// from the RespState. This way they won't be passed onwards.
 	logger.Infof("Discarding %d auth/state events due to invalid signatures", len(failures))
+	authCount := len(r.AuthEvents)
+	stateCount := len(r.StateEvents)
 	for i := range r.AuthEvents {
 		if _, ok := failures[r.AuthEvents[i].EventID()]; ok {
+			if i+1 == authCount {
+				r.AuthEvents = r.AuthEvents[:i]
+				break
+			}
 			r.AuthEvents = append(r.AuthEvents[:i], r.AuthEvents[i+1:]...)
 		}
 	}
 	for i := range r.StateEvents {
 		if _, ok := failures[r.StateEvents[i].EventID()]; ok {
+			if i+1 == stateCount {
+				r.StateEvents = r.StateEvents[:i]
+				break
+			}
 			r.StateEvents = append(r.StateEvents[:i], r.StateEvents[i+1:]...)
 		}
 	}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 
@@ -413,10 +414,10 @@ func (r RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth 
 	}
 
 	// Work out which events failed the signature checks.
-	failures := map[string]struct{}{}
+	failures := map[string]error{}
 	for i, e := range allEvents {
 		if errors[i] != nil {
-			failures[e.EventID()] = struct{}{}
+			failures[e.EventID()] = errors[i]
 		}
 	}
 
@@ -437,7 +438,11 @@ func (r RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth 
 
 	// For all of the events that weren't verified, remove them
 	// from the RespState. This way they won't be passed onwards.
+	for i, e := range failures {
+		logrus.WithError(e).Errorf("Signature validation failed for event %q", i)
+	}
 	logger.Infof("Discarding %d auth/state events due to invalid signatures", len(failures))
+
 	for i := 0; i < len(r.AuthEvents); i++ {
 		if _, ok := failures[r.AuthEvents[i].EventID()]; ok {
 			r.AuthEvents = append(r.AuthEvents[:i], r.AuthEvents[i+1:]...)

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -441,7 +441,7 @@ func (r RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth 
 	for i, e := range failures {
 		logrus.WithError(e).Errorf("Signature validation failed for event %q", i)
 	}
-	logger.Infof("Discarding %d auth/state events due to invalid signatures", len(failures))
+	logger.Warnf("Discarding %d auth/state events due to invalid signatures", len(failures))
 
 	for i := 0; i < len(r.AuthEvents); i++ {
 		if _, ok := failures[r.AuthEvents[i].EventID()]; ok {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -438,24 +438,16 @@ func (r RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth 
 	// For all of the events that weren't verified, remove them
 	// from the RespState. This way they won't be passed onwards.
 	logger.Infof("Discarding %d auth/state events due to invalid signatures", len(failures))
-	authCount := len(r.AuthEvents)
-	stateCount := len(r.StateEvents)
-	for i := range r.AuthEvents {
+	for i := 0; i < len(r.AuthEvents); i++ {
 		if _, ok := failures[r.AuthEvents[i].EventID()]; ok {
-			if i+1 == authCount {
-				r.AuthEvents = r.AuthEvents[:i]
-				break
-			}
 			r.AuthEvents = append(r.AuthEvents[:i], r.AuthEvents[i+1:]...)
+			i--
 		}
 	}
-	for i := range r.StateEvents {
+	for i := 0; i < len(r.StateEvents); i++ {
 		if _, ok := failures[r.StateEvents[i].EventID()]; ok {
-			if i+1 == stateCount {
-				r.StateEvents = r.StateEvents[:i]
-				break
-			}
 			r.StateEvents = append(r.StateEvents[:i], r.StateEvents[i+1:]...)
+			i--
 		}
 	}
 


### PR DESCRIPTION
This happened because we were trimming things out of the slices but the original `range` was running on a copy of the slice, meaning that we'd hit an invalid index and panic.

This helps matrix-org/dendrite#1401 — sort of. Joining that room still doesn't work because of a bad state event in the room, but at least we don't panic anymore. 