### PR TITLE
Use intermediate step for RespSendJoin to drop invalid events

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -116,6 +116,9 @@ func (ac *FederationClient) SendJoin(
 		Origin      ServerName        `json:"origin"`
 	}
 	process := func() {
+		res.StateEvents = make([]*Event, 0, len(intermediate.StateEvents))
+		res.AuthEvents = make([]*Event, 0, len(intermediate.AuthEvents))
+		res.Origin = intermediate.Origin
 		for _, se := range intermediate.StateEvents {
 			if ev, err := NewEventFromUntrustedJSON(se, roomVersion); err == nil {
 				res.StateEvents = append(res.StateEvents, ev)
@@ -127,7 +130,6 @@ func (ac *FederationClient) SendJoin(
 			}
 		}
 	}
-	res.Origin = intermediate.Origin
 	if err = ac.doRequest(ctx, req, &intermediate); err == nil {
 		process()
 	}

--- a/federationclient.go
+++ b/federationclient.go
@@ -146,7 +146,7 @@ func (ac *FederationClient) SendJoin(
 		var v1Res []json.RawMessage
 		err = ac.doRequest(ctx, v1req, &v1Res)
 		if err == nil && len(v1Res) == 2 {
-			if err = json.Unmarshal(v1Res[1], &res); err != nil {
+			if err = json.Unmarshal(v1Res[1], &intermediate); err != nil {
 				return
 			}
 			process()


### PR DESCRIPTION
This should fix matrix-org/dendrite#1927. 