### PR TITLE
Remove `event_id` field from `eventFormatV2Fields`

### DIFF
--- a/event.go
+++ b/event.go
@@ -116,13 +116,13 @@ func (eb *EventBuilder) SetUnsigned(unsigned interface{}) (err error) {
 // eventFormatV1Fields, eventFormatV2Fields.
 type Event struct {
 	redacted    bool
+	eventID     string
 	eventJSON   []byte
 	fields      interface{}
 	roomVersion RoomVersion
 }
 
 type eventFields struct {
-	EventID        string     `json:"event_id,omitempty"`
 	RoomID         string     `json:"room_id"`
 	Sender         string     `json:"sender"`
 	Type           string     `json:"type"`
@@ -138,6 +138,7 @@ type eventFields struct {
 // Fields for room versions 1, 2.
 type eventFormatV1Fields struct {
 	eventFields
+	EventID    string           `json:"event_id,omitempty"`
 	PrevEvents []EventReference `json:"prev_events"`
 	AuthEvents []EventReference `json:"auth_events"`
 }
@@ -428,12 +429,10 @@ func (e *Event) populateFieldsFromJSON(eventIDIfKnown string, eventJSON []byte) 
 		// Populate the fields of the received object.
 		fields.fixNilSlices()
 		e.fields = fields
+		e.eventID = fields.EventID
 	case EventFormatV2:
 		// Later room versions don't have the event_id field so if it is
 		// present, remove it.
-		if eventJSON, err = sjson.DeleteBytes(eventJSON, "event_id"); err != nil {
-			return err
-		}
 		e.eventJSON = eventJSON
 		// Unmarshal the event fields.
 		fields := eventFormatV2Fields{}
@@ -442,12 +441,9 @@ func (e *Event) populateFieldsFromJSON(eventIDIfKnown string, eventJSON []byte) 
 		}
 		// Generate a hash of the event which forms the event ID.
 		if eventIDIfKnown != "" {
-			fields.EventID = eventIDIfKnown
-		} else {
-			fields.EventID, err = e.generateEventID()
-			if err != nil {
-				return err
-			}
+			e.eventID = eventIDIfKnown
+		} else if e.eventID, err = e.generateEventID(); err != nil {
+			return err
 		}
 		// Populate the fields of the received object.
 		fields.fixNilSlices()
@@ -775,9 +771,8 @@ func (e *Event) generateEventID() (eventID string, err error) {
 	case EventFormatV1:
 		eventID = e.fields.(eventFormatV1Fields).EventID
 	case EventFormatV2:
-		eventJSON := e.eventJSON
 		var reference EventReference
-		reference, err = referenceOfEvent(eventJSON, e.roomVersion)
+		reference, err = referenceOfEvent(e.eventJSON, e.roomVersion)
 		if err != nil {
 			return
 		}
@@ -794,7 +789,7 @@ func (e *Event) EventID() string {
 	case eventFormatV1Fields:
 		return fields.EventID
 	case eventFormatV2Fields:
-		return fields.EventID
+		return e.eventID
 	default:
 		panic(e.invalidFieldType())
 	}

--- a/event.go
+++ b/event.go
@@ -429,17 +429,19 @@ func (e *Event) populateFieldsFromJSON(eventIDIfKnown string, eventJSON []byte) 
 		// Populate the fields of the received object.
 		fields.fixNilSlices()
 		e.fields = fields
+		// In room versions 1 and 2, we will use the event_id from the
+		// event itself.
 		e.eventID = fields.EventID
 	case EventFormatV2:
-		// Later room versions don't have the event_id field so if it is
-		// present, remove it.
 		e.eventJSON = eventJSON
 		// Unmarshal the event fields.
 		fields := eventFormatV2Fields{}
 		if err := json.Unmarshal(eventJSON, &fields); err != nil {
 			return err
 		}
-		// Generate a hash of the event which forms the event ID.
+		// Generate a hash of the event which forms the event ID. There
+		// is no event_id field in room versions 3 and later so we will
+		// always generate our own.
 		if eventIDIfKnown != "" {
 			e.eventID = eventIDIfKnown
 		} else if e.eventID, err = e.generateEventID(); err != nil {

--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -82,8 +82,8 @@ func getBaseStateResV2Graph() []*Event {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$CREATE:example.com",
 				eventFields: eventFields{
-					EventID:        "$CREATE:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomCreate,
 					OriginServerTS: 1,
@@ -96,8 +96,8 @@ func getBaseStateResV2Graph() []*Event {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$IMA:example.com",
 				eventFields: eventFields{
-					EventID:        "$IMA:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomMember,
 					OriginServerTS: 2,
@@ -116,8 +116,8 @@ func getBaseStateResV2Graph() []*Event {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$IPOWER:example.com",
 				eventFields: eventFields{
-					EventID:        "$IPOWER:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomPowerLevels,
 					OriginServerTS: 3,
@@ -137,8 +137,8 @@ func getBaseStateResV2Graph() []*Event {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$IJR:example.com",
 				eventFields: eventFields{
-					EventID:        "$IJR:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomJoinRules,
 					OriginServerTS: 4,
@@ -159,8 +159,8 @@ func getBaseStateResV2Graph() []*Event {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$IMB:example.com",
 				eventFields: eventFields{
-					EventID:        "$IMB:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomMember,
 					OriginServerTS: 5,
@@ -181,8 +181,8 @@ func getBaseStateResV2Graph() []*Event {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$IMC:example.com",
 				eventFields: eventFields{
-					EventID:        "$IMC:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomMember,
 					OriginServerTS: 6,
@@ -230,8 +230,8 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$PA:example.com",
 				eventFields: eventFields{
-					EventID:        "$PA:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomPowerLevels,
 					OriginServerTS: 7,
@@ -255,8 +255,8 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$PB:example.com",
 				eventFields: eventFields{
-					EventID:        "$PB:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomPowerLevels,
 					OriginServerTS: 8,
@@ -280,8 +280,8 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$MB:example.com",
 				eventFields: eventFields{
-					EventID:        "$MB:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomMember,
 					OriginServerTS: 9,
@@ -302,8 +302,8 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$IME:example.com",
 				eventFields: eventFields{
-					EventID:        "$IME:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomMember,
 					OriginServerTS: 10,
@@ -335,8 +335,8 @@ func TestStateResolutionJoinRuleEvasion(t *testing.T) {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$JR:example.com",
 				eventFields: eventFields{
-					EventID:        "$JR:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomJoinRules,
 					OriginServerTS: 8,
@@ -357,8 +357,8 @@ func TestStateResolutionJoinRuleEvasion(t *testing.T) {
 		{
 			roomVersion: RoomVersionV2,
 			fields: eventFormatV1Fields{
+				EventID: "$IMZ:example.com",
 				eventFields: eventFields{
-					EventID:        "$IMZ:example.com",
 					RoomID:         "!ROOM:example.com",
 					Type:           MRoomMember,
 					OriginServerTS: 9,


### PR DESCRIPTION
This removes `EventID` from `eventFormatV2Fields` and puts a central `eventID` field in the `Event` struct which will either be populated from the `eventFormatV1Fields` (room versions 1-2) or from computing our own event ID (room versions 3 and later).

Beforehand we were trying to find and remove the `event_id` field on every event in room version 3 and later, even though it probably isn't present. The `sjson` call had a few allocations even though it was not really accomplishing anything.

Even if the `event_id` field is present in those room versions, which it really shouldn't be, removing it would break the event signatures, when instead we should just be ignoring what the event ID is and computing our own.