### PR TITLE
Add NewEventFromTrustedJSONWithEventID

### DIFF
--- a/event.go
+++ b/event.go
@@ -410,16 +410,14 @@ func (e *Event) populateFieldsFromJSON(eventIDIfKnown string, eventJSON []byte) 
 		}
 		e.eventJSON = eventJSON
 		// Unmarshal the event fields.
-		fields := eventFormatV2Fields{
-			eventFields: eventFields{
-				EventID: eventIDIfKnown,
-			},
-		}
+		fields := eventFormatV2Fields{}
 		if err := json.Unmarshal(eventJSON, &fields); err != nil {
 			return err
 		}
 		// Generate a hash of the event which forms the event ID.
-		if fields.EventID == "" {
+		if eventIDIfKnown != "" {
+			fields.EventID = eventIDIfKnown
+		} else {
 			fields.EventID, err = e.generateEventID()
 			if err != nil {
 				return err

--- a/event.go
+++ b/event.go
@@ -360,16 +360,16 @@ func NewEventFromTrustedJSON(eventJSON []byte, redacted bool, roomVersion RoomVe
 	result = &Event{}
 	result.roomVersion = roomVersion
 	result.redacted = redacted
-	err = result.populateFieldsFromJSON("", eventJSON)
+	err = result.populateFieldsFromJSON("", eventJSON) // "" -> event ID not known
 	return
 }
 
-// NewEventFromStoredJSON loads a new event from some JSON that must be valid
+// NewEventFromTrustedJSONWithEventID loads a new event from some JSON that must be valid
 // and that the event ID is already known. This must ONLY be used when retrieving
 // an event from the database and NEVER when accepting an event over federation.
 // This will be more efficient than NewEventFromTrustedJSON since, if the event
 // ID is known, we skip all the reference hash and canonicalisation work.
-func NewEventFromStoredJSON(eventID string, eventJSON []byte, redacted bool, roomVersion RoomVersion) (result *Event, err error) {
+func NewEventFromTrustedJSONWithEventID(eventID string, eventJSON []byte, redacted bool, roomVersion RoomVersion) (result *Event, err error) {
 	result = &Event{}
 	result.roomVersion = roomVersion
 	result.redacted = redacted


### PR DESCRIPTION
This adds `NewEventFromTrustedJSONWithEventID`, which is used specifically when we're pulling the event out of storage and *we already know the event ID*. This saves us *a lot* of CPU time because then we don't need to calculate the reference hash, redact, canonicalise etc just to work it out.