### PR TITLE
Redaction tweaks

### DIFF
--- a/event.go
+++ b/event.go
@@ -540,6 +540,7 @@ func (e *Event) Redact() {
 	if err = e.populateFieldsFromJSON(e.EventID(), eventJSON); err != nil {
 		panic(fmt.Errorf("gomatrixserverlib: populateFieldsFromJSON failed %v", err))
 	}
+	e.redacted = true
 }
 
 // SetUnsigned sets the unsigned key of the event.

--- a/event.go
+++ b/event.go
@@ -402,7 +402,7 @@ func NewEventFromUntrustedJSON(eventJSON []byte, roomVersion RoomVersion) (resul
 		// If the content hash doesn't match then we have to discard all non-essential fields
 		// because they've been tampered with.
 		var redactedJSON []byte
-		if redactedJSON, err = redactEvent(eventJSON, roomVersion); err != nil {
+		if redactedJSON, err = RedactEventJSON(eventJSON, roomVersion); err != nil {
 			return
 		}
 
@@ -528,7 +528,7 @@ func (e *Event) Redact() {
 	if e.redacted {
 		return
 	}
-	eventJSON, err := redactEvent(e.eventJSON, e.roomVersion)
+	eventJSON, err := RedactEventJSON(e.eventJSON, e.roomVersion)
 	if err != nil {
 		// This is unreachable for events created with EventBuilder.Build or NewEventFromUntrustedJSON
 		panic(fmt.Errorf("gomatrixserverlib: invalid event %v", err))

--- a/event.go
+++ b/event.go
@@ -523,10 +523,10 @@ func (e *Event) Version() RoomVersion { return e.roomVersion }
 // JSON returns the JSON bytes for the event.
 func (e *Event) JSON() []byte { return e.eventJSON }
 
-// Redact returns a redacted copy of the event.
-func (e *Event) Redact() *Event {
+// Redact redacts the event.
+func (e *Event) Redact() {
 	if e.redacted {
-		return e
+		return
 	}
 	eventJSON, err := redactEvent(e.eventJSON, e.roomVersion)
 	if err != nil {
@@ -537,16 +537,9 @@ func (e *Event) Redact() *Event {
 		// This is unreachable for events created with EventBuilder.Build or NewEventFromUntrustedJSON
 		panic(fmt.Errorf("gomatrixserverlib: invalid event %v", err))
 	}
-	result := Event{
-		redacted:    true,
-		roomVersion: e.roomVersion,
-		eventJSON:   eventJSON,
-	}
-	err = result.populateFieldsFromJSON(e.EventID(), eventJSON)
-	if err != nil {
+	if err = e.populateFieldsFromJSON(e.EventID(), eventJSON); err != nil {
 		panic(fmt.Errorf("gomatrixserverlib: populateFieldsFromJSON failed %v", err))
 	}
-	return &result
 }
 
 // SetUnsigned sets the unsigned key of the event.

--- a/event_test.go
+++ b/event_test.go
@@ -83,7 +83,7 @@ func TestRedact(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	event = event.Redact()
+	event.Redact()
 	if !reflect.DeepEqual([]byte(`{}`), event.Content()) {
 		t.Fatalf("content not redacted: %s", string(event.Content()))
 	}
@@ -94,7 +94,7 @@ func TestRedact(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	event = event.Redact()
+	event.Redact()
 	if !reflect.DeepEqual([]byte(`{}`), event.Content()) {
 		t.Fatalf("content not redacted: %s", string(event.Content()))
 	}

--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -101,7 +101,7 @@ func (e *Event) VerifyEventSignatures(ctx context.Context, verifier JSONVerifier
 		return fmt.Errorf("failed to check strict validity checking: %w", err)
 	}
 
-	redactedJSON, err := redactEvent(e.eventJSON, e.roomVersion)
+	redactedJSON, err := RedactEventJSON(e.eventJSON, e.roomVersion)
 	if err != nil {
 		return fmt.Errorf("failed to redact event: %w", err)
 	}
@@ -209,7 +209,7 @@ func checkEventContentHash(eventJSON []byte) error {
 // ReferenceSha256HashOfEvent returns the SHA-256 hash of the redacted event content.
 // This is used when referring to this event from other events.
 func referenceOfEvent(eventJSON []byte, roomVersion RoomVersion) (EventReference, error) {
-	redactedJSON, err := redactEvent(eventJSON, roomVersion)
+	redactedJSON, err := RedactEventJSON(eventJSON, roomVersion)
 	if err != nil {
 		return EventReference{}, err
 	}
@@ -272,7 +272,7 @@ func referenceOfEvent(eventJSON []byte, roomVersion RoomVersion) (EventReference
 // SignEvent adds a ED25519 signature to the event for the given key.
 func signEvent(signingName string, keyID KeyID, privateKey ed25519.PrivateKey, eventJSON []byte, roomVersion RoomVersion) ([]byte, error) {
 	// Redact the event before signing so signature that will remain valid even if the event is redacted.
-	redactedJSON, err := redactEvent(eventJSON, roomVersion)
+	redactedJSON, err := RedactEventJSON(eventJSON, roomVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/eventcrypto_test.go
+++ b/eventcrypto_test.go
@@ -41,7 +41,7 @@ func TestVerifyEventSignatureTestVectors(t *testing.T) {
 	}
 
 	testVerifyOK := func(input string) {
-		redactedInput, err := redactEvent([]byte(input), RoomVersionV1)
+		redactedInput, err := RedactEventJSON([]byte(input), RoomVersionV1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -52,7 +52,7 @@ func TestVerifyEventSignatureTestVectors(t *testing.T) {
 	}
 
 	testVerifyNotOK := func(reason, input string) {
-		redactedInput, err := redactEvent([]byte(input), RoomVersionV1)
+		redactedInput, err := RedactEventJSON([]byte(input), RoomVersionV1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -390,7 +390,7 @@ func TestVerifyAllEventSignatures(t *testing.T) {
 	if len(verifier.requests) != 2 {
 		t.Fatalf("Number of requests: got %d, want 2", len(verifier.requests))
 	}
-	wantContent, err := redactEvent(eventJSON, RoomVersionV1)
+	wantContent, err := RedactEventJSON(eventJSON, RoomVersionV1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func TestVerifyAllEventSignaturesForInvite(t *testing.T) {
 	if len(verifier.requests) != 2 {
 		t.Fatalf("Number of requests: got %d, want 2", len(verifier.requests))
 	}
-	wantContent, err := redactEvent(eventJSON, RoomVersionV1)
+	wantContent, err := RedactEventJSON(eventJSON, RoomVersionV1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/redactevent.go
+++ b/redactevent.go
@@ -50,9 +50,9 @@ func (r *RawJSON) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// redactEvent strips the user controlled fields from an event, but leaves the
+// RedactEventJSON strips the user controlled fields from an event, but leaves the
 // fields necessary for authenticating the event.
-func redactEvent(eventJSON []byte, roomVersion RoomVersion) ([]byte, error) {
+func RedactEventJSON(eventJSON []byte, roomVersion RoomVersion) ([]byte, error) {
 
 	// createContent keeps the fields needed in a m.room.create event.
 	// Create events need to keep the creator.

--- a/redactevent_test.go
+++ b/redactevent_test.go
@@ -14,12 +14,12 @@ func TestRedactionAlgorithmV4(t *testing.T) {
 	expectedv8 := []byte(`{"sender":"@someone:somewhere.org","room_id":"!someroom:matrix.org","content":{"membership":"join"},"type":"m.room.member","state_key":"@someone:somewhere.org","origin_server_ts":1633108629915}`)
 	expectedv9 := []byte(`{"sender":"@someone:somewhere.org","room_id":"!someroom:matrix.org","content":{"membership":"join","join_authorised_via_users_server":"@someoneelse:somewhere.org"},"type":"m.room.member","state_key":"@someone:somewhere.org","origin_server_ts":1633108629915}`)
 
-	redactedv8, err := redactEvent(input, RoomVersionV8)
+	redactedv8, err := RedactEventJSON(input, RoomVersionV8)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	redactedv9, err := redactEvent(input, RoomVersionV9)
+	redactedv9, err := RedactEventJSON(input, RoomVersionV9)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This makes two changes:

1. `(*Event).Redact()` now doesn't return a copy of the event, but instead modifies the event from the receiver, since all we ever seem to do is `event = event.Redact()`;
2. Exports `RedactEventJSON` so that it can be used in combination with `VerifyJSON` without having to round-trip an `*Event`