### PR TITLE
Tweak event auth to always allow an invited user to join

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -1120,16 +1120,8 @@ func (m *membershipAllower) membershipAllowedSelf() error { // nolint: gocyclo
 		if m.oldMember.Membership == Leave && m.joinRule.JoinRule == Public {
 			return nil
 		}
-		// An invited user is allowed to join if the join rules are "public"
-		if m.oldMember.Membership == Invite && m.joinRule.JoinRule == Public {
-			return nil
-		}
-		// An invited user is allowed to join if the join rules are "invite"
-		if m.oldMember.Membership == Invite && m.joinRule.JoinRule == Invite {
-			return nil
-		}
-		// An invited user is allowed to join if the join rules are "knock"
-		if m.oldMember.Membership == Invite && m.joinRule.JoinRule == Knock {
+		// An invited user is always allowed to join, regardless of the join rule
+		if m.oldMember.Membership == Invite {
 			return nil
 		}
 		// A joined user is allowed to update their join.


### PR DESCRIPTION
Previously we had an `if` statement for each join rule, which is excessive because an invited user is always allowed to join. This PR simplifies it so that it's just a single statement and that way it also covers the `"restricted"` join rule. 