### PR TITLE
Only extract the membership key when Membership() gets called

### DIFF
--- a/event.go
+++ b/event.go
@@ -906,7 +906,9 @@ func (e *Event) extractContent(eventType string, content interface{}) error {
 // Returns an error if the event is not a m.room.member event or if the content
 // is not valid m.room.member content.
 func (e *Event) Membership() (string, error) {
-	var content MemberContent
+	var content struct {
+		Membership string `json:"membership"`
+	}
 	if err := e.extractContent(MRoomMember, &content); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
If we extract the entire MemberContent and there are JSON parse
errors there (e.g from a bad displayname) then we will return
an error even when we could return the requested data.

Part of fixing the sytest: "Membership event with an invalid displayname in the send_join response should not cause room join to fail"