### PR TITLE
MSC2787 Add support for splitting UPK IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .*.swp
+coverage.out

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
 	github.com/miekg/dns v1.1.25
 	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/tidwall/gjson v1.12.1
 	github.com/tidwall/sjson v1.0.3
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d


### PR DESCRIPTION
Add code coverage for SplitID. Create SplitIDWithSigil for future extension. Mark SplitID deprecated as callers should only pass ID with embedded sigals, letting SplitIDWithSigil parse the sigil.

### Pull Request Checklist

* [X ] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Brian Meek <brian@hntlabs.com>`
