### PR TITLE
client.go: Use /v3/ for media downloads

### DIFF
--- a/client.go
+++ b/client.go
@@ -483,7 +483,7 @@ func (fc *Client) CreateMediaDownloadRequest(
 ) (*http.Response, error) {
 	// Set allow_remote=false here so that we avoid loops:
 	// https://github.com/matrix-org/synapse/pull/1992
-	requestURL := "matrix://" + string(matrixServer) + "/_matrix/media/v1/download/" + string(matrixServer) + "/" + mediaID + "?allow_remote=false"
+	requestURL := "matrix://" + string(matrixServer) + "/_matrix/media/v3/download/" + string(matrixServer) + "/" + mediaID + "?allow_remote=false"
 	req, err := http.NewRequest("GET", requestURL, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Client-server spec 1.1, 1.2, and 1.3 use /v3/ for media downloads
https://spec.matrix.org/v1.3/client-server-api/#get_matrixmediav3downloadservernamemediaid
so let's use this one.

fixes #323

Signed-off-by: Sebastian Spaeth <Sebastian@SSpaeth.de>