### PR TITLE
Add Unwrap to BadJSONError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,3 +23,7 @@ type BadJSONError struct {
 func (e BadJSONError) Error() string {
 	return fmt.Sprintf("gomatrixserverlib: bad JSON: %s", e.err.Error())
 }
+
+func (e BadJSONError) Unwrap() error {
+	return e.err
+}


### PR DESCRIPTION
In addition to #239, this is required to ensure we can use `errors.Is`

### Pull Request Checklist

* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)
