### PR TITLE
Return concrete error type for unsupported room version 

### DIFF
--- a/event.go
+++ b/event.go
@@ -158,6 +158,12 @@ func (eb *EventBuilder) Build(
 	now time.Time, origin ServerName, keyID KeyID,
 	privateKey ed25519.PrivateKey, roomVersion RoomVersion,
 ) (result *Event, err error) {
+	if ver, ok := SupportedRoomVersions()[roomVersion]; !ok || !ver.Supported {
+		return nil, UnsupportedRoomVersionError{
+			Version: roomVersion,
+		}
+	}
+
 	eventFormat, err := roomVersion.EventFormat()
 	if err != nil {
 		return result, err
@@ -278,6 +284,12 @@ func (eb *EventBuilder) Build(
 // It also checks the content hashes to ensure the event has not been tampered with.
 // This should be used when receiving new events from remote servers.
 func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (result *Event, err error) {
+	if ver, ok := SupportedRoomVersions()[roomVersion]; !ok || !ver.Supported {
+		return nil, UnsupportedRoomVersionError{
+			Version: roomVersion,
+		}
+	}
+
 	if r := gjson.GetBytes(eventJSON, "_*"); r.Exists() {
 		err = fmt.Errorf("gomatrixserverlib NewEventFromUntrustedJSON: %w", UnexpectedHeaderedEvent{})
 		return
@@ -357,6 +369,12 @@ func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (resul
 // This will be more efficient than NewEventFromUntrustedJSON since it can skip cryptographic checks.
 // This can be used when loading matrix events from a local database.
 func NewEventFromTrustedJSON(eventJSON []byte, redacted bool, roomVersion RoomVersion) (result *Event, err error) {
+	if ver, ok := SupportedRoomVersions()[roomVersion]; !ok || !ver.Supported {
+		return nil, UnsupportedRoomVersionError{
+			Version: roomVersion,
+		}
+	}
+
 	result = &Event{}
 	result.roomVersion = roomVersion
 	result.redacted = redacted
@@ -370,6 +388,12 @@ func NewEventFromTrustedJSON(eventJSON []byte, redacted bool, roomVersion RoomVe
 // This will be more efficient than NewEventFromTrustedJSON since, if the event
 // ID is known, we skip all the reference hash and canonicalisation work.
 func NewEventFromTrustedJSONWithEventID(eventID string, eventJSON []byte, redacted bool, roomVersion RoomVersion) (result *Event, err error) {
+	if ver, ok := SupportedRoomVersions()[roomVersion]; !ok || !ver.Supported {
+		return nil, UnsupportedRoomVersionError{
+			Version: roomVersion,
+		}
+	}
+
 	result = &Event{}
 	result.roomVersion = roomVersion
 	result.redacted = redacted

--- a/invitev2.go
+++ b/invitev2.go
@@ -13,8 +13,10 @@ import (
 func NewInviteV2Request(event *HeaderedEvent, state []InviteV2StrippedState) (
 	request InviteV2Request, err error,
 ) {
-	if event.RoomVersion == "" {
-		err = errors.New("gomatrixserverlib: missing room version from event header")
+	if ver, ok := SupportedRoomVersions()[event.RoomVersion]; !ok || !ver.Supported {
+		err = UnsupportedRoomVersionError{
+			Version: event.RoomVersion,
+		}
 		return
 	}
 	request.fields.inviteV2RequestHeaders = inviteV2RequestHeaders{
@@ -53,8 +55,10 @@ func (i *InviteV2Request) UnmarshalJSON(data []byte) error {
 	if !eventJSON.Exists() {
 		return errors.New("gomatrixserverlib: request doesn't contain event")
 	}
-	if i.fields.RoomVersion == "" {
-		return errors.New("gomatrixserverlib: missing room version from event header")
+	if ver, ok := SupportedRoomVersions()[i.fields.RoomVersion]; !ok || !ver.Supported {
+		return UnsupportedRoomVersionError{
+			Version: i.fields.RoomVersion,
+		}
 	}
 	i.fields.Event, err = NewEventFromUntrustedJSON([]byte(eventJSON.String()), i.fields.RoomVersion)
 	return err


### PR DESCRIPTION
This should make matrix-org/dendrite#1930 much simpler because then we can just try to type-cast the error to `gomatrixserverlib.UnsupportedRoomVersionError`.

It also adds the check to the various `NewEvent` functions for good measure.