### PR TITLE
History visibility convenience functions

### DIFF
--- a/eventcontent.go
+++ b/eventcontent.go
@@ -236,17 +236,17 @@ func (h HistoryVisibility) Value() HistoryVisibility {
 }
 
 var hisVisStringToIntMapping = map[HistoryVisibility]uint8{
-	HistoryVisibilityWorldReadable: 0,
-	HistoryVisibilityShared:        1,
-	HistoryVisibilityInvited:       2,
-	HistoryVisibilityJoined:        3,
+	HistoryVisibilityWorldReadable: 1, // Starting at 1, to avoid confusions with Go default values
+	HistoryVisibilityShared:        2,
+	HistoryVisibilityInvited:       3,
+	HistoryVisibilityJoined:        4,
 }
 
 var hisVisIntToStringMapping = map[uint8]HistoryVisibility{
-	0: HistoryVisibilityWorldReadable,
-	1: HistoryVisibilityShared,
-	2: HistoryVisibilityInvited,
-	3: HistoryVisibilityJoined,
+	1: HistoryVisibilityWorldReadable, // Starting at 1, to avoid confusions with Go default values
+	2: HistoryVisibilityShared,
+	3: HistoryVisibilityInvited,
+	4: HistoryVisibilityJoined,
 }
 
 // NumericValue returns the numeric value of the HistoryVisibility.

--- a/eventcontent.go
+++ b/eventcontent.go
@@ -223,7 +223,7 @@ const (
 )
 
 // Value returns the history visibility. If an unknown value is set then
-// it will return "joined".
+// it will return "shared".
 func (h HistoryVisibility) Value() HistoryVisibility {
 	switch h {
 	case HistoryVisibilityWorldReadable, HistoryVisibilityShared:
@@ -231,8 +231,37 @@ func (h HistoryVisibility) Value() HistoryVisibility {
 	case HistoryVisibilityInvited, HistoryVisibilityJoined:
 		return h
 	default:
-		return HistoryVisibilityJoined
+		return HistoryVisibilityShared
 	}
+}
+
+var hisVisStringToIntMapping = map[HistoryVisibility]uint8{
+	HistoryVisibilityWorldReadable: 0,
+	HistoryVisibilityShared:        1,
+	HistoryVisibilityInvited:       2,
+	HistoryVisibilityJoined:        3,
+}
+
+var hisVisIntToStringMapping = map[uint8]HistoryVisibility{
+	0: HistoryVisibilityWorldReadable,
+	1: HistoryVisibilityShared,
+	2: HistoryVisibilityInvited,
+	3: HistoryVisibilityJoined,
+}
+
+// NumericValue returns the numeric value of the HistoryVisibility.
+func (h HistoryVisibility) NumericValue() uint8 {
+	return hisVisStringToIntMapping[h.Value()]
+}
+
+// HistoryVisibilityFromInt gets the HistoryVisibility given an uint8.
+// If there is no match, it returns "shared".
+func HistoryVisibilityFromInt(n uint8) HistoryVisibility {
+	vis, ok := hisVisIntToStringMapping[n]
+	if !ok {
+		return HistoryVisibilityShared
+	}
+	return vis
 }
 
 // JoinRuleContent is the JSON content of a m.room.join_rules event needed for auth checks.

--- a/eventcontent_test.go
+++ b/eventcontent_test.go
@@ -107,7 +107,7 @@ func TestHistoryVisibilityFromInt(t *testing.T) {
 		},
 		{
 			name: "known value returns correct visibility",
-			args: 0,
+			args: 1,
 			want: HistoryVisibilityWorldReadable,
 		},
 	}
@@ -129,17 +129,17 @@ func TestHistoryVisibility_NumericValue(t *testing.T) {
 		{
 			name: "unknown history visibility defaults to shared",
 			h:    HistoryVisibility("doesNotExist"),
-			want: 1,
+			want: 2,
 		},
 		{
 			name: "history visibility returns correct value",
 			h:    HistoryVisibilityJoined,
-			want: 3,
+			want: 4,
 		},
 		{
 			name: "history visibility returns correct value 2",
 			h:    HistoryVisibilityShared,
-			want: 1,
+			want: 2,
 		},
 	}
 	for _, tt := range tests {

--- a/eventcontent_test.go
+++ b/eventcontent_test.go
@@ -93,3 +93,60 @@ func TestStrictPowerLevelContent(t *testing.T) {
 		t.Fatal("bad content should have errored but didn't")
 	}
 }
+
+func TestHistoryVisibilityFromInt(t *testing.T) {
+	tests := []struct {
+		name string
+		args uint8
+		want HistoryVisibility
+	}{
+		{
+			name: "unknown value returns shared visibility",
+			args: 100,
+			want: HistoryVisibilityShared,
+		},
+		{
+			name: "known value returns correct visibility",
+			args: 0,
+			want: HistoryVisibilityWorldReadable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HistoryVisibilityFromInt(tt.args); got != tt.want {
+				t.Errorf("HistoryVisibilityFromInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHistoryVisibility_NumericValue(t *testing.T) {
+	tests := []struct {
+		name string
+		h    HistoryVisibility
+		want uint8
+	}{
+		{
+			name: "unknown history visibility defaults to shared",
+			h:    HistoryVisibility("doesNotExist"),
+			want: 1,
+		},
+		{
+			name: "history visibility returns correct value",
+			h:    HistoryVisibilityJoined,
+			want: 3,
+		},
+		{
+			name: "history visibility returns correct value 2",
+			h:    HistoryVisibilityShared,
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.h.NumericValue(); got != tt.want {
+				t.Errorf("NumericValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/headeredevent.go
+++ b/headeredevent.go
@@ -9,7 +9,8 @@ import (
 // about the room version. All header fields will be added into the event
 // when marshalling into JSON and will be separated out when unmarshalling.
 type HeaderedEvent struct {
-	RoomVersion RoomVersion `json:"-"`
+	RoomVersion RoomVersion       `json:"-"`
+	Visibility  HistoryVisibility `json:"-"`
 	*Event
 }
 


### PR DESCRIPTION
Updates the default value to `shared` as per the spec:
> By default if no history_visibility is set, or if the value is not understood, the visibility is assumed to be shared.

Adds some helper functions to convert between int and string (e.g. when storing numeric values in the database)