### PR TITLE
Keep alive options for Client/FederationClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -121,7 +121,8 @@ func WithSkipVerify(skipVerify bool) ClientOption {
 }
 
 // WithKeepAlives is an option that can be supplied to either NewClient or
-// NewFederationClient.
+// NewFederationClient. This option will be ineffective if WithTransport
+// has already been supplied.
 func WithKeepAlives(keepAlives bool) ClientOption {
 	return func(options *clientOptions) {
 		options.keepAlives = keepAlives


### PR DESCRIPTION
This adds the `WithKeepAlive` client option for `Client` and `FederationClient`, to control whether or not HTTP keepalives should be enabled or disabled.