### PR TITLE
Remove event ID-origin check, move to signature checking

### DIFF
--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -243,6 +243,19 @@ func VerifyEventSignatures(ctx context.Context, events []Event, keyRing JSONVeri
 		}
 		senderServer := ServerName(senderDomain)
 		domains[senderServer] = true
+		// Synapse requires that the event ID domain has a valid signature.
+		// https://github.com/matrix-org/synapse/blob/develop/synapse/event_auth.py#L98-L104
+		// There's a good reason for this. Surely.
+		if format, _ := event.roomVersion.EventIDFormat(); format == EventIDFormatV1 {
+			eventIDDomain, err := domainFromID(event.EventID())
+			if err != nil {
+				return nil, err
+			}
+			eventIDServer := ServerName(eventIDDomain)
+			if senderServer != eventIDServer {
+				domains[eventIDServer] = true
+			}
+		}
 		// TODO: This enables deprecation of the "origin" field as per MSC1664
 		// (https://github.com/matrix-org/matrix-doc/issues/1664) but really
 		// this has been done so that we can join rooms touched by Conduit again.


### PR DESCRIPTION
This removes the check for the event ID domain and the origin field being the same, instead moving the responsibility onto checking that the event ID domain has provided a signature (on room versions where it is applicable).

This means that we now do the same as Synapse. 