### PR TITLE
Implement sql.Scanner & sql.Valuer for HistoryVisibilty

### DIFF
--- a/event.go
+++ b/event.go
@@ -1016,7 +1016,7 @@ func (e *Event) HistoryVisibility() (HistoryVisibility, error) {
 	if err := e.extractContent(MRoomHistoryVisibility, &content); err != nil {
 		return "", err
 	}
-	return content.HistoryVisibility.Value(), nil
+	return content.HistoryVisibility, nil
 }
 
 // PowerLevels returns the power levels content if this event

--- a/eventcontent_test.go
+++ b/eventcontent_test.go
@@ -99,7 +99,7 @@ func TestHistoryVisibility_Value(t *testing.T) {
 	tests := []struct {
 		name    string
 		h       HistoryVisibility
-		want    uint8
+		want    int64
 		wantErr bool
 	}{
 		{


### PR DESCRIPTION
As mentioned in https://github.com/matrix-org/dendrite/pull/2533#discussion_r921056138, implements `sql.Scanner` & `sql.Valuer`