### PR TITLE
Improve state resolution v2 performance using allowerContext

### DIFF
--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -338,7 +338,7 @@ func (r *stateResolverV2) authAndApplyEvents(events []*Event) {
 	for _, event := range events {
 		// Check if the event is allowed based on the current partial state. If the
 		// event isn't allowed then simply ignore it and process the next one.
-		if err := Allowed(event, r); err != nil {
+		if err := allower.Allowed(event); err != nil {
 			continue
 		}
 		// Apply the newly authed event to the partial state. We need to do this

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -331,6 +331,10 @@ func (r *stateResolverV2) getFirstPowerLevelMainlineEvent(event *Event) (
 // the event is ignored and dropped. Returns two lists - the first contains the
 // accepted (authed) events and the second contains the rejected events.
 func (r *stateResolverV2) authAndApplyEvents(events []*Event) {
+	allower, err := NewAllowerContext(r)
+	if err != nil {
+		panic(err)
+	}
 	for _, event := range events {
 		// Check if the event is allowed based on the current partial state. If the
 		// event isn't allowed then simply ignore it and process the next one.

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -331,14 +331,11 @@ func (r *stateResolverV2) getFirstPowerLevelMainlineEvent(event *Event) (
 // the event is ignored and dropped. Returns two lists - the first contains the
 // accepted (authed) events and the second contains the rejected events.
 func (r *stateResolverV2) authAndApplyEvents(events []*Event) {
-	allower, err := NewAllowerContext(r)
-	if err != nil {
-		panic(err)
-	}
+	allower := newAllowerContext(r)
 	for _, event := range events {
 		// Check if the event is allowed based on the current partial state. If the
 		// event isn't allowed then simply ignore it and process the next one.
-		if err := allower.Allowed(event); err != nil {
+		if err := allower.allowed(event); err != nil {
 			continue
 		}
 		// Apply the newly authed event to the partial state. We need to do this

--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -212,6 +212,13 @@ func TestStateResolutionBase(t *testing.T) {
 	runStateResolutionV2(t, []*Event{}, expected)
 }
 
+func BenchmarkStateResolutionBanVsPowerLevel(b *testing.B) {
+	t := &testing.T{}
+	for i := 0; i < b.N; i++ {
+		TestStateResolutionBanVsPowerLevel(t)
+	}
+}
+
 func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 	expected := []string{
 		"$CREATE:example.com", "$IJR:example.com", "$PA:example.com",


### PR DESCRIPTION
This improves state resolution v2 performance quite dramatically in large rooms when authing and applying events by reducing the number of times that we parse the content of the create, power levels and join rule events from the auth event provider.