### PR TITLE
Optimise levelJSONValue

### DIFF
--- a/eventcontent.go
+++ b/eventcontent.go
@@ -418,11 +418,11 @@ func (v *levelJSONValue) UnmarshalJSON(data []byte) error {
 	var err error
 
 	// First try to unmarshal as an int64.
-	if err = json.Unmarshal(data, &int64Value); err != nil {
+	if int64Value, err = strconv.ParseInt(string(data), 10, 64); err != nil {
 		// If unmarshalling as an int64 fails try as a string.
 		if err = json.Unmarshal(data, &stringValue); err != nil {
 			// If unmarshalling as a string fails try as a float.
-			if err = json.Unmarshal(data, &floatValue); err != nil {
+			if floatValue, err = strconv.ParseFloat(string(data), 64); err != nil {
 				return err
 			}
 			int64Value = int64(floatValue)

--- a/eventcontent_test.go
+++ b/eventcontent_test.go
@@ -20,6 +20,27 @@ import (
 	"testing"
 )
 
+func BenchmarkLevelJSONValueInt(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		var value []levelJSONValue
+		_ = json.Unmarshal([]byte(`[1, 2, 3]`), &value)
+	}
+}
+
+func BenchmarkLevelJSONValueFloat(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		var value []levelJSONValue
+		_ = json.Unmarshal([]byte(`[1.1, 1.2, 1.3]`), &value)
+	}
+}
+
+func BenchmarkLevelJSONValueString(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		var value []levelJSONValue
+		_ = json.Unmarshal([]byte(`["1", "2", "3"]`), &value)
+	}
+}
+
 func TestLevelJSONValueValid(t *testing.T) {
 	var values []levelJSONValue
 	input := `[0,"1",2.0]`


### PR DESCRIPTION
The existence of this type is due to a long-standing Synapse bug where power levels can be strings (matrix-org/synapse#1237, matrix-org/matrix-doc#3264). However, it gets hit quite hard when resolving room state as we need to pull power levels out of possibly a large set of events.

This PR changes from `json.Unmarshal` to `strconv.ParseInt`/`strconv.ParseFloat` where possible, as they are significantly faster (not relying on `reflect` internally, for a start).

Before this PR:
```
BenchmarkLevelJSONValueInt-12             741554              1430 ns/op
BenchmarkLevelJSONValueFloat-12           317689              3312 ns/op
BenchmarkLevelJSONValueString-12          547220              2123 ns/op
```

With this PR:
```
BenchmarkLevelJSONValueInt-12            1332276               884.9 ns/op
BenchmarkLevelJSONValueFloat-12           585170              1949 ns/op
BenchmarkLevelJSONValueString-12          708974              1757 ns/op
```