### PR TITLE
Always add the event in LoadAndVerify, even in case of an error

### DIFF
--- a/backfill.go
+++ b/backfill.go
@@ -77,8 +77,14 @@ func RequestBackfill(ctx context.Context, b BackfillRequester, keyRing JSONVerif
 			continue // try the next server
 		}
 		for _, res := range loadResults {
-			if res.Error != nil {
-				continue // skip this event
+			switch res.Error.(type) {
+			case nil, SignatureErr:
+				// The signature of the event might not be valid anymore, for example if
+				// the key ID was reused with a different signature.
+			case AuthChainErr, AuthRulesErr:
+				continue
+			default:
+				continue
 			}
 			if haveEventIDs[res.Event.EventID()] {
 				continue // we got this event from a different server

--- a/load.go
+++ b/load.go
@@ -39,8 +39,8 @@ func NewEventsLoader(roomVer RoomVersion, keyRing JSONVerifier, stateProvider St
 // LoadAndVerify loads untrusted events and verifies them.
 // Checks performed are outlined at https://matrix.org/docs/spec/server_server/latest#checks-performed-on-receipt-of-a-pdu
 // The length of the returned slice will always equal the length of rawEvents.
-// The order of the returned events depends on `sortOrder`. The events are reverse topologically sorted by the ordering specified. However
-// in order to sort the events the events must be loaded which could fail. For those events which fail to be loaded, they will
+// The order of the returned events depends on `sortOrder`. The events are reverse topologically sorted by the ordering specified. However,
+// in order to sort the events must be loaded which could fail. For those events which fail to be loaded, they will
 // be put at the end of the returned slice.
 func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMessage, sortOrder TopologicalOrder) ([]EventLoadResult, error) {
 	results := make([]EventLoadResult, len(rawEvents))
@@ -77,21 +77,20 @@ func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMe
 		return nil, fmt.Errorf("gomatrixserverlib: bulk event signature verification length mismatch: %d != %d", len(failures), len(events))
 	}
 	for i := range events {
+		h := events[i].Headered(l.roomVer)
+		results[i] = EventLoadResult{
+			Event: h,
+		}
 		if eventErr := failures[i]; eventErr != nil {
 			if results[i].Error == nil { // could have failed earlier
-				results[i] = EventLoadResult{
-					Error: eventErr,
-				}
+				results[i].Error = eventErr
 				continue
 			}
 		}
-		h := events[i].Headered(l.roomVer)
 		// 4. Passes authorization rules based on the event's auth events, otherwise it is rejected.
 		if err := VerifyEventAuthChain(ctx, h, l.provider); err != nil {
 			if results[i].Error == nil { // could have failed earlier
-				results[i] = EventLoadResult{
-					Error: err,
-				}
+				results[i].Error = err
 				continue
 			}
 		}
@@ -99,14 +98,9 @@ func (l *EventsLoader) LoadAndVerify(ctx context.Context, rawEvents []json.RawMe
 		// 5. Passes authorization rules based on the state at the event, otherwise it is rejected.
 		if err := VerifyAuthRulesAtState(ctx, l.stateProvider, h, true); err != nil {
 			if results[i].Error == nil { // could have failed earlier
-				results[i] = EventLoadResult{
-					Error: err,
-				}
+				results[i].Error = err
 				continue
 			}
-		}
-		results[i] = EventLoadResult{
-			Event: h,
 		}
 	}
 


### PR DESCRIPTION
With this we should be able to skip over different errors from `LoadAndVerify` (used when backfilling in Dendrite) or rather ignore the error and still persist the event.
The event is not sent to the output stream nor is it rejected in Dendrite.

Tested on my instance and I was able to scroll back in "Dendrite alerts" until the beginning of the room.