### PR TITLE
Fix `Base64Bytes` sql.Scanner

### DIFF
--- a/base64.go
+++ b/base64.go
@@ -58,8 +58,7 @@ func (b64 *Base64Bytes) Scan(src interface{}) error {
 	case string:
 		return b64.Decode(v)
 	case []byte:
-		new := append(Base64Bytes{}, v...)
-		b64 = &new
+		*b64 = append(Base64Bytes{}, v...)
 		return nil
 	case RawJSON:
 		return b64.UnmarshalJSON(v)

--- a/base64_test.go
+++ b/base64_test.go
@@ -157,7 +157,7 @@ func TestScanBase64(t *testing.T) {
 
 	inputStr := "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n"
 	inputJSON := RawJSON(`"` + inputStr + `"`)
-	inputBytes := []byte(inputStr)
+	inputBytes := []byte(expecting)
 	inputInt := 3
 
 	var b Base64Bytes


### PR DESCRIPTION
This should fix the issue encountered in https://github.com/matrix-org/dendrite/commit/8ae34c4e5f78584f0edb479f5a893556d2b95d19