### PR TITLE
Ignore events with invalid signatures in RespState/RespSendJoin

### DIFF
--- a/federationtypes.go
+++ b/federationtypes.go
@@ -376,7 +376,9 @@ func (r RespState) Events() ([]Event, error) {
 	return result, nil
 }
 
-// Check that a response to /state is valid.
+// Check that a response to /state is valid. This function mutates
+// the RespState to remove any events from AuthEvents or StateEvents
+// that do not have valid signatures.
 func (r *RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth AuthChainProvider) error {
 	logger := util.GetLogger(ctx)
 	var allEvents []Event
@@ -549,8 +551,10 @@ func (r RespSendJoin) ToRespState() RespState {
 // Check that a response to /send_join is valid. If it is then it
 // returns a reference to the RespState that contains the room state
 // excluding any events that failed signature checks.
-// This checks that it would be valid as a response to /state
+// This checks that it would be valid as a response to /state.
 // This also checks that the join event is allowed by the state.
+// This function mutates the RespSendJoin to remove any events from
+// AuthEvents or StateEvents that do not have valid signatures.
 func (r *RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent Event, missingAuth AuthChainProvider) (*RespState, error) {
 	// First check that the state is valid and that the events in the response
 	// are correctly signed.

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -377,7 +377,7 @@ func (r RespState) Events() ([]Event, error) {
 }
 
 // Check that a response to /state is valid.
-func (r RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth AuthChainProvider) error {
+func (r *RespState) Check(ctx context.Context, keyRing JSONVerifier, missingAuth AuthChainProvider) error {
 	logger := util.GetLogger(ctx)
 	var allEvents []Event
 	for _, event := range r.AuthEvents {
@@ -551,7 +551,7 @@ func (r RespSendJoin) ToRespState() RespState {
 // excluding any events that failed signature checks.
 // This checks that it would be valid as a response to /state
 // This also checks that the join event is allowed by the state.
-func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent Event, missingAuth AuthChainProvider) (*RespState, error) {
+func (r *RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent Event, missingAuth AuthChainProvider) (*RespState, error) {
 	// First check that the state is valid and that the events in the response
 	// are correctly signed.
 	//

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -577,21 +577,21 @@ func (r RespSendJoin) Check(ctx context.Context, keyRing JSONVerifier, joinEvent
 	// Since checkAllowedByAuthEvents needs to be able to look up any of the
 	// auth events by ID only, we will build a map which contains references
 	// to all of the auth events.
-	for i, event := range r.AuthEvents {
-		eventsByID[event.EventID()] = &r.AuthEvents[i]
+	for i, event := range rs.AuthEvents {
+		eventsByID[event.EventID()] = &rs.AuthEvents[i]
 	}
 
 	// Then we add the current state events too, since our newly formed
 	// membership event will likely refer to these as auth events too.
-	for i, event := range r.StateEvents {
-		eventsByID[event.EventID()] = &r.StateEvents[i]
+	for i, event := range rs.StateEvents {
+		eventsByID[event.EventID()] = &rs.StateEvents[i]
 	}
 
 	// Add all of the current state events to an auth provider, allowing us
 	// to check specifically that the join event is allowed by the supplied
 	// state (and not by former auth events).
-	for i := range r.StateEvents {
-		if err := authEventProvider.AddEvent(&r.StateEvents[i]); err != nil {
+	for i := range rs.StateEvents {
+		if err := authEventProvider.AddEvent(&rs.StateEvents[i]); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This means that we can join rooms that have invalid state events by simply ignoring them, so long as the event isn't critical to the join in some other way (e.g. as an auth event).