### PR TITLE
Update `applyAndAuthEvents`

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -342,6 +342,13 @@ func (a *AuthEvents) ThirdPartyInvite(stateKey string) (*Event, error) {
 	return a.events[StateKeyTuple{MRoomThirdPartyInvite, stateKey}], nil
 }
 
+// Clear removes all entries from the AuthEventProvider.
+func (a *AuthEvents) Clear() {
+	for k := range a.events {
+		delete(a.events, k)
+	}
+}
+
 // NewAuthEvents returns an AuthEventProvider backed by the given events. New events can be added by
 // calling AddEvent().
 func NewAuthEvents(events []*Event) AuthEvents {

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -406,7 +406,8 @@ func (r *stateResolverV2) authAndApplyEvents(events []*Event) {
 		// Check if the event is allowed based on the current partial state.
 		r.allower.update(&authEvents)
 		if err := r.allower.allowed(event); err != nil {
-			// The event was not allowed by the partial state, so skip it.
+			// The event was not allowed by the partial state and/or relevant
+			// auth events from the event, so skip it.
 			continue
 		}
 

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -404,10 +404,12 @@ func (r *stateResolverV2) authAndApplyEvents(events []*Event) {
 		}
 
 		// Check if the event is allowed based on the current partial state.
-		if err := newAllowerContext(&authEvents).allowed(event); err != nil {
+		r.allower.update(&authEvents)
+		if err := r.allower.allowed(event); err != nil {
 			// The event was not allowed by the partial state, so skip it.
 			continue
 		}
+
 		// Apply the newly authed event to the partial state. We need to do this
 		// here so that the next loop will have partial state to auth against.
 		r.applyEvents([]*Event{event})


### PR DESCRIPTION
This updates `applyAndAuthEvents` in state res v2 to pick auth events from the event if there is no matching event type/state key tuple in the partial state. It also optimises the auth event provider so that it only unmarshals the contents of events if they have changed to save CPU/allocations.