### PR TITLE
Control whether `Client` performs well-known or SRV lookups, update `FederationClient`

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -30,7 +30,9 @@ func NewFederationClient(
 	options ...ClientOption,
 ) *FederationClient {
 	return &FederationClient{
-		Client:           *NewClient(options...),
+		Client: *NewClient(
+			append(options, WithWellKnownSRVLookups(true))...,
+		),
 		serverName:       serverName,
 		serverKeyID:      keyID,
 		serverPrivateKey: privateKey,


### PR DESCRIPTION
That way we can use `Client` to do regular requests without performing well-known or SRV lookups.