### PR TITLE
Add EventJSON and EventJSONs types

### DIFF
--- a/authstate.go
+++ b/authstate.go
@@ -55,14 +55,22 @@ func (p *FederatedStateProvider) StateBeforeEvent(ctx context.Context, roomVer R
 		return nil, err
 	}
 	if p.RememberAuthEvents {
-		for i := range res.AuthEvents {
-			p.AuthEventMap[res.AuthEvents[i].EventID()] = res.AuthEvents[i]
+		for _, js := range res.AuthEvents {
+			event, err := js.UntrustedEvent(roomVer)
+			if err != nil {
+				continue
+			}
+			p.AuthEventMap[event.EventID()] = event
 		}
 	}
 
 	result := make(map[string]*Event)
-	for i := range res.StateEvents {
-		result[res.StateEvents[i].EventID()] = res.StateEvents[i]
+	for _, js := range res.StateEvents {
+		event, err := js.UntrustedEvent(roomVer)
+		if err != nil {
+			continue
+		}
+		result[event.EventID()] = event
 	}
 	return result, nil
 }

--- a/federationclient.go
+++ b/federationclient.go
@@ -221,7 +221,7 @@ func (ac *FederationClient) SendInviteV2(
 		}
 		// assume v1 as per spec: https://matrix.org/docs/spec/server_server/latest#put-matrix-federation-v1-invite-roomid-eventid
 		// Servers which receive a v1 invite request must assume that the room version is either "1" or "2".
-		res = RespInviteV2{
+		res = RespInviteV2{ // nolint:gosimple
 			Event: resp.Event,
 		}
 	}

--- a/federationclient.go
+++ b/federationclient.go
@@ -100,9 +100,8 @@ func (ac *FederationClient) MakeJoin(
 // This is used to join a room the local server isn't a member of.
 // See https://matrix.org/docs/spec/server_server/unstable.html#joining-rooms
 func (ac *FederationClient) SendJoin(
-	ctx context.Context, s ServerName, event *Event, roomVersion RoomVersion,
+	ctx context.Context, s ServerName, event *Event,
 ) (res RespSendJoin, err error) {
-	res.roomVersion = roomVersion
 	path := federationPathPrefixV2 + "/send_join/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
@@ -110,29 +109,7 @@ func (ac *FederationClient) SendJoin(
 	if err = req.SetContent(event); err != nil {
 		return
 	}
-	var intermediate struct {
-		StateEvents []json.RawMessage `json:"state"`
-		AuthEvents  []json.RawMessage `json:"auth_chain"`
-		Origin      ServerName        `json:"origin"`
-	}
-	process := func() {
-		res.StateEvents = make([]*Event, 0, len(intermediate.StateEvents))
-		res.AuthEvents = make([]*Event, 0, len(intermediate.AuthEvents))
-		res.Origin = intermediate.Origin
-		for _, se := range intermediate.StateEvents {
-			if ev, err := NewEventFromUntrustedJSON(se, roomVersion); err == nil {
-				res.StateEvents = append(res.StateEvents, ev)
-			}
-		}
-		for _, ae := range intermediate.AuthEvents {
-			if ev, err := NewEventFromUntrustedJSON(ae, roomVersion); err == nil {
-				res.AuthEvents = append(res.AuthEvents, ev)
-			}
-		}
-	}
-	if err = ac.doRequest(ctx, req, &intermediate); err == nil {
-		process()
-	}
+	err = ac.doRequest(ctx, req, &res)
 	gerr, ok := err.(gomatrix.HTTPError)
 	if ok && gerr.Code == 404 {
 		// fallback to v1 which returns [200, body]
@@ -146,10 +123,7 @@ func (ac *FederationClient) SendJoin(
 		var v1Res []json.RawMessage
 		err = ac.doRequest(ctx, v1req, &v1Res)
 		if err == nil && len(v1Res) == 2 {
-			if err = json.Unmarshal(v1Res[1], &intermediate); err != nil {
-				return
-			}
-			process()
+			err = json.Unmarshal(v1Res[1], &res)
 		}
 	}
 	return
@@ -227,7 +201,6 @@ func (ac *FederationClient) SendInvite(
 func (ac *FederationClient) SendInviteV2(
 	ctx context.Context, s ServerName, request InviteV2Request,
 ) (res RespInviteV2, err error) {
-	res.roomVersion = request.RoomVersion()
 	event := request.Event()
 	path := federationPathPrefixV2 + "/invite/" +
 		url.PathEscape(event.RoomID()) + "/" +
@@ -249,8 +222,7 @@ func (ac *FederationClient) SendInviteV2(
 		// assume v1 as per spec: https://matrix.org/docs/spec/server_server/latest#put-matrix-federation-v1-invite-roomid-eventid
 		// Servers which receive a v1 invite request must assume that the room version is either "1" or "2".
 		res = RespInviteV2{
-			Event:       resp.Event,
-			roomVersion: RoomVersionV1,
+			Event: resp.Event,
 		}
 	}
 	return
@@ -280,7 +252,6 @@ func (ac *FederationClient) ExchangeThirdPartyInvite(
 func (ac *FederationClient) LookupState(
 	ctx context.Context, s ServerName, roomID, eventID string, roomVersion RoomVersion,
 ) (res RespState, err error) {
-	res.roomVersion = roomVersion
 	path := federationPathPrefixV1 + "/state/" +
 		url.PathEscape(roomID) +
 		"?event_id=" +
@@ -311,7 +282,6 @@ func (ac *FederationClient) LookupMissingEvents(
 	ctx context.Context, s ServerName, roomID string,
 	missing MissingEvents, roomVersion RoomVersion,
 ) (res RespMissingEvents, err error) {
-	res.roomVersion = roomVersion
 	path := federationPathPrefixV1 + "/get_missing_events/" +
 		url.PathEscape(roomID)
 	req := NewFederationRequest("POST", s, path)
@@ -481,7 +451,6 @@ func (ac *FederationClient) GetEvent(
 func (ac *FederationClient) GetEventAuth(
 	ctx context.Context, s ServerName, roomVersion RoomVersion, roomID, eventID string,
 ) (res RespEventAuth, err error) {
-	res.roomVersion = roomVersion
 	path := federationPathPrefixV1 + "/event_auth/" + url.PathEscape(roomID) + "/" + url.PathEscape(eventID)
 	req := NewFederationRequest("GET", s, path)
 	err = ac.doRequest(ctx, req, &res)
@@ -530,7 +499,6 @@ func (ac *FederationClient) Backfill(
 func (ac *FederationClient) MSC2836EventRelationships(
 	ctx context.Context, dst ServerName, r MSC2836EventRelationshipsRequest, roomVersion RoomVersion,
 ) (res MSC2836EventRelationshipsResponse, err error) {
-	res.roomVersion = roomVersion
 	path := "/_matrix/federation/unstable/event_relationships"
 	req := NewFederationRequest("POST", dst, path)
 	if err = req.SetContent(r); err != nil {

--- a/federationclient_test.go
+++ b/federationclient_test.go
@@ -32,7 +32,7 @@ func TestSendJoinFallback(t *testing.T) {
 	_, privateKey, _ := ed25519.GenerateKey(nil)
 	roomVer := gomatrixserverlib.RoomVersionV1
 	// we don't care about the actual contents, just that it ferries data across fine.
-	retEv := gomatrixserverlib.EventJSON(`{"auth_events":[],"content":{"creator":"@userid:baba.is.you"},"depth":0,"event_id":"$WCraVpPZe5TtHAqs:baba.is.you","hashes":{"sha256":"EehWNbKy+oDOMC0vIvYl1FekdDxMNuabXKUVzV7DG74"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"08aF4/bYWKrdGPFdXmZCQU6IrOE1ulpevmWBM3kiShJPAbRbZ6Awk7buWkIxlMF6kX3kb4QpbAlZfHLQgncjCw"}},"state_key":"","type":"m.room.create"}`)
+	retEv := gomatrixserverlib.RawJSON(`{"auth_events":[],"content":{"creator":"@userid:baba.is.you"},"depth":0,"event_id":"$WCraVpPZe5TtHAqs:baba.is.you","hashes":{"sha256":"EehWNbKy+oDOMC0vIvYl1FekdDxMNuabXKUVzV7DG74"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"08aF4/bYWKrdGPFdXmZCQU6IrOE1ulpevmWBM3kiShJPAbRbZ6Awk7buWkIxlMF6kX3kb4QpbAlZfHLQgncjCw"}},"state_key":"","type":"m.room.create"}`)
 	wantRes := gomatrixserverlib.RespSendJoin{
 		StateEvents: gomatrixserverlib.EventJSONs{
 			retEv,
@@ -83,4 +83,67 @@ func TestSendJoinFallback(t *testing.T) {
 	if !reflect.DeepEqual(res.StateEvents, wantRes.StateEvents) {
 		t.Fatalf("SendJoin response got %+v want %+v", res.StateEvents, wantRes.StateEvents)
 	}
+}
+
+// The purpose of this test is to ensure that the federation client is capable of marshalling into
+// a RespSendJoin response type. This is mostly a sanity check that EventJSON and EventJSONs behave
+// correctly.
+func TestSendJoinJSON(t *testing.T) {
+	serverName := gomatrixserverlib.ServerName("local.server.name")
+	targetServerName := gomatrixserverlib.ServerName("target.server.name")
+	keyID := gomatrixserverlib.KeyID("ed25519:auto")
+	_, privateKey, _ := ed25519.GenerateKey(nil)
+	roomVer := gomatrixserverlib.RoomVersionV1
+	// we don't care about the actual contents, just that it ferries data across fine.
+	retEv := gomatrixserverlib.RawJSON(`{"auth_events":[],"content":{"creator":"@userid:baba.is.you"},"depth":0,"event_id":"$WCraVpPZe5TtHAqs:baba.is.you","hashes":{"sha256":"EehWNbKy+oDOMC0vIvYl1FekdDxMNuabXKUVzV7DG74"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"08aF4/bYWKrdGPFdXmZCQU6IrOE1ulpevmWBM3kiShJPAbRbZ6Awk7buWkIxlMF6kX3kb4QpbAlZfHLQgncjCw"}},"state_key":"","type":"m.room.create"}`)
+	respSendJoinResponseJSON := []byte(fmt.Sprintf(`{
+		"state": [%s],
+		"auth_chain": [%s]
+	}`, string(retEv), string(retEv)))
+
+	fc := gomatrixserverlib.NewFederationClient(
+		serverName, keyID, privateKey,
+		gomatrixserverlib.WithSkipVerify(true),
+	)
+	fc.Client = *gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(
+		&roundTripper{
+			fn: func(req *http.Request) (*http.Response, error) {
+				if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v2/send_join") {
+					t.Logf("Sending response: %s", string(respSendJoinResponseJSON))
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(bytes.NewReader(respSendJoinResponseJSON)),
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: 404,
+					Body:       ioutil.NopCloser(strings.NewReader("404 not found")),
+				}, nil
+			},
+		},
+	))
+	ev, err := gomatrixserverlib.NewEventFromTrustedJSON(
+		[]byte(`{"auth_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}]],"content":{"membership":"join"},"depth":1,"event_id":"$fnwGrQEpiOIUoDU2:baba.is.you","hashes":{"sha256":"DqOjdFgvFQ3V/jvQW2j3ygHL4D+t7/LaIPZ/tHTDZtI"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[["$WCraVpPZe5TtHAqs:baba.is.you",{"sha256":"gBxQI2xzDLMoyIjkrpCJFBXC5NnrSemepc7SninSARI"}]],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"qBWLb42zicQVsbh333YrcKpHfKokcUOM/ytldGlrgSdXqDEDDxvpcFlfadYnyvj3Z/GjA2XZkqKHanNEh575Bw"}},"state_key":"@userid:baba.is.you","type":"m.room.member"}`),
+		false, roomVer,
+	)
+	if err != nil {
+		t.Fatalf("failed to read event json: %s", err)
+	}
+	res, err := fc.SendJoin(context.Background(), targetServerName, ev)
+	if err != nil {
+		t.Fatalf("SendJoin returned an error: %s", err)
+	}
+	wantStateEvents := gomatrixserverlib.EventJSONs{[]byte(retEv)}
+	wantAuthChain := gomatrixserverlib.EventJSONs{[]byte(retEv)}
+	if !reflect.DeepEqual(res.StateEvents, wantStateEvents) {
+		t.Fatalf("SendJoin response got state %+v want %+v", jsonify(res.StateEvents), jsonify(wantStateEvents))
+	}
+	if !reflect.DeepEqual(res.AuthEvents, wantAuthChain) {
+		t.Fatalf("SendJoin response got auth %+v want %+v", jsonify(res.AuthEvents), jsonify(wantAuthChain))
+	}
+}
+
+func jsonify(x interface{}) string {
+	b, _ := json.Marshal(x)
+	return string(b)
 }

--- a/federationclient_test.go
+++ b/federationclient_test.go
@@ -32,15 +32,9 @@ func TestSendJoinFallback(t *testing.T) {
 	_, privateKey, _ := ed25519.GenerateKey(nil)
 	roomVer := gomatrixserverlib.RoomVersionV1
 	// we don't care about the actual contents, just that it ferries data across fine.
-	retEv, err := gomatrixserverlib.NewEventFromTrustedJSON(
-		[]byte(`{"auth_events":[],"content":{"creator":"@userid:baba.is.you"},"depth":0,"event_id":"$WCraVpPZe5TtHAqs:baba.is.you","hashes":{"sha256":"EehWNbKy+oDOMC0vIvYl1FekdDxMNuabXKUVzV7DG74"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"08aF4/bYWKrdGPFdXmZCQU6IrOE1ulpevmWBM3kiShJPAbRbZ6Awk7buWkIxlMF6kX3kb4QpbAlZfHLQgncjCw"}},"state_key":"","type":"m.room.create"}`),
-		false, roomVer,
-	)
-	if err != nil {
-		t.Fatalf("failed to marshal RespSendJoin event: %s", err)
-	}
+	retEv := gomatrixserverlib.EventJSON(`{"auth_events":[],"content":{"creator":"@userid:baba.is.you"},"depth":0,"event_id":"$WCraVpPZe5TtHAqs:baba.is.you","hashes":{"sha256":"EehWNbKy+oDOMC0vIvYl1FekdDxMNuabXKUVzV7DG74"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"08aF4/bYWKrdGPFdXmZCQU6IrOE1ulpevmWBM3kiShJPAbRbZ6Awk7buWkIxlMF6kX3kb4QpbAlZfHLQgncjCw"}},"state_key":"","type":"m.room.create"}`)
 	wantRes := gomatrixserverlib.RespSendJoin{
-		StateEvents: []*gomatrixserverlib.Event{
+		StateEvents: gomatrixserverlib.EventJSONs{
 			retEv,
 		},
 	}
@@ -82,7 +76,7 @@ func TestSendJoinFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read event json: %s", err)
 	}
-	res, err := fc.SendJoin(context.Background(), targetServerName, ev, roomVer)
+	res, err := fc.SendJoin(context.Background(), targetServerName, ev)
 	if err != nil {
 		t.Fatalf("SendJoin returned an error: %s", err)
 	}

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -433,19 +433,21 @@ func (r *RespState) Check(ctx context.Context, roomVersion RoomVersion, keyRing 
 	if f := len(failures); f > 0 {
 		logger.Warnf("Discarding %d auth/state event(s) due to invalid signatures", f)
 
-		for i := 0; i < len(r.AuthEvents); i++ {
+		for i := 0; i < len(authEvents); i++ {
 			if _, ok := failures[authEvents[i].EventID()]; ok {
-				r.AuthEvents = append(r.AuthEvents[:i], r.AuthEvents[i+1:]...)
+				authEvents = append(authEvents[:i], authEvents[i+1:]...)
 				i--
 			}
 		}
-		for i := 0; i < len(r.StateEvents); i++ {
+		for i := 0; i < len(stateEvents); i++ {
 			if _, ok := failures[stateEvents[i].EventID()]; ok {
-				r.StateEvents = append(r.StateEvents[:i], r.StateEvents[i+1:]...)
+				stateEvents = append(stateEvents[:i], stateEvents[i+1:]...)
 				i--
 			}
 		}
 	}
+	r.AuthEvents = NewEventJSONsFromEvents(authEvents)
+	r.StateEvents = NewEventJSONsFromEvents(stateEvents)
 
 	return nil
 }

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -279,7 +279,7 @@ func (r RespState) MarshalJSON() ([]byte, error) {
 	if len(r.AuthEvents) == 0 {
 		r.AuthEvents = EventJSONs{}
 	}
-	return json.Marshal(respStateFields{
+	return json.Marshal(respStateFields{ // nolint:gosimple
 		StateEvents: r.StateEvents,
 		AuthEvents:  r.AuthEvents,
 	})

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 )
 
 // A ServerName is the name a matrix homeserver is identified by.
@@ -704,7 +705,9 @@ func (r *RespInvite) UnmarshalJSON(data []byte) error {
 	if len(tuple) != 2 {
 		return fmt.Errorf("gomatrixserverlib: invalid invite response, invalid length: %d != 2", len(tuple))
 	}
-	r.Event = tuple[1]
+	if jr := gjson.GetBytes(tuple[1], "event"); jr.Exists() {
+		r.Event = []byte(jr.Raw)
+	}
 	return nil
 }
 

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -293,7 +293,15 @@ func (r RespState) MarshalJSON() ([]byte, error) {
 func (r RespState) Events(roomVersion RoomVersion) ([]*Event, error) {
 	authEvents := r.AuthEvents.UntrustedEvents(roomVersion)
 	stateEvents := r.StateEvents.UntrustedEvents(roomVersion)
+	return OrderAuthAndStateEvents(authEvents, stateEvents, roomVersion)
+}
 
+// OrderAuthAndStateEvents combines the auth events and the state events and returns
+// them in an order where every event comes after its auth events.
+// Each event will only appear once in the output list.
+// Returns an error if there are missing auth events or if there is
+// a cycle in the auth events.
+func OrderAuthAndStateEvents(authEvents, stateEvents []*Event, roomVersion RoomVersion) ([]*Event, error) {
 	// Collect a map of event reference to event
 	eventsByID := map[string]*Event{}
 	for i, event := range authEvents {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -681,7 +681,7 @@ func checkAllowedByAuthEvents(event *Event, eventsByID map[string]*Event, missin
 // RespInvite is the content of a response to PUT /_matrix/federation/v1/invite/{roomID}/{eventID}
 type RespInvite struct {
 	// The invite event signed by recipient server.
-	Event EventJSON `json:"event"`
+	Event RawJSON `json:"event"`
 }
 
 // MarshalJSON implements json.Marshaller
@@ -707,13 +707,13 @@ func (r *RespInvite) UnmarshalJSON(data []byte) error {
 }
 
 type respInviteFields struct {
-	Event EventJSON `json:"event"`
+	Event RawJSON `json:"event"`
 }
 
 // RespInvite is the content of a response to PUT /_matrix/federation/v2/invite/{roomID}/{eventID}
 type RespInviteV2 struct {
 	// The invite event signed by recipient server.
-	Event EventJSON `json:"event"`
+	Event RawJSON `json:"event"`
 }
 
 // RespClaimKeys is the response for https://matrix.org/docs/spec/server_server/latest#post-matrix-federation-v1-user-keys-claim

--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -55,7 +55,6 @@ func TestParseServerName(t *testing.T) {
 func TestRespStateMarshalJSON(t *testing.T) {
 	inputData := `{"pdus":[],"auth_chain":[]}`
 	var input RespState
-	input.roomVersion = RoomVersionV1
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +74,6 @@ func TestRespStateMarshalJSON(t *testing.T) {
 func TestRespStateUnmarshalJSON(t *testing.T) {
 	inputData := `{"pdus":[],"auth_chain":[]}`
 	var input RespState
-	input.roomVersion = RoomVersionV1
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +92,6 @@ func TestRespStateUnmarshalJSON(t *testing.T) {
 func TestRespSendJoinMarshalJSON(t *testing.T) {
 	inputData := `{"state":[],"auth_chain":[],"origin":""}`
 	var input RespSendJoin
-	input.roomVersion = RoomVersionV1
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +111,6 @@ func TestRespSendJoinMarshalJSON(t *testing.T) {
 func TestRespSendJoinUnmarshalJSON(t *testing.T) {
 	inputData := `{"state":[],"auth_chain":[],"origin":""}`
 	var input RespSendJoin
-	input.roomVersion = RoomVersionV1
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {
 		t.Fatal(err)
 	}

--- a/json.go
+++ b/json.go
@@ -25,14 +25,13 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type EventJSON RawJSON
-type EventJSONs []EventJSON
+type EventJSONs []RawJSON
 
-func (e EventJSON) TrustedEvent(roomVersion RoomVersion, redacted bool) (*Event, error) {
+func (e RawJSON) TrustedEvent(roomVersion RoomVersion, redacted bool) (*Event, error) {
 	return NewEventFromTrustedJSON(e, redacted, roomVersion)
 }
 
-func (e EventJSON) UntrustedEvent(roomVersion RoomVersion) (*Event, error) {
+func (e RawJSON) UntrustedEvent(roomVersion RoomVersion) (*Event, error) {
 	return NewEventFromUntrustedJSON(e, roomVersion)
 }
 

--- a/json.go
+++ b/json.go
@@ -25,6 +25,41 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+type EventJSON RawJSON
+type EventJSONs []EventJSON
+
+func (e EventJSON) TrustedEvent(roomVersion RoomVersion, redacted bool) (*Event, error) {
+	return NewEventFromTrustedJSON(e, redacted, roomVersion)
+}
+
+func (e EventJSON) UntrustedEvent(roomVersion RoomVersion) (*Event, error) {
+	return NewEventFromUntrustedJSON(e, roomVersion)
+}
+
+func (e EventJSONs) TrustedEvents(roomVersion RoomVersion, redacted bool) []*Event {
+	events := make([]*Event, 0, len(e))
+	for _, js := range e {
+		event, err := NewEventFromTrustedJSON(js, redacted, roomVersion)
+		if err != nil {
+			continue
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func (e EventJSONs) UntrustedEvents(roomVersion RoomVersion) []*Event {
+	events := make([]*Event, 0, len(e))
+	for _, js := range e {
+		event, err := NewEventFromUntrustedJSON(js, roomVersion)
+		if err != nil {
+			continue
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
 // CanonicalJSON re-encodes the JSON in a canonical encoding. The encoding is
 // the shortest possible encoding using integer values with sorted object keys.
 // At present this function performs:

--- a/json.go
+++ b/json.go
@@ -67,6 +67,14 @@ func NewEventJSONsFromHeaderedEvents(he []*HeaderedEvent) EventJSONs {
 	return events
 }
 
+func NewEventJSONsFromEvents(he []*Event) EventJSONs {
+	events := make(EventJSONs, len(he))
+	for i := range he {
+		events[i] = he[i].JSON()
+	}
+	return events
+}
+
 // CanonicalJSON re-encodes the JSON in a canonical encoding. The encoding is
 // the shortest possible encoding using integer values with sorted object keys.
 // At present this function performs:

--- a/json.go
+++ b/json.go
@@ -60,6 +60,14 @@ func (e EventJSONs) UntrustedEvents(roomVersion RoomVersion) []*Event {
 	return events
 }
 
+func NewEventJSONsFromHeaderedEvents(he []*HeaderedEvent) EventJSONs {
+	events := make(EventJSONs, len(he))
+	for i := range he {
+		events[i] = he[i].JSON()
+	}
+	return events
+}
+
 // CanonicalJSON re-encodes the JSON in a canonical encoding. The encoding is
 // the shortest possible encoding using integer values with sorted object keys.
 // At present this function performs:

--- a/json_test.go
+++ b/json_test.go
@@ -16,6 +16,8 @@
 package gomatrixserverlib
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -126,4 +128,23 @@ func TestReadHex(t *testing.T) {
 	testReadHex(t, "CDEF", 0xCDEF)
 	testReadHex(t, "89ab", 0x89AB)
 	testReadHex(t, "cdef", 0xCDEF)
+}
+
+func TestEventJSON(t *testing.T) {
+	resp := struct {
+		Events EventJSONs
+	}{}
+	jsonValue := []byte(`{"events":[{"foo":"bar"}, {"baz":"quuz"}]}`)
+	if err := json.Unmarshal(jsonValue, &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %s", err)
+	}
+	if len(resp.Events) != 2 {
+		t.Fatalf("got %d events, want 2", len(resp.Events))
+	}
+	if !reflect.DeepEqual([]byte(resp.Events[0]), []byte(`{"foo":"bar"}`)) {
+		t.Fatalf("first event wrong, got %s", string(resp.Events[0]))
+	}
+	if !reflect.DeepEqual([]byte(resp.Events[1]), []byte(`{"baz":"quuz"}`)) {
+		t.Fatalf("first event wrong, got %s", string(resp.Events[1]))
+	}
 }


### PR DESCRIPTION
This is largely driven by the desire to use GMSL Response types without knowing the room version up front. Now basically every response just returns these new types which then have functions to deserialise them into events with the given room version.