### PR TITLE
State/auth tweaks

### DIFF
--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -251,19 +251,19 @@ func HeaderedReverseTopologicalOrdering(events []*HeaderedEvent, order Topologic
 func isControlEvent(e *Event) bool {
 	switch e.Type() {
 	case MRoomPowerLevels:
-		// Power level events are control events.
-		return true
+		// Power level events with an empty state key are control events.
+		return e.StateKeyEquals("")
 	case MRoomJoinRules:
-		// Join rule events are control events.
-		return true
+		// Join rule events with an empty state key are control events.
+		return e.StateKeyEquals("")
 	case MRoomMember:
 		// Membership events must not have an empty state key.
-		if e.StateKey() == nil || *e.StateKey() == "" {
+		if e.StateKey() == nil || e.StateKeyEquals("") {
 			break
 		}
 		// Membership events are only control events if the sender does not match
 		// the state key, i.e. because the event is caused by an admin or moderator.
-		if e.Sender() == *e.StateKey() {
+		if e.StateKeyEquals(e.Sender()) {
 			break
 		}
 		// Membership events are only control events if the "membership" key in the

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -42,7 +42,7 @@ type stateResolverV2 struct {
 	resolvedJoinRules         *Event                        // Resolved join rules event
 	resolvedThirdPartyInvites map[string]*Event             // Resolved third party invite events
 	resolvedMembers           map[string]*Event             // Resolved member events
-	resolvedOthers            map[string]*Event             // Resolved other events
+	resolvedOthers            map[StateKeyTuple]*Event      // Resolved other events
 	result                    []*Event                      // Final list of resolved events
 }
 
@@ -88,7 +88,7 @@ func ResolveStateConflictsV2(
 		powerLevelMainlinePos:     make(map[string]int),
 		resolvedThirdPartyInvites: make(map[string]*Event, len(conflicted)),
 		resolvedMembers:           make(map[string]*Event, len(conflicted)),
-		resolvedOthers:            make(map[string]*Event, len(conflicted)),
+		resolvedOthers:            make(map[StateKeyTuple]*Event, len(conflicted)),
 		result:                    make([]*Event, 0, len(conflicted)+len(unconflicted)),
 	}
 	r.allower = newAllowerContext(&r)
@@ -422,7 +422,7 @@ func (r *stateResolverV2) applyEvents(events []*Event) {
 			case MRoomJoinRules:
 				r.resolvedJoinRules = event
 			default:
-				r.resolvedOthers[st+"\000"+*sk] = event
+				r.resolvedOthers[StateKeyTuple{st, *sk}] = event
 			}
 		} else {
 			// Some events with non-empty state keys are special,
@@ -434,7 +434,7 @@ func (r *stateResolverV2) applyEvents(events []*Event) {
 			case MRoomMember:
 				r.resolvedMembers[*sk] = event
 			default:
-				r.resolvedOthers[st+"\000"+*sk] = event
+				r.resolvedOthers[StateKeyTuple{st, *sk}] = event
 			}
 		}
 	}


### PR DESCRIPTION
This PR makes a couple minor changes:

* refactors the create check slightly, also checks that the room version is valid 
* modifies the state res v2 `applyEvents` function so that it doesn't accidentally drop events with unexpected non-empty state keys (i.e. `{"m.room.create", "something"}`) into oblivion, but instead sorts them into "other" events, so that event auth can decide the right thing to do with them instead
* modifies the state res v2 `isControlEvent` function to also check state keys, so that we don't incorrectly classify something that shouldn't be a control event