### PR TITLE
Fix bugs in `checkUserLevels`

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -669,9 +669,9 @@ func checkUserLevels(senderLevel int64, senderID string, oldPowerLevels, newPowe
 		// Check if the user is trying to set any of the levels to above their own.
 		if senderLevel < level.new {
 			return errorf(
-				"sender with level %d is not allowed change user level from %d to %d"+
+				"sender %q with level %d is not allowed change user %q level from %d to %d"+
 					" because the new level is above the level of the sender",
-				senderLevel, level.old, level.new,
+				senderID, senderLevel, level.userID, level.old, level.new,
 			)
 		}
 
@@ -685,9 +685,9 @@ func checkUserLevels(senderLevel int64, senderID string, oldPowerLevels, newPowe
 		// Check if the user is changing the level that was above or the same as their own.
 		if senderLevel <= level.old {
 			return errorf(
-				"sender with level %d is not allowed to change user level from %d to %d"+
+				"sender %q with level %d is not allowed to change user %q level from %d to %d"+
 					" because the old level is equal to or above the level of the sender",
-				senderLevel, level.old, level.new,
+				senderID, senderLevel, level.userID, level.old, level.new,
 			)
 		}
 	}
@@ -1261,6 +1261,7 @@ func (m *membershipAllower) membershipAllowedOther() error { // nolint: gocyclo
 			}
 			return nil
 		}
+
 		return m.membershipFailed(
 			"sender has insufficient power to invite (sender level %d, target level %d, invite level %d)",
 			senderLevel, targetLevel, m.powerLevels.Invite,

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -1080,7 +1080,7 @@ var powerLevelTestRoom = &testAuthEvents{
 	},
 }
 
-func TestDemoteUserDefaultPowerLeveBelowOwnl(t *testing.T) {
+func TestDemoteUserDefaultPowerLevelBelowOwn(t *testing.T) {
 	// User should be able to demote the user default level
 	// below their own effective level.
 	powerChangeShouldSucceed, err := NewEventFromTrustedJSON(RawJSON(`{

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -1059,7 +1059,6 @@ var powerLevelTestRoom = &testAuthEvents{
 		"event_id": "$e3:a",
 		"content": {
 			"users_default": 100,
-			"state_default": 0,
 			"users": {
 				"@u1:a": 100
 			},
@@ -1116,7 +1115,6 @@ func TestPromoteUserDefaultLevelAboveOwn(t *testing.T) {
 		"event_id": "$e5:a",
 		"content": {
 			"users_default": 500,
-			"state_default": 0,
 			"users": {
 				"@u1:a": 100
 			},


### PR DESCRIPTION
The `checkUserLevels` function was considering the default user level if the user didn't have a key defined, which meant that promoting or demoting a user above/below the default power levels could result in the event auth failing, even though the changes should be allowed.

It could also end up adding duplicates, which just seems wasteful.