### PR TITLE
Parallelise checkUsingKeys

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -347,7 +347,7 @@ func (k *KeyRing) checkUsingKeys(
 	wg.Add(len(jobs))
 	for _, j := range jobs {
 		go func(jobs []job) {
-			for i, j := range jobs {
+			for _, j := range jobs {
 				mu.RLock()
 				if results[j.index].Error == nil {
 					// We've already checked this message and it passed the signature checks.

--- a/keyring.go
+++ b/keyring.go
@@ -331,19 +331,15 @@ func (k *KeyRing) checkUsingKeys(
 		procs = 1
 	}
 	type job struct {
-		index   int
-		request VerifyJSONRequest
+		index   int               // the original index in the requests/results array
+		request VerifyJSONRequest // the request itself
 	}
 	jobs := make(map[int][]job)
 	for i := range requests {
 		jobs[i%procs] = append(jobs[i%procs], job{i, requests[i]})
 	}
-	fmt.Println("Balancing jobs across", procs, "queues")
-	for i, r := range jobs {
-		fmt.Println("*", i, "has", len(r), "jobs")
-	}
-	var wg sync.WaitGroup
-	var mu sync.RWMutex
+	var wg sync.WaitGroup // tracks the workers
+	var mu sync.RWMutex   // protects results array
 	wg.Add(len(jobs))
 	for _, j := range jobs {
 		go func(jobs []job) {


### PR DESCRIPTION
This speeds up signature checks by performing them across available CPU cores (less one, to not totally starve the system).

This might cause problems if lots of big signature checks are taking place concurrently though, so there's that.