### PR TITLE
Use contexts for well-known and DNS SRV lookups

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,7 +204,7 @@ retryResolution:
 	// If the cache returned nothing then we'll have no results here,
 	// so go and hit the network.
 	if len(resolutionResults) == 0 {
-		resolutionResults, err = f.client.ResolveServer(r.Context(), serverName)
+		resolutionResults, err = ResolveServer(r.Context(), serverName)
 		if err != nil {
 			return nil, err
 		}

--- a/resolve.go
+++ b/resolve.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 )
 
 // ResolutionResult is a result of looking up a Matrix homeserver according to
@@ -99,14 +100,27 @@ func resolveServer(ctx context.Context, serverName ServerName, checkWellKnown bo
 		}
 	}
 
-	return handleNoWellKnown(serverName), nil
+	return handleNoWellKnown(ctx, serverName), nil
+}
+
+// dnsResolver is a custom DNS resolver that allows us to use contexts and
+// strict timeout periods. This ensures we don't ever get wedged on a DNS
+// lookup request.
+var dnsResolver = net.Resolver{
+	PreferGo: true,
+	Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+		d := net.Dialer{
+			Timeout: time.Millisecond * time.Duration(10000),
+		}
+		return d.DialContext(ctx, network, address)
+	},
 }
 
 // handleNoWellKnown implements steps 4 and 5 of the resolution algorithm (as
 // well as 3.3 and 3.4)
-func handleNoWellKnown(serverName ServerName) (results []ResolutionResult) {
+func handleNoWellKnown(ctx context.Context, serverName ServerName) (results []ResolutionResult) {
 	// 4. If the /.well-known request resulted in an error response
-	_, records, err := net.LookupSRV("matrix", "tcp", string(serverName))
+	_, records, err := dnsResolver.LookupSRV(ctx, "matrix", "tcp", string(serverName))
 	if err == nil && len(records) > 0 {
 		for _, rec := range records {
 			// If the domain is a FQDN, remove the trailing dot at the end. This

--- a/resolve.go
+++ b/resolve.go
@@ -35,14 +35,14 @@ type ResolutionResult struct {
 // Returns a slice of ResolutionResult that can be used to send a federation
 // request to the server using a given server name.
 // Returns an error if the server name isn't valid.
-func (c *Client) ResolveServer(ctx context.Context, serverName ServerName) (results []ResolutionResult, err error) {
-	return c.resolveServer(ctx, serverName, true)
+func ResolveServer(ctx context.Context, serverName ServerName) (results []ResolutionResult, err error) {
+	return resolveServer(ctx, serverName, true)
 }
 
 // resolveServer does the same thing as ResolveServer, except it also requires
 // the checkWellKnown parameter, which indicates whether a .well-known file
 // should be looked up.
-func (c *Client) resolveServer(ctx context.Context, serverName ServerName, checkWellKnown bool) (results []ResolutionResult, err error) {
+func resolveServer(ctx context.Context, serverName ServerName, checkWellKnown bool) (results []ResolutionResult, err error) {
 	host, port, valid := ParseAndValidateServerName(serverName)
 	if !valid {
 		err = fmt.Errorf("Invalid server name")
@@ -92,10 +92,10 @@ func (c *Client) resolveServer(ctx context.Context, serverName ServerName, check
 	if checkWellKnown {
 		// 3. If the hostname is not an IP literal
 		var result *WellKnownResult
-		result, err = c.LookupWellKnown(ctx, serverName)
+		result, err = LookupWellKnown(ctx, serverName)
 		if err == nil {
 			// We don't want to check .well-known on the result
-			return c.resolveServer(ctx, result.NewAddress, false)
+			return resolveServer(ctx, result.NewAddress, false)
 		}
 	}
 

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -27,7 +28,10 @@ func assertCritical(t *testing.T, val, expected interface{}) {
 // If one of them doesn't match, or the resolution function returned with an
 // error, it aborts the current test.
 func testResolve(t *testing.T, serverName ServerName, destination, host, certName string) {
-	res, err := ResolveServer(serverName)
+	client := NewClient(
+		WithTransport(http.DefaultTransport),
+	)
+	res, err := client.ResolveServer(context.Background(), serverName)
 	assertCritical(t, err, nil)
 	assertCritical(t, len(res), 1)
 	assertCritical(t, res[0].Destination, destination)

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -28,10 +27,7 @@ func assertCritical(t *testing.T, val, expected interface{}) {
 // If one of them doesn't match, or the resolution function returned with an
 // error, it aborts the current test.
 func testResolve(t *testing.T, serverName ServerName, destination, host, certName string) {
-	client := NewClient(
-		WithTransport(http.DefaultTransport),
-	)
-	res, err := client.ResolveServer(context.Background(), serverName)
+	res, err := ResolveServer(context.Background(), serverName)
 	assertCritical(t, err, nil)
 	assertCritical(t, len(res), 1)
 	assertCritical(t, res[0].Destination, destination)

--- a/well_known.go
+++ b/well_known.go
@@ -41,7 +41,7 @@ func (c *Client) LookupWellKnown(ctx context.Context, serverNameType ServerName)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.DoHTTPRequest(ctx, req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/well_known.go
+++ b/well_known.go
@@ -1,6 +1,7 @@
 package gomatrixserverlib
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,7 +27,7 @@ type WellKnownResult struct {
 
 // LookupWellKnown looks up a well-known record for a matrix server. If one if
 // found, it returns the server to redirect to.
-func LookupWellKnown(serverNameType ServerName) (*WellKnownResult, error) {
+func (c *Client) LookupWellKnown(ctx context.Context, serverNameType ServerName) (*WellKnownResult, error) {
 	serverName := string(serverNameType)
 
 	// Handle ending "/"
@@ -35,7 +36,12 @@ func LookupWellKnown(serverNameType ServerName) (*WellKnownResult, error) {
 	wellKnownPath := "/.well-known/matrix/server"
 
 	// Request server's well-known record
-	resp, err := http.Get("https://" + serverName + wellKnownPath)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://"+serverName+wellKnownPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.DoHTTPRequest(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/well_known.go
+++ b/well_known.go
@@ -27,7 +27,7 @@ type WellKnownResult struct {
 
 // LookupWellKnown looks up a well-known record for a matrix server. If one if
 // found, it returns the server to redirect to.
-func (c *Client) LookupWellKnown(ctx context.Context, serverNameType ServerName) (*WellKnownResult, error) {
+func LookupWellKnown(ctx context.Context, serverNameType ServerName) (*WellKnownResult, error) {
 	serverName := string(serverNameType)
 
 	// Handle ending "/"
@@ -41,7 +41,7 @@ func (c *Client) LookupWellKnown(ctx context.Context, serverNameType ServerName)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This stops them from potentially wedging for aaaaages.