### PR TITLE
Handle Content-Type header properly

### DIFF
--- a/request.go
+++ b/request.go
@@ -256,7 +256,7 @@ func readHTTPRequest(req *http.Request) (*FederationRequest, error) { // nolint:
 	if len(content) != 0 {
 		mimetype, _, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
 		if err != nil {
-			return nil, fmt.Errorf("gomatrixserverlib: Failed to parse Content-Type header: %w", err)
+			return nil, fmt.Errorf("gomatrixserverlib: The request had an invalid Content-Type header: %w", err)
 		}
 		if mimetype != "application/json" {
 			return nil, fmt.Errorf("gomatrixserverlib: The request must be \"application/json\" not %q", mimetype)

--- a/request.go
+++ b/request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strings"
 	"time"
@@ -253,11 +254,12 @@ func readHTTPRequest(req *http.Request) (*FederationRequest, error) { // nolint:
 		return nil, err
 	}
 	if len(content) != 0 {
-		if req.Header.Get("Content-Type") != "application/json" {
-			return nil, fmt.Errorf(
-				"gomatrixserverlib: The request must be \"application/json\" not %q",
-				req.Header.Get("Content-Type"),
-			)
+		mimetype, _, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, fmt.Errorf("gomatrixserverlib: Failed to parse Content-Type header: %w", err)
+		}
+		if mimetype != "application/json" {
+			return nil, fmt.Errorf("gomatrixserverlib: The request must be \"application/json\" not %q", mimetype)
 		}
 		result.fields.Content = RawJSON(content)
 	}


### PR DESCRIPTION
This fixes the `readHTTPRequest` function so that it handles MIME in the `Content-Type` header properly. The old check would match `application/json` but would fail on `application/json; charset=utf-8`.