### PR TITLE
Add support for partial state in `send_join` responses

### DIFF
--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -122,10 +122,10 @@ func TestRespSendJoinMarshalJSON(t *testing.T) {
 
 func TestRespSendJoinMarshalJSONPartialState(t *testing.T) {
 	inputData := `{
-        "state":[],"auth_chain":[],"origin":"o1",
-	    "org.matrix.msc3706.partial_state":true,
-        "org.matrix.msc3706.servers_in_room":["s1", "s2"]
-    }`
+		"state":[],"auth_chain":[],"origin":"o1",
+		"org.matrix.msc3706.partial_state":true,
+		"org.matrix.msc3706.servers_in_room":["s1", "s2"]
+	}`
 
 	var input RespSendJoin
 	if err := json.Unmarshal([]byte(inputData), &input); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/matrix-org/gomatrixserverlib
 
 require (
 	github.com/frankban/quicktest v1.7.2 // indirect
-	github.com/google/go-cmp v0.4.0 // indirect
+	github.com/google/go-cmp v0.4.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26


### PR DESCRIPTION
[MSC3706](https://github.com/matrix-org/matrix-doc/pull/3706) adds some new fields to `/send_join` responses. Here we add support for the new fields, and the new query param