### PR TITLE
Implement `destination` field in `X-Matrix` header as per MSC3383

### DIFF
--- a/request.go
+++ b/request.go
@@ -285,7 +285,7 @@ func readHTTPRequest(req *http.Request) (*FederationRequest, error) { // nolint:
 	}
 
 	for _, authorization := range req.Header["Authorization"] {
-		scheme, origin, destination, key, sig := parseAuthorization(authorization)
+		scheme, origin, destination, key, sig := ParseAuthorization(authorization)
 		if scheme != "X-Matrix" {
 			// Ignore unknown types of Authorization.
 			continue
@@ -308,7 +308,7 @@ func readHTTPRequest(req *http.Request) (*FederationRequest, error) { // nolint:
 	return &result, nil
 }
 
-func parseAuthorization(header string) (scheme string, origin, destination ServerName, key KeyID, sig string) {
+func ParseAuthorization(header string) (scheme string, origin, destination ServerName, key KeyID, sig string) {
 	parts := strings.SplitN(header, " ", 2)
 	scheme = parts[0]
 	if scheme != "X-Matrix" {

--- a/request_test.go
+++ b/request_test.go
@@ -19,6 +19,7 @@ const exampleGetRequest = "GET /_matrix/federation/v1/query/directory?room_alias
 	" origin=\"localhost:8800\"" +
 	",key=\"ed25519:a_Obwu\"" +
 	",sig=\"7vt4vP/w8zYB3Zg77nuTPwie3TxEy2OHZQMsSa4nsXZzL4/qw+DguXbyMy3BF77XvSJmBt+Gw+fU6T4HId7fBg\"" +
+	",destination=\"localhost:44033\"" +
 	"\r\n" +
 	"\r\n"
 
@@ -31,6 +32,7 @@ const examplePutRequest = "PUT /_matrix/federation/v1/send/1493385816575/ HTTP/1
 	" origin=\"localhost:8800\"" +
 	",key=\"ed25519:a_Obwu\"" +
 	",sig=\"+hmW6UjEXx7vMt2+MXO/EImSfdEYdBsZEOmpiz3evYktAgGNpGuNMBYXIA969WGubmceREKA/r1phasUFHBpDg\"" +
+	",destination=\"localhost:44033\"" +
 	"\r\n" +
 	"Content-Type: application/json\r\n" +
 	"\r\n" +


### PR DESCRIPTION
This sets the `destination=` field in the federation request auth header so that a proxy can distinguish the target of a federation request without needing to rely on the `Host` header, which is more likely to be set to the hostname of the proxy itself. This should be useful for P2P.