### PR TITLE
Don't default to federation tripper for normal Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,6 +68,14 @@ func NewClient(options ...ClientOption) *Client {
 	for _, option := range options {
 		option(clientOpts)
 	}
+	if clientOpts.transport == nil {
+		clientOpts.transport = &http.Transport{
+			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: clientOpts.skipVerify,
+			},
+		}
+	}
 	client := &Client{
 		client: http.Client{
 			Transport: clientOpts.transport,

--- a/client.go
+++ b/client.go
@@ -68,12 +68,6 @@ func NewClient(options ...ClientOption) *Client {
 	for _, option := range options {
 		option(clientOpts)
 	}
-	if clientOpts.transport == nil {
-		clientOpts.transport = newFederationTripper(
-			clientOpts.skipVerify,
-			clientOpts.dnsCache,
-		)
-	}
 	client := &Client{
 		client: http.Client{
 			Transport: clientOpts.transport,

--- a/client.go
+++ b/client.go
@@ -120,6 +120,19 @@ func WithSkipVerify(skipVerify bool) ClientOption {
 	}
 }
 
+// withFederationTransport is an option that can be supplied to NewClient.
+// It causes the federation tripper to be used. This must be specified
+// AFTER other options such as WithTimeout, WithDNSCache or WithSkipVerify
+// and is called by NewFederationClient automatically.
+func withFederationTransport() ClientOption {
+	return func(options *clientOptions) {
+		options.transport = newFederationTripper(
+			options.skipVerify,
+			options.dnsCache,
+		)
+	}
+}
+
 type federationTripper struct {
 	// transports maps an TLS server name with an HTTP transport.
 	transports      map[string]http.RoundTripper

--- a/federationclient.go
+++ b/federationclient.go
@@ -29,6 +29,15 @@ func NewFederationClient(
 	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
 	options ...ClientOption,
 ) *FederationClient {
+	options = append(
+		[]ClientOption{
+			// Start with the default federation tripper. This may
+			// be overridden by caller-supplied options, as they are
+			// processed in order, but it gives us sane defaults.
+			WithTransport(newFederationTripper(false, nil)),
+		},
+		options...,
+	)
 	return &FederationClient{
 		Client:           *NewClient(options...),
 		serverName:       serverName,

--- a/federationclient.go
+++ b/federationclient.go
@@ -29,17 +29,8 @@ func NewFederationClient(
 	serverName ServerName, keyID KeyID, privateKey ed25519.PrivateKey,
 	options ...ClientOption,
 ) *FederationClient {
-	options = append(
-		[]ClientOption{
-			// Start with the default federation tripper. This may
-			// be overridden by caller-supplied options, as they are
-			// processed in order, but it gives us sane defaults.
-			WithTransport(newFederationTripper(false, nil)),
-		},
-		options...,
-	)
 	return &FederationClient{
-		Client:           *NewClient(options...),
+		Client:           *NewClient(append(options, withFederationTransport())...),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,


### PR DESCRIPTION
`FederationClient` should default to the federation tripper but a normal `Client` shouldn't. 