### PR TITLE
Remove TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: go
-go:
- - "1.13"
-install:
-script: ./travis.sh


### PR DESCRIPTION
TravisCI builds are failing to start, and as of https://github.com/matrix-org/pipelines/pull/125 we have the same steps running on Buildkite already. So there's not much point in keeping TravisCI around.

Signed-off-by: `Andrew Morgan <andrewm@element.io>`