### PR TITLE
Specify `omitempty` for some fields in `DeviceListUpdateEvent`

### DIFF
--- a/device_update.go
+++ b/device_update.go
@@ -6,9 +6,9 @@ import "encoding/json"
 type DeviceListUpdateEvent struct {
 	UserID            string          `json:"user_id"`
 	DeviceID          string          `json:"device_id"`
-	DeviceDisplayName string          `json:"device_display_name"`
+	DeviceDisplayName string          `json:"device_display_name,omitempty"`
 	StreamID          int64           `json:"stream_id"`
-	PrevID            []int64         `json:"prev_id"`
-	Deleted           bool            `json:"deleted"`
-	Keys              json.RawMessage `json:"keys"`
+	PrevID            []int64         `json:"prev_id,omitempty"`
+	Deleted           bool            `json:"deleted,omitempty"`
+	Keys              json.RawMessage `json:"keys,omitempty"`
 }


### PR DESCRIPTION
This should address the cause of matrix-org/synapse#12829. These fields are optional, so we should omit them if they are empty instead of sending `null`.