### PR TITLE
Update client functions

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,7 +59,7 @@ func NewClientWithTimeout(timeout time.Duration, skipVerify bool) *Client {
 }
 
 // NewClientWithTransport makes a new Client with an existing transport
-func NewClientWithTransport(skipVerify bool, transport http.RoundTripper) *Client {
+func NewClientWithTransport(transport http.RoundTripper) *Client {
 	return NewClientWithTransportTimeout(requestTimeout, transport)
 }
 

--- a/client.go
+++ b/client.go
@@ -50,16 +50,21 @@ type UserInfo struct {
 
 // NewClient makes a new Client (with default timeout)
 func NewClient(skipVerify bool) *Client {
-	return NewClientWithTimeout(requestTimeout, newFederationTripper(skipVerify))
+	return NewClientWithTransportTimeout(requestTimeout, newFederationTripper(skipVerify))
+}
+
+// NewClientWithTieout makes a new Client (with specified timeout)
+func NewClientWithTimeout(timeout time.Duration, skipVerify bool) *Client {
+	return NewClientWithTransportTimeout(timeout, newFederationTripper(skipVerify))
 }
 
 // NewClientWithTransport makes a new Client with an existing transport
 func NewClientWithTransport(skipVerify bool, transport http.RoundTripper) *Client {
-	return NewClientWithTimeout(requestTimeout, transport)
+	return NewClientWithTransportTimeout(requestTimeout, transport)
 }
 
-// NewClientWithTimeout makes a new Client with a specified request timeout
-func NewClientWithTimeout(timeout time.Duration, transport http.RoundTripper) *Client {
+// NewClientWithTransportTimeout makes a new Client with a specified request timeout
+func NewClientWithTransportTimeout(timeout time.Duration, transport http.RoundTripper) *Client {
 	return &Client{
 		client: http.Client{
 			Transport: transport,

--- a/federationclient.go
+++ b/federationclient.go
@@ -42,7 +42,7 @@ func NewFederationClientWithTransport(
 	skipVerify bool, transport *http.Transport,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           *NewClientWithTransport(skipVerify, transport),
+		Client:           *NewClientWithTransport(transport),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,

--- a/federationclient_test.go
+++ b/federationclient_test.go
@@ -52,7 +52,7 @@ func TestSendJoinFallback(t *testing.T) {
 		t.Fatalf("failed to marshal RespSendJoin: %s", err)
 	}
 	fc := gomatrixserverlib.NewFederationClient(serverName, keyID, privateKey, true)
-	fc.Client = *gomatrixserverlib.NewClientWithTransport(true, &roundTripper{
+	fc.Client = *gomatrixserverlib.NewClientWithTransport(&roundTripper{
 		fn: func(req *http.Request) (*http.Response, error) {
 			if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v2/send_join") {
 				return &http.Response{


### PR DESCRIPTION
This shuffles the client creation functions a bit so we can create things with/without transports and with/without timeouts. 