### PR TITLE
Cross-signing types, `Base64Types` updates

### DIFF
--- a/base64.go
+++ b/base64.go
@@ -58,10 +58,11 @@ func (b64 *Base64Bytes) Scan(src interface{}) error {
 	case string:
 		return b64.Decode(v)
 	case []byte:
-		*b64 = append([]byte{}, v...)
+		new := append(Base64Bytes{}, v...)
+		b64 = &new
 		return nil
 	case RawJSON:
-		return json.Unmarshal(v, b64)
+		return b64.UnmarshalJSON(v)
 	default:
 		return fmt.Errorf("unsupported source type")
 	}

--- a/base64.go
+++ b/base64.go
@@ -57,6 +57,11 @@ func (b64 *Base64Bytes) Scan(src interface{}) error {
 	switch v := src.(type) {
 	case string:
 		return b64.Decode(v)
+	case []byte:
+		*b64 = append([]byte{}, v...)
+		return nil
+	case RawJSON:
+		return json.Unmarshal(v, b64)
 	default:
 		return fmt.Errorf("unsupported source type")
 	}

--- a/base64.go
+++ b/base64.go
@@ -16,6 +16,7 @@
 package gomatrixserverlib
 
 import (
+	"database/sql/driver"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -56,12 +57,14 @@ func (b64 *Base64Bytes) Scan(src interface{}) error {
 	switch v := src.(type) {
 	case string:
 		return b64.Decode(v)
-	case []byte:
-		*b64 = append(Base64Bytes{}, v...)
-		return nil
 	default:
 		return fmt.Errorf("unsupported source type")
 	}
+}
+
+// Implements sql.Valuer
+func (b64 *Base64Bytes) Value() (driver.Value, error) {
+	return b64.Encode(), nil
 }
 
 // MarshalJSON encodes the bytes as base64 and then encodes the base64 as a JSON string.

--- a/base64.go
+++ b/base64.go
@@ -63,7 +63,7 @@ func (b64 *Base64Bytes) Scan(src interface{}) error {
 }
 
 // Implements sql.Valuer
-func (b64 *Base64Bytes) Value() (driver.Value, error) {
+func (b64 Base64Bytes) Value() (driver.Value, error) {
 	return b64.Encode(), nil
 }
 

--- a/base64_test.go
+++ b/base64_test.go
@@ -150,3 +150,20 @@ func TestUnmarshalYAMLBase64Struct(t *testing.T) {
 		t.Fatalf("yaml.Unmarshal(%v): wanted %q got %q", input, want, result)
 	}
 }
+
+func TestScanBase64(t *testing.T) {
+	str := "PHq54MtxJxVcavizqxvFZ4E4Xd2GpWJYg6wCVs7DamA"
+	bya := []byte(str)
+	itg := 3
+
+	var b Base64Bytes
+	if err := b.Scan(str); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Scan(bya); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Scan(itg); err == nil {
+		t.Fatal("should have failed")
+	}
+}

--- a/base64_test.go
+++ b/base64_test.go
@@ -16,6 +16,7 @@
 package gomatrixserverlib
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -152,18 +153,37 @@ func TestUnmarshalYAMLBase64Struct(t *testing.T) {
 }
 
 func TestScanBase64(t *testing.T) {
-	str := "PHq54MtxJxVcavizqxvFZ4E4Xd2GpWJYg6wCVs7DamA"
-	bya := []byte(str)
-	itg := 3
+	expecting := Base64Bytes("This is a test string")
+
+	inputStr := "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n"
+	inputJSON := RawJSON(`"` + inputStr + `"`)
+	inputBytes := []byte(inputStr)
+	inputInt := 3
 
 	var b Base64Bytes
-	if err := b.Scan(str); err != nil {
+
+	if err := b.Scan(inputStr); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Scan(bya); err != nil {
+	if !bytes.Equal(expecting, b) {
+		t.Fatalf("scanning from string failed, got %v, wanted %v", b, expecting)
+	}
+
+	if err := b.Scan(inputJSON); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Scan(itg); err == nil {
-		t.Fatal("should have failed")
+	if !bytes.Equal(expecting, b) {
+		t.Fatalf("scanning from RawJSON failed, got %v, wanted %v", b, expecting)
+	}
+
+	if err := b.Scan(inputBytes); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(expecting, b) {
+		t.Fatalf("scanning from []byte failed, got %v, wanted %v", b, expecting)
+	}
+
+	if err := b.Scan(inputInt); err == nil {
+		t.Fatal("scanning from int should have failed but didn't")
 	}
 }

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -54,7 +54,7 @@ type CrossSigningForKeyOrDevice struct {
 
 // Implements json.Unmarshaler
 func (c *CrossSigningForKeyOrDevice) UnmarshalJSON(b []byte) error {
-	if gjson.Get(string(b), "device_id").Exists() {
+	if gjson.GetBytes(b, "device_id").Exists() {
 		body := &DeviceKeys{}
 		if err := json.Unmarshal(b, body); err != nil {
 			return err

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -1,0 +1,51 @@
+// Copyright 2021 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomatrixserverlib
+
+// CrossSigningBody represents either of the concrete types CrossSingingKeys or CrossSigningSignatures
+type CrossSigningBody interface {
+	isCrossSigningBody()
+}
+
+// https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0keysdevice_signingupload
+
+type CrossSigningKeys struct {
+	MasterKey      CrossSigningKey `json:"master_key"`
+	SelfSigningKey CrossSigningKey `json:"self_signing_key"`
+	UserSigningKey CrossSigningKey `json:"user_signing_key"`
+}
+
+type CrossSigningKey struct {
+	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures"`
+	Keys       map[KeyID]Base64Bytes            `json:"keys"`
+	Usage      []string                         `json:"usage"`
+	UserID     string                           `json:"user_id"`
+}
+
+func (s *CrossSigningKey) isCrossSigningBody() {} // implements CrossSigningBody
+
+// https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0keyssignaturesupload
+
+type CrossSigningSignatures map[string]map[string]CrossSigningBody // user ID -> device ID -> key or signature
+
+type CrossSigningSignature struct {
+	Algorithms []string                         `json:"algorithms"`
+	UserID     string                           `json:"user_id"`
+	DeviceID   string                           `json:"device_id"`
+	Keys       map[KeyID]Base64Bytes            `json:"keys"`
+	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures"`
+}
+
+func (s *CrossSigningSignature) isCrossSigningBody() {} // implements CrossSigningBody

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -67,8 +67,16 @@ type CrossSigningForKeyOrDevice struct {
 func (c *CrossSigningForKeyOrDevice) UnmarshalJSON(b []byte) error {
 	if gjson.Get(string(b), "device_id").Exists() {
 		body := &CrossSigningForDevice{}
-		return json.Unmarshal(b, body)
+		if err := json.Unmarshal(b, body); err != nil {
+			return err
+		}
+		c.CrossSigningBody = body
+		return nil
 	}
 	body := &CrossSigningForKey{}
-	return json.Unmarshal(b, body)
+	if err := json.Unmarshal(b, body); err != nil {
+		return err
+	}
+	c.CrossSigningBody = body
+	return nil
 }

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -28,7 +28,7 @@ type CrossSigningKeys struct {
 }
 
 type CrossSigningKey struct {
-	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures"`
+	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
 	Keys       map[KeyID]Base64Bytes            `json:"keys"`
 	Usage      []string                         `json:"usage"`
 	UserID     string                           `json:"user_id"`
@@ -45,7 +45,7 @@ type CrossSigningSignature struct {
 	UserID     string                           `json:"user_id"`
 	DeviceID   string                           `json:"device_id"`
 	Keys       map[KeyID]Base64Bytes            `json:"keys"`
-	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures"`
+	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
 }
 
 func (s *CrossSigningSignature) isCrossSigningBody() {} // implements CrossSigningBody

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -22,38 +22,25 @@ const (
 	CrossSigningKeyPurposeUserSigning CrossSigningKeyPurpose = "user_signing"
 )
 
-// CrossSigningBody represents either of the concrete types CrossSingingKeys or CrossSigningSignatures
-type CrossSigningBody interface {
-	isCrossSigningBody()
+type CrossSigningKeys struct {
+	MasterKey      CrossSigningForKey `json:"master_key"`
+	SelfSigningKey CrossSigningForKey `json:"self_signing_key"`
+	UserSigningKey CrossSigningForKey `json:"user_signing_key"`
 }
 
 // https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0keysdevice_signingupload
-
-type CrossSigningKeys struct {
-	MasterKey      CrossSigningKey `json:"master_key"`
-	SelfSigningKey CrossSigningKey `json:"self_signing_key"`
-	UserSigningKey CrossSigningKey `json:"user_signing_key"`
-}
-
-type CrossSigningKey struct {
+type CrossSigningForKey struct {
 	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
 	Keys       map[KeyID]Base64Bytes            `json:"keys"`
 	Usage      []CrossSigningKeyPurpose         `json:"usage"`
 	UserID     string                           `json:"user_id"`
 }
 
-func (s *CrossSigningKey) isCrossSigningBody() {} // implements CrossSigningBody
-
 // https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0keyssignaturesupload
-
-type CrossSigningSignatures map[string]map[string]CrossSigningBody // user ID -> device ID -> key or signature
-
-type CrossSigningSignature struct {
+type CrossSigningForDevice struct {
 	Algorithms []string                         `json:"algorithms"`
 	UserID     string                           `json:"user_id"`
 	DeviceID   string                           `json:"device_id"`
 	Keys       map[KeyID]Base64Bytes            `json:"keys"`
 	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
 }
-
-func (s *CrossSigningSignature) isCrossSigningBody() {} // implements CrossSigningBody

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -14,6 +14,14 @@
 
 package gomatrixserverlib
 
+type CrossSigningKeyPurpose string
+
+const (
+	CrossSigningKeyPurposeMaster      CrossSigningKeyPurpose = "master"
+	CrossSigningKeyPurposeSelfSigning CrossSigningKeyPurpose = "self_signing"
+	CrossSigningKeyPurposeUserSigning CrossSigningKeyPurpose = "user_signing"
+)
+
 // CrossSigningBody represents either of the concrete types CrossSingingKeys or CrossSigningSignatures
 type CrossSigningBody interface {
 	isCrossSigningBody()
@@ -30,7 +38,7 @@ type CrossSigningKeys struct {
 type CrossSigningKey struct {
 	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
 	Keys       map[KeyID]Base64Bytes            `json:"keys"`
-	Usage      []string                         `json:"usage"`
+	Usage      []CrossSigningKeyPurpose         `json:"usage"`
 	UserID     string                           `json:"user_id"`
 }
 

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -29,31 +29,20 @@ const (
 )
 
 type CrossSigningKeys struct {
-	MasterKey      CrossSigningForKey `json:"master_key"`
-	SelfSigningKey CrossSigningForKey `json:"self_signing_key"`
-	UserSigningKey CrossSigningForKey `json:"user_signing_key"`
+	MasterKey      CrossSigningKey `json:"master_key"`
+	SelfSigningKey CrossSigningKey `json:"self_signing_key"`
+	UserSigningKey CrossSigningKey `json:"user_signing_key"`
 }
 
 // https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0keysdevice_signingupload
-type CrossSigningForKey struct {
+type CrossSigningKey struct {
 	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
 	Keys       map[KeyID]Base64Bytes            `json:"keys"`
 	Usage      []CrossSigningKeyPurpose         `json:"usage"`
 	UserID     string                           `json:"user_id"`
 }
 
-func (s *CrossSigningForKey) isCrossSigningBody() {} // implements CrossSigningBody
-
-// https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0keyssignaturesupload
-type CrossSigningForDevice struct {
-	Algorithms []string                         `json:"algorithms"`
-	UserID     string                           `json:"user_id"`
-	DeviceID   string                           `json:"device_id"`
-	Keys       map[KeyID]Base64Bytes            `json:"keys"`
-	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
-}
-
-func (s *CrossSigningForDevice) isCrossSigningBody() {} // implements CrossSigningBody
+func (s *CrossSigningKey) isCrossSigningBody() {} // implements CrossSigningBody
 
 type CrossSigningBody interface {
 	isCrossSigningBody()
@@ -66,14 +55,14 @@ type CrossSigningForKeyOrDevice struct {
 // Implements json.Unmarshaler
 func (c *CrossSigningForKeyOrDevice) UnmarshalJSON(b []byte) error {
 	if gjson.Get(string(b), "device_id").Exists() {
-		body := &CrossSigningForDevice{}
+		body := &DeviceKeys{}
 		if err := json.Unmarshal(b, body); err != nil {
 			return err
 		}
 		c.CrossSigningBody = body
 		return nil
 	}
-	body := &CrossSigningForKey{}
+	body := &CrossSigningKey{}
 	if err := json.Unmarshal(b, body); err != nil {
 		return err
 	}

--- a/crosssigning.go
+++ b/crosssigning.go
@@ -68,8 +68,7 @@ func (c *CrossSigningForKeyOrDevice) UnmarshalJSON(b []byte) error {
 	if gjson.Get(string(b), "device_id").Exists() {
 		body := &CrossSigningForDevice{}
 		return json.Unmarshal(b, body)
-	} else {
-		body := &CrossSigningForDevice{}
-		return json.Unmarshal(b, body)
 	}
+	body := &CrossSigningForKey{}
+	return json.Unmarshal(b, body)
 }

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -2,6 +2,7 @@ package gomatrixserverlib
 
 import (
 	"context"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -885,6 +886,22 @@ type DeviceKeys struct {
 	// Additional data added to the device key information by intermediate servers, and not covered by the signatures.
 	// E.g { "device_display_name": "Alice's mobile phone" }
 	Unsigned map[string]interface{} `json:"unsigned"`
+}
+
+func (s *DeviceKeys) isCrossSigningBody() {} // implements CrossSigningBody
+
+func (s *DeviceKeys) Scan(src interface{}) error {
+	switch v := src.(type) {
+	case string:
+		return json.Unmarshal([]byte(v), s)
+	case []byte:
+		return json.Unmarshal(v, s)
+	}
+	return fmt.Errorf("unsupported source type")
+}
+
+func (s DeviceKeys) Value() (driver.Value, error) {
+	return json.Marshal(s)
 }
 
 // MSC2836EventRelationshipsRequest is a request to /event_relationships from

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -244,11 +244,11 @@ type RespUserDeviceKeys struct {
 	DeviceID   string   `json:"device_id"`
 	Algorithms []string `json:"algorithms"`
 	// E.g "curve25519:JLAFKJWSCS": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI"
-	Keys map[string]string `json:"keys"`
+	Keys map[KeyID]Base64Bytes `json:"keys"`
 	// E.g "@alice:example.com": {
 	//	"ed25519:JLAFKJWSCS": "dSO80A01XiigH3uBiDVx/EjzaoycHcjq9lfQX0uWsqxl2giMIiSPR8a4d291W1ihKJL/a+myXS367WT6NAIcBA"
 	// }
-	Signatures map[string]map[string]string `json:"signatures"`
+	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures"`
 }
 
 // UnmarshalJSON implements json.Unmarshaller

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -874,7 +874,9 @@ type RespClaimKeys struct {
 
 // RespQueryKeys is the response for https://matrix.org/docs/spec/server_server/latest#post-matrix-federation-v1-user-keys-query
 type RespQueryKeys struct {
-	DeviceKeys map[string]map[string]DeviceKeys `json:"device_keys"`
+	DeviceKeys      map[string]map[string]DeviceKeys                `json:"device_keys"`
+	MasterKeys      map[string]map[KeyID]CrossSigningForKeyOrDevice `json:"master_keys"`
+	SelfSigningKeys map[string]map[KeyID]CrossSigningForKeyOrDevice `json:"self_signing_keys"`
 }
 
 // DeviceKeys as per https://matrix.org/docs/spec/server_server/latest#post-matrix-federation-v1-user-keys-query

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -874,9 +874,9 @@ type RespClaimKeys struct {
 
 // RespQueryKeys is the response for https://matrix.org/docs/spec/server_server/latest#post-matrix-federation-v1-user-keys-query
 type RespQueryKeys struct {
-	DeviceKeys      map[string]map[string]DeviceKeys                `json:"device_keys"`
-	MasterKeys      map[string]map[KeyID]CrossSigningForKeyOrDevice `json:"master_keys"`
-	SelfSigningKeys map[string]map[KeyID]CrossSigningForKeyOrDevice `json:"self_signing_keys"`
+	DeviceKeys      map[string]map[string]DeviceKeys      `json:"device_keys"`
+	MasterKeys      map[string]CrossSigningForKeyOrDevice `json:"master_keys"`
+	SelfSigningKeys map[string]CrossSigningForKeyOrDevice `json:"self_signing_keys"`
 }
 
 // DeviceKeys as per https://matrix.org/docs/spec/server_server/latest#post-matrix-federation-v1-user-keys-query


### PR DESCRIPTION
This includes some types for cross-signing, as well as the ability to marshal unmarshal `Base64Bytes` to/from a database.