### PR TITLE
Fix control flow a bit when authing membership changes in restricted rooms

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -972,14 +972,6 @@ func (m *membershipAllower) membershipAllowed(event *Event) error { // nolint: g
 	}
 
 	if m.targetID == m.senderID {
-		// If the room is set to restricted join, evaluate restricted join rules
-		// in addition to updating their own membership.
-		if m.joinRule.JoinRule == Restricted {
-			if err := m.membershipAllowedSelfForRestrictedJoin(); err != nil {
-				return err
-			}
-		}
-
 		// If the state_key and the sender are the same then this is an attempt
 		// by a user to update their own membership.
 		return m.membershipAllowedSelf()
@@ -1119,7 +1111,9 @@ func (m *membershipAllower) membershipAllowedSelf() error { // nolint: gocyclo
 
 	case Join:
 		if m.oldMember.Membership == Leave && m.joinRule.JoinRule == Restricted {
-			return m.membershipAllowedSelfForRestrictedJoin()
+			if err := m.membershipAllowedSelfForRestrictedJoin(); err != nil {
+				return err
+			}
 		}
 		// A user that is not in the room is allowed to join if the room
 		// join rules are "public".

--- a/eventcontent.go
+++ b/eventcontent.go
@@ -229,14 +229,15 @@ type JoinRuleContentAllowRule struct {
 // NewJoinRuleContentFromAuthEvents loads the join rule content from the join rules event in the auth event.
 // Returns an error if there was an error loading the join rule event or parsing the content.
 func NewJoinRuleContentFromAuthEvents(authEvents AuthEventProvider) (c JoinRuleContent, err error) {
-	var joinRulesEvent *Event
-	if joinRulesEvent, err = authEvents.JoinRules(); err != nil {
+	// Start off with "invite" as the default. Hopefully the unmarshal
+	// step later will replace it with a better value.
+	c.JoinRule = Invite
+	// Then see if the specified join event contains something better.
+	joinRulesEvent, err := authEvents.JoinRules()
+	if err != nil {
 		return
 	}
 	if joinRulesEvent == nil {
-		// Default to "invite"
-		// https://github.com/matrix-org/synapse/blob/v0.18.5/synapse/api/auth.py#L368
-		c.JoinRule = Invite
 		return
 	}
 	if err = json.Unmarshal(joinRulesEvent.Content(), &c); err != nil {


### PR DESCRIPTION
Previously we were calling `m.membershipAllowedSelfForRestrictedJoin` twice, which caused problems when it switches to `invite` or `public`.

This also makes `NewJoinRuleContentFromAuthEvents` a bit to make it more obvious.