### PR TITLE
Simplify NewClient and NewFederationClient with ClientOpts

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,7 +58,7 @@ type clientOptions struct {
 // ClientOption are supplied to NewClient or NewFederationClient.
 type ClientOption func(*clientOptions)
 
-// NewClient makes a new Client. You can supply zero or more ClientOpts
+// NewClient makes a new Client. You can supply zero or more ClientOptions
 // which control the transport, timeout, TLS validation etc - see
 // WithTransport, WithTimeout, WithSkipVerify, WithDNSCache etc.
 func NewClient(options ...ClientOption) *Client {

--- a/client.go
+++ b/client.go
@@ -52,7 +52,9 @@ type ClientOption interface {
 	IsClientOption()
 }
 
-// NewClient makes a new Client (with default timeout)
+// NewClient makes a new Client. You can supply zero or more ClientOpts
+// which control the transport, timeout, TLS validation etc - see
+// WithTransport, WithTimeout, WithSkipVerify, WithDNSCache etc.
 func NewClient(options ...ClientOption) *Client {
 	var transport http.RoundTripper
 	var dnsCache *DNSCache

--- a/federationclient.go
+++ b/federationclient.go
@@ -21,7 +21,10 @@ type FederationClient struct {
 	serverPrivateKey ed25519.PrivateKey
 }
 
-// NewFederationClient makes a new FederationClient
+// NewFederationClient makes a new FderationClient. You can supply
+// zero or more ClientOpts which control the transport, timeout,
+// TLS validation etc - see WithTransport, WithTimeout, WithSkipVerify,
+// WithDNSCache etc.
 func NewFederationClient(
 	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
 	skipVerify bool, options ...ClientOption,

--- a/federationclient.go
+++ b/federationclient.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/matrix-org/gomatrix"
 	"golang.org/x/crypto/ed25519"
@@ -29,34 +27,7 @@ func NewFederationClient(
 	skipVerify bool, options ...ClientOption,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           *NewClient(skipVerify, options...),
-		serverName:       serverName,
-		serverKeyID:      keyID,
-		serverPrivateKey: privateKey,
-	}
-}
-
-// NewFederationClientWithTimeout makes a new FederationClient
-func NewFederationClientWithTimeout(
-	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
-	skipVerify bool, timeout time.Duration, options ...ClientOption,
-) *FederationClient {
-	return &FederationClient{
-		Client:           *NewClientWithTimeout(timeout, skipVerify, options...),
-		serverName:       serverName,
-		serverKeyID:      keyID,
-		serverPrivateKey: privateKey,
-	}
-}
-
-// NewFederationClientWithTransport makes a new FederationClient with a custom
-// transport.
-func NewFederationClientWithTransport(
-	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
-	skipVerify bool, transport *http.Transport,
-) *FederationClient {
-	return &FederationClient{
-		Client:           *NewClientWithTransport(transport),
+		Client:           *NewClient(options...),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,

--- a/federationclient.go
+++ b/federationclient.go
@@ -22,7 +22,7 @@ type FederationClient struct {
 }
 
 // NewFederationClient makes a new FederationClient. You can supply
-// zero or more ClientOpts which control the transport, timeout,
+// zero or more ClientOptions which control the transport, timeout,
 // TLS validation etc - see WithTransport, WithTimeout, WithSkipVerify,
 // WithDNSCache etc.
 func NewFederationClient(

--- a/federationclient.go
+++ b/federationclient.go
@@ -21,7 +21,7 @@ type FederationClient struct {
 	serverPrivateKey ed25519.PrivateKey
 }
 
-// NewFederationClient makes a new FderationClient. You can supply
+// NewFederationClient makes a new FederationClient. You can supply
 // zero or more ClientOpts which control the transport, timeout,
 // TLS validation etc - see WithTransport, WithTimeout, WithSkipVerify,
 // WithDNSCache etc.

--- a/federationclient_test.go
+++ b/federationclient_test.go
@@ -52,8 +52,8 @@ func TestSendJoinFallback(t *testing.T) {
 		t.Fatalf("failed to marshal RespSendJoin: %s", err)
 	}
 	fc := gomatrixserverlib.NewFederationClient(serverName, keyID, privateKey, true)
-	fc.Client = *gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport{
-		Transport: &roundTripper{
+	fc.Client = *gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(
+		&roundTripper{
 			fn: func(req *http.Request) (*http.Response, error) {
 				if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v2/send_join") {
 					return &http.Response{
@@ -71,7 +71,7 @@ func TestSendJoinFallback(t *testing.T) {
 				}, nil
 			},
 		},
-	})
+	))
 	ev, err := gomatrixserverlib.NewEventFromTrustedJSON(
 		[]byte(`{"auth_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}]],"content":{"membership":"join"},"depth":1,"event_id":"$fnwGrQEpiOIUoDU2:baba.is.you","hashes":{"sha256":"DqOjdFgvFQ3V/jvQW2j3ygHL4D+t7/LaIPZ/tHTDZtI"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}]],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"qBWLb42zicQVsbh333YrcKpHfKokcUOM/ytldGlrgSdXqDEDDxvpcFlfadYnyvj3Z/GjA2XZkqKHanNEh575Bw"}},"state_key":"@userid:baba.is.you","type":"m.room.member"}`),
 		false, roomVer,


### PR DESCRIPTION
This removes some of the duplicate messy functions and returns us to just having `NewClient` and `NewFederationClient`. You can provide one or more `ClientOpts` to control the transport, timeout, TLS validation, DNS cache etc.