### PR TITLE
Use http.DefaultTransport, which loads proxy config from environment

### DIFF
--- a/client.go
+++ b/client.go
@@ -176,7 +176,7 @@ func (f *federationTripper) getTransport(tlsServerName string) (transport http.R
 			ServerName:         tlsServerName,
 			InsecureSkipVerify: f.skipVerify,
 		}
-		tr.Dial = federationTripperDialer.Dial
+		tr.Dial = federationTripperDialer.Dial // nolint: staticcheck
 		tr.DialContext = federationTripperDialer.DialContext
 		if f.dnsCache != nil {
 			tr.DialContext = f.dnsCache.DialContext

--- a/client.go
+++ b/client.go
@@ -170,14 +170,16 @@ func (f *federationTripper) getTransport(tlsServerName string) (transport http.R
 
 	// Create the transport if we don't have any for this TLS server name.
 	if transport, ok = f.transports[tlsServerName]; !ok {
-		tr := http.DefaultTransport.(*http.Transport).Clone()
-		tr.DisableKeepAlives = !f.keepAlives
-		tr.TLSClientConfig = &tls.Config{
-			ServerName:         tlsServerName,
-			InsecureSkipVerify: f.skipVerify,
+		tr := &http.Transport{
+			DisableKeepAlives: !f.keepAlives,
+			TLSClientConfig: &tls.Config{
+				ServerName:         tlsServerName,
+				InsecureSkipVerify: f.skipVerify,
+			},
+			Dial:        federationTripperDialer.Dial, // nolint: staticcheck
+			DialContext: federationTripperDialer.DialContext,
+			Proxy:       http.ProxyFromEnvironment,
 		}
-		tr.Dial = federationTripperDialer.Dial // nolint: staticcheck
-		tr.DialContext = federationTripperDialer.DialContext
 		if f.dnsCache != nil {
 			tr.DialContext = f.dnsCache.DialContext
 		}

--- a/client.go
+++ b/client.go
@@ -170,15 +170,14 @@ func (f *federationTripper) getTransport(tlsServerName string) (transport http.R
 
 	// Create the transport if we don't have any for this TLS server name.
 	if transport, ok = f.transports[tlsServerName]; !ok {
-		tr := &http.Transport{
-			DisableKeepAlives: !f.keepAlives,
-			TLSClientConfig: &tls.Config{
-				ServerName:         tlsServerName,
-				InsecureSkipVerify: f.skipVerify,
-			},
-			Dial:        federationTripperDialer.Dial,
-			DialContext: federationTripperDialer.DialContext,
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.DisableKeepAlives = !f.keepAlives
+		tr.TLSClientConfig = &tls.Config{
+			ServerName:         tlsServerName,
+			InsecureSkipVerify: f.skipVerify,
 		}
+		tr.Dial = federationTripperDialer.Dial
+		tr.DialContext = federationTripperDialer.DialContext
 		if f.dnsCache != nil {
 			tr.DialContext = f.dnsCache.DialContext
 		}


### PR DESCRIPTION
Should make the [proxy_outbound](https://github.com/matrix-org/dendrite/blob/5106cc807cf22a95420b24f6bfdd5c9ac8aa06de/dendrite-config.yaml#L207-L212) config obsolete, since it uses the default mechanism to get the proxy settings.


