### PR TITLE
MSC3667 implementation

### DIFF
--- a/event.go
+++ b/event.go
@@ -978,11 +978,11 @@ func (e *Event) PowerLevels() (*PowerLevelContent, error) {
 	if !e.StateKeyEquals("") {
 		return nil, fmt.Errorf("gomatrixserverlib: PowerLevels() event is not a m.room.power_levels event, bad state key")
 	}
-	var content PowerLevelContent
-	if err := e.extractContent(MRoomPowerLevels, &content); err != nil {
+	c, err := NewPowerLevelContentFromEvent(e)
+	if err != nil {
 		return nil, err
 	}
-	return &content, nil
+	return &c, nil
 }
 
 // AuthEvents returns references to the events needed to auth the event.

--- a/eventcontent_test.go
+++ b/eventcontent_test.go
@@ -70,3 +70,21 @@ func TestLevelJSONValueInvalid(t *testing.T) {
 		}
 	}
 }
+
+func TestStrictPowerLevelContent(t *testing.T) {
+	eventJSON := `{"content":{"ban":50,"events":{"m.room.avatar":50,"m.room.canonical_alias":50,"m.room.encryption":100,"m.room.history_visibility":100,"m.room.name":50,"m.room.power_levels":100,"m.room.server_acl":100,"m.room.tombstone":100},"events_default":0,"historical":100,"invite":0,"kick":50,"redact":50,"state_default":50,"users":{"@neilalexander:matrix.org":"100"},"users_default":0},"origin_server_ts":1643017369993,"sender":"@neilalexander:matrix.org","state_key":"","type":"m.room.power_levels","unsigned":{"age":592},"event_id":"$2CT2RSF8B4XJyysh7i6Zdw0oYSs53JkIhTMrapIVYnw","room_id":"!CeUyQRqMxuBnjcxiIr:matrix.org"}`
+	goodEvent, err := NewEventFromTrustedJSON([]byte(eventJSON), false, RoomVersionV7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	badEvent, err := NewEventFromTrustedJSON([]byte(eventJSON), false, "org.matrix.msc3667")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := goodEvent.PowerLevels(); err != nil {
+		t.Fatalf("good content should not have errored but did: %s", err)
+	}
+	if _, err := badEvent.PowerLevels(); err == nil {
+		t.Fatal("bad content should have errored but didn't")
+	}
+}

--- a/eventcontent_test.go
+++ b/eventcontent_test.go
@@ -72,6 +72,9 @@ func TestLevelJSONValueInvalid(t *testing.T) {
 }
 
 func TestStrictPowerLevelContent(t *testing.T) {
+	// The event JSON has a "100" instead of a 100 in the power level. In
+	// room version 7, this is permissible, but it isn't in our new experimental
+	// room version.
 	eventJSON := `{"content":{"ban":50,"events":{"m.room.avatar":50,"m.room.canonical_alias":50,"m.room.encryption":100,"m.room.history_visibility":100,"m.room.name":50,"m.room.power_levels":100,"m.room.server_acl":100,"m.room.tombstone":100},"events_default":0,"historical":100,"invite":0,"kick":50,"redact":50,"state_default":50,"users":{"@neilalexander:matrix.org":"100"},"users_default":0},"origin_server_ts":1643017369993,"sender":"@neilalexander:matrix.org","state_key":"","type":"m.room.power_levels","unsigned":{"age":592},"event_id":"$2CT2RSF8B4XJyysh7i6Zdw0oYSs53JkIhTMrapIVYnw","room_id":"!CeUyQRqMxuBnjcxiIr:matrix.org"}`
 	goodEvent, err := NewEventFromTrustedJSON([]byte(eventJSON), false, RoomVersionV7)
 	if err != nil {

--- a/eventversion.go
+++ b/eventversion.go
@@ -72,6 +72,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: false,
 		allowKnockingInEventAuth:        false,
 		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV2: {
 		Supported:                       true,
@@ -85,6 +86,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: false,
 		allowKnockingInEventAuth:        false,
 		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV3: {
 		Supported:                       true,
@@ -98,6 +100,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: false,
 		allowKnockingInEventAuth:        false,
 		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV4: {
 		Supported:                       true,
@@ -111,6 +114,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: false,
 		allowKnockingInEventAuth:        false,
 		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV5: {
 		Supported:                       true,
@@ -124,6 +128,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: false,
 		allowKnockingInEventAuth:        false,
 		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV6: {
 		Supported:                       true,
@@ -137,6 +142,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: true,
 		allowKnockingInEventAuth:        false,
 		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV7: {
 		Supported:                       true,
@@ -150,6 +156,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: true,
 		allowKnockingInEventAuth:        true,
 		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV8: {
 		Supported:                       true,
@@ -163,6 +170,7 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: true,
 		allowKnockingInEventAuth:        true,
 		allowRestrictedJoinsInEventAuth: true,
+		requireIntegerPowerLevels:       false,
 	},
 	RoomVersionV9: {
 		Supported:                       true,
@@ -176,6 +184,21 @@ var roomVersionMeta = map[RoomVersion]RoomVersionDescription{
 		powerLevelsIncludeNotifications: true,
 		allowKnockingInEventAuth:        true,
 		allowRestrictedJoinsInEventAuth: true,
+		requireIntegerPowerLevels:       false,
+	},
+	"org.matrix.msc3667": { // based on room version 7
+		Supported:                       true,
+		Stable:                          false,
+		stateResAlgorithm:               StateResV2,
+		eventFormat:                     EventFormatV2,
+		eventIDFormat:                   EventIDFormatV3,
+		redactionAlgorithm:              RedactionAlgorithmV2,
+		enforceSignatureChecks:          true,
+		enforceCanonicalJSON:            true,
+		powerLevelsIncludeNotifications: true,
+		allowKnockingInEventAuth:        true,
+		allowRestrictedJoinsInEventAuth: false,
+		requireIntegerPowerLevels:       true,
 	},
 }
 
@@ -231,6 +254,7 @@ type RoomVersionDescription struct {
 	powerLevelsIncludeNotifications bool
 	allowKnockingInEventAuth        bool
 	allowRestrictedJoinsInEventAuth bool
+	requireIntegerPowerLevels       bool
 	Supported                       bool
 	Stable                          bool
 }
@@ -308,6 +332,15 @@ func (v RoomVersion) AllowRestrictedJoinsInEventAuth() (bool, error) {
 func (v RoomVersion) EnforceCanonicalJSON() (bool, error) {
 	if r, ok := roomVersionMeta[v]; ok {
 		return r.enforceCanonicalJSON, nil
+	}
+	return false, UnsupportedRoomVersionError{v}
+}
+
+// RequireIntegerPowerLevels returns true if the given room version calls for
+// power levels as integers only, false otherwise.
+func (v RoomVersion) RequireIntegerPowerLevels() (bool, error) {
+	if r, ok := roomVersionMeta[v]; ok {
+		return r.requireIntegerPowerLevels, nil
 	}
 	return false, UnsupportedRoomVersionError{v}
 }


### PR DESCRIPTION
This is an implementation of matrix-org/matrix-doc#3667 to enforce that power levels are integers rather than accepting stringified equivalents. 

It works by adding a new proof-of-concept `org.matrix.msc3667` room version based on room version 7. Unmarshalling stringified power levels with this room version should fail outright.