### PR TITLE
Trim whitespace from string power levels

### DIFF
--- a/eventcontent.go
+++ b/eventcontent.go
@@ -438,7 +438,7 @@ func (v *levelJSONValue) UnmarshalJSON(data []byte) error {
 			int64Value = int64(floatValue)
 		} else {
 			// If we managed to get a string, try parsing the string as an int.
-			int64Value, err = strconv.ParseInt(stringValue, 10, 64)
+			int64Value, err = strconv.ParseInt(strings.TrimSpace(stringValue), 10, 64)
 			if err != nil {
 				return err
 			}

--- a/eventcontent_test.go
+++ b/eventcontent_test.go
@@ -43,7 +43,9 @@ func BenchmarkLevelJSONValueString(b *testing.B) {
 
 func TestLevelJSONValueValid(t *testing.T) {
 	var values []levelJSONValue
-	input := `[0,"1",2.0]`
+	// thanks python: https://docs.python.org/3/library/functions.html#int
+	// "Optionally, the literal can be preceded by + or - (with no space in between) and surrounded by whitespace."
+	input := `[0,"1",2.0,"+3","  +4  "]`
 	if err := json.Unmarshal([]byte(input), &values); err != nil {
 		t.Fatal("Unexpected error unmarshalling ", input, ": ", err)
 	}


### PR DESCRIPTION
Python's [`int()`](https://docs.python.org/3/library/functions.html#int) function is ✨ s p e c i a l ✨ and means that string power levels can be padded with whitespace. We now trim this whitespace, which at least fixes joining Watercooler.