### PR TITLE
Hint where AuthChainProvider should retrieve events from

### DIFF
--- a/authchain.go
+++ b/authchain.go
@@ -6,7 +6,7 @@ import (
 )
 
 // AuthChainProvider returns the requested list of auth events.
-type AuthChainProvider func(roomVer RoomVersion, eventIDs []string) ([]Event, error)
+type AuthChainProvider func(roomVer RoomVersion, eventIDs []string, serverName ServerName) ([]Event, error)
 
 // VerifyEventAuthChain will verify that the event is allowed according to its auth_events, and then
 // recursively verify each of those auth_events.
@@ -44,7 +44,7 @@ func VerifyEventAuthChain(ctx context.Context, eventToVerify HeaderedEvent, prov
 		}
 		// fetch the events and add them to the lookup table
 		if len(need) > 0 {
-			newEvents, err := provideEvents(eventToVerify.roomVersion, need)
+			newEvents, err := provideEvents(eventToVerify.roomVersion, need, curr.Origin())
 			if err != nil {
 				return fmt.Errorf("gomatrixserverlib: VerifyEventAuthChain failed to obtain auth events: %w", err)
 			}

--- a/authchain_test.go
+++ b/authchain_test.go
@@ -79,7 +79,7 @@ func provideEvents(t *testing.T, events [][]byte) gomatrixserverlib.AuthChainPro
 		}
 		eventMap[ev.EventID()] = ev
 	}
-	return func(roomVer gomatrixserverlib.RoomVersion, eventIDs []string) (result []gomatrixserverlib.Event, err error) {
+	return func(roomVer gomatrixserverlib.RoomVersion, eventIDs []string, serverName gomatrixserverlib.ServerName) (result []gomatrixserverlib.Event, err error) {
 		for _, id := range eventIDs {
 			if ev, ok := eventMap[id]; ok {
 				result = append(result, ev)

--- a/backfill.go
+++ b/backfill.go
@@ -28,7 +28,7 @@ type BackfillRequester interface {
 	// will be servers that are in the room already. The entries at the beginning are preferred servers
 	// and will be tried first. An empty list will fail the request.
 	ServersAtEvent(ctx context.Context, roomID, eventID string) []ServerName
-	ProvideEvents(roomVer RoomVersion, eventIDs []string) ([]Event, error)
+	ProvideEvents(roomVer RoomVersion, eventIDs []string, serverName ServerName) ([]Event, error)
 }
 
 // RequestBackfill implements the server logic for making backfill requests to other servers.

--- a/backfill_test.go
+++ b/backfill_test.go
@@ -35,7 +35,7 @@ func (t *testBackfillRequester) Backfill(ctx context.Context, server ServerName,
 	}
 	return *txn, nil
 }
-func (t *testBackfillRequester) ProvideEvents(roomVer RoomVersion, eventIDs []string) (result []Event, err error) {
+func (t *testBackfillRequester) ProvideEvents(roomVer RoomVersion, eventIDs []string, serverName ServerName) (result []Event, err error) {
 	eventMap := make(map[string]Event)
 	for _, eventBytes := range t.authEventsToProvide {
 		ev, err := NewEventFromTrustedJSON(eventBytes, false, RoomVersionV1)

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -650,7 +650,7 @@ func checkAllowedByAuthEvents(event Event, eventsByID map[string]*Event, missing
 			// We don't have an entry in the eventsByID map - neither an event nor nil.
 			if missingAuth != nil {
 				// If we have a AuthChainProvider then ask it for the missing event.
-				if ev, err := missingAuth(event.roomVersion, []string{ae}); err == nil && len(ev) > 0 {
+				if ev, err := missingAuth(event.roomVersion, []string{ae}, event.Origin()); err == nil && len(ev) > 0 {
 					// It claims to have returned events - populate the eventsByID
 					// map and the authEvents provider so that we can retry with the
 					// new events.


### PR DESCRIPTION
This adds a `ServerName` field to the `AuthChainProvider` so that we can hint where we should try to fetch events from. This is probably going to be the origin of the event that we're trying to find the `auth_events` for. 