### PR TITLE
Refactor `SignJSON`, preserve signatures in `EventBuilder`

### DIFF
--- a/event.go
+++ b/event.go
@@ -259,8 +259,10 @@ func (eb *EventBuilder) Build(
 		return
 	}
 
-	if eventJSON, err = sjson.SetBytes(eventJSON, "signatures", event.Signatures); err != nil {
-		return
+	if len(event.Signatures) > 0 {
+		if eventJSON, err = sjson.SetBytes(eventJSON, "signatures", event.Signatures); err != nil {
+			return
+		}
 	}
 
 	if eventJSON, err = signEvent(string(origin), keyID, privateKey, eventJSON, roomVersion); err != nil {

--- a/event.go
+++ b/event.go
@@ -88,7 +88,7 @@ type EventBuilder struct {
 	// The depth of the event, This should be one greater than the maximum depth of the previous events.
 	// The create event has a depth of 1.
 	Depth int64 `json:"depth"`
-	// The JSON object for "signature" key of the event.
+	// The JSON object for "signatures" key of the event.
 	Signature RawJSON `json:"signatures,omitempty"`
 	// The JSON object for "content" key of the event.
 	Content RawJSON `json:"content"`

--- a/event.go
+++ b/event.go
@@ -88,8 +88,8 @@ type EventBuilder struct {
 	// The depth of the event, This should be one greater than the maximum depth of the previous events.
 	// The create event has a depth of 1.
 	Depth int64 `json:"depth"`
-	// The JSON object for "signatures" key of the event.
-	Signatures RawJSON `json:"signatures,omitempty"`
+	// The JSON object for "signature" key of the event.
+	Signature RawJSON `json:"signatures,omitempty"`
 	// The JSON object for "content" key of the event.
 	Content RawJSON `json:"content"`
 	// The JSON object for the "unsigned" key
@@ -257,15 +257,6 @@ func (eb *EventBuilder) Build(
 
 	if eventJSON, err = addContentHashesToEvent(eventJSON); err != nil {
 		return
-	}
-
-	// Preserve existing signatures from other servers. Necessary for
-	// restricted joins to work, since we unmarshal the make_join
-	// response straight into an EventBuilder.
-	if len(event.Signatures) > 0 {
-		if eventJSON, err = sjson.SetRawBytes(eventJSON, "signatures", event.Signatures); err != nil {
-			return
-		}
 	}
 
 	if eventJSON, err = signEvent(string(origin), keyID, privateKey, eventJSON, roomVersion); err != nil {

--- a/event.go
+++ b/event.go
@@ -88,8 +88,8 @@ type EventBuilder struct {
 	// The depth of the event, This should be one greater than the maximum depth of the previous events.
 	// The create event has a depth of 1.
 	Depth int64 `json:"depth"`
-	// The previous signatures of the event.
-	Signatures RawJSON `json:"signatures"`
+	// The JSON object for "signatures" key of the event.
+	Signatures RawJSON `json:"signatures,omitempty"`
 	// The JSON object for "content" key of the event.
 	Content RawJSON `json:"content"`
 	// The JSON object for the "unsigned" key
@@ -259,8 +259,11 @@ func (eb *EventBuilder) Build(
 		return
 	}
 
+	// Preserve existing signatures from other servers. Necessary for
+	// restricted joins to work, since we unmarshal the make_join
+	// response straight into an EventBuilder.
 	if len(event.Signatures) > 0 {
-		if eventJSON, err = sjson.SetBytes(eventJSON, "signatures", event.Signatures); err != nil {
+		if eventJSON, err = sjson.SetRawBytes(eventJSON, "signatures", event.Signatures); err != nil {
 			return
 		}
 	}

--- a/event.go
+++ b/event.go
@@ -88,6 +88,8 @@ type EventBuilder struct {
 	// The depth of the event, This should be one greater than the maximum depth of the previous events.
 	// The create event has a depth of 1.
 	Depth int64 `json:"depth"`
+	// The previous signatures of the event.
+	Signatures RawJSON `json:"signatures"`
 	// The JSON object for "content" key of the event.
 	Content RawJSON `json:"content"`
 	// The JSON object for the "unsigned" key
@@ -254,6 +256,10 @@ func (eb *EventBuilder) Build(
 	}
 
 	if eventJSON, err = addContentHashesToEvent(eventJSON); err != nil {
+		return
+	}
+
+	if eventJSON, err = sjson.SetBytes(eventJSON, "signatures", event.Signatures); err != nil {
 		return
 	}
 

--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -142,6 +142,7 @@ func addContentHashesToEvent(eventJSON []byte) ([]byte, error) {
 	}
 
 	unsignedJSON := event["unsigned"]
+	signatures := event["signatures"]
 
 	delete(event, "signatures")
 	delete(event, "unsigned")
@@ -168,6 +169,9 @@ func addContentHashesToEvent(eventJSON []byte) ([]byte, error) {
 
 	if len(unsignedJSON) > 0 {
 		event["unsigned"] = unsignedJSON
+	}
+	if len(signatures) > 0 {
+		event["signatures"] = signatures
 	}
 	event["hashes"] = RawJSON(hashesJSON)
 
@@ -267,7 +271,6 @@ func referenceOfEvent(eventJSON []byte, roomVersion RoomVersion) (EventReference
 
 // SignEvent adds a ED25519 signature to the event for the given key.
 func signEvent(signingName string, keyID KeyID, privateKey ed25519.PrivateKey, eventJSON []byte, roomVersion RoomVersion) ([]byte, error) {
-
 	// Redact the event before signing so signature that will remain valid even if the event is redacted.
 	redactedJSON, err := redactEvent(eventJSON, roomVersion)
 	if err != nil {


### PR DESCRIPTION
This PR refactors `SignJSON` to just be so much less of a mess by using `gjson`/`sjson` instead, and also ensures that old signatures are preserved when we unmarshal an event into an `EventBuilder`. 