### PR TITLE
Omit tls_fingerprints from server keys when empty

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -53,7 +53,7 @@ type ServerKeyFields struct {
 	// The name of the server
 	ServerName ServerName `json:"server_name"`
 	// List of SHA256 fingerprints of X509 certificates used by this server.
-	TLSFingerprints []TLSFingerprint `json:"tls_fingerprints"`
+	TLSFingerprints []TLSFingerprint `json:"tls_fingerprints,omitempty"`
 	// The current signing keys in use on this server.
 	// The keys of the map are the IDs of the keys.
 	// These are valid while this response is valid.


### PR DESCRIPTION
Construct breaks if it's null instead of an array. It's a legacy field which shouldn't be used anyway, so it could be removed altogether, but this is just a quick fix that shouldn't affect anything else.

Signed-off-by: Tulir Asokan &lt;tulir@maunium.net&gt;