### PR TITLE
Preserve history visibility in `HeaderedReverseTopologicalOrdering`

### DIFF
--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -231,7 +231,7 @@ func ReverseTopologicalOrdering(input []*Event, order TopologicalOrder) []*Event
 func HeaderedReverseTopologicalOrdering(events []*HeaderedEvent, order TopologicalOrder) []*HeaderedEvent {
 	r := stateResolverV2{}
 	input := make([]*Event, len(events))
-	hisVis := make(map[string]HistoryVisibility)
+	hisVis := make(map[string]HistoryVisibility, len(events))
 	for i := range events {
 		unwrapped := events[i].Unwrap()
 		input[i] = unwrapped

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -231,13 +231,16 @@ func ReverseTopologicalOrdering(input []*Event, order TopologicalOrder) []*Event
 func HeaderedReverseTopologicalOrdering(events []*HeaderedEvent, order TopologicalOrder) []*HeaderedEvent {
 	r := stateResolverV2{}
 	input := make([]*Event, len(events))
+	hisVis := make(map[string]HistoryVisibility)
 	for i := range events {
 		unwrapped := events[i].Unwrap()
 		input[i] = unwrapped
+		hisVis[unwrapped.EventID()] = events[i].Visibility
 	}
 	result := make([]*HeaderedEvent, len(input))
 	for i, e := range r.reverseTopologicalOrdering(input, order) {
 		result[i] = e.Headered(e.roomVersion)
+		result[i].Visibility = hisVis[e.EventID()]
 	}
 	return result
 }


### PR DESCRIPTION
This preserves the history visibility when using `HeaderedReverseTopologicalOrdering`, otherwise incremental syncs in Dendrite can't check the visibility of an event.