### PR TITLE
Fix /send_knock to be v1

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -189,7 +189,7 @@ func (ac *FederationClient) MakeKnock(
 func (ac *FederationClient) SendKnock(
 	ctx context.Context, s ServerName, event *Event,
 ) (res RespSendKnock, err error) {
-	path := federationPathPrefixV2 + "/send_knock/" +
+	path := federationPathPrefixV1 + "/send_knock/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
 
@@ -198,18 +198,6 @@ func (ac *FederationClient) SendKnock(
 		return
 	}
 	err = ac.doRequest(ctx, req, &res)
-	gerr, ok := err.(gomatrix.HTTPError)
-	if ok && gerr.Code == 404 {
-		// fallback to v1
-		v1path := federationPathPrefixV1 + "/send_knock/" +
-			url.PathEscape(event.RoomID()) + "/" +
-			url.PathEscape(event.EventID())
-		v1req := NewFederationRequest("PUT", s, v1path)
-		if err = v1req.SetContent(event); err != nil {
-			return
-		}
-		err = ac.doRequest(ctx, v1req, &res)
-	}
 	return
 }
 


### PR DESCRIPTION
Sorry about this. Turns out that /send_knock doesn't have a v2, but the format looks the same as /send_join's v2...

Follow-up to #329. I have since figured how to use gomatrixserverlib locally as an override in Complement and have tested it this time :-)