### PR TITLE
Enforce `type`, `sender`, `state_key` and `room_id` lengths using bytes rather than codepoints

### DIFF
--- a/event.go
+++ b/event.go
@@ -728,18 +728,18 @@ func (e *Event) CheckFields() error { // nolint: gocyclo
 		}
 	}
 
-	if l := len([]rune(fields.Type)); l > maxIDLength {
+	if l := len(fields.Type); l > maxIDLength {
 		return EventValidationError{
 			Code:    EventValidationTooLarge,
-			Message: fmt.Sprintf("gomatrixserverlib: event type is too long, length %d codepoints > maximum %d codepoints", l, maxIDLength),
+			Message: fmt.Sprintf("gomatrixserverlib: event type is too long, length %d bytes > maximum %d bytes", l, maxIDLength),
 		}
 	}
 
 	if fields.StateKey != nil {
-		if l := len([]rune(*fields.StateKey)); l > maxIDLength {
+		if l := len(*fields.StateKey); l > maxIDLength {
 			return EventValidationError{
 				Code:    EventValidationTooLarge,
-				Message: fmt.Sprintf("gomatrixserverlib: state key is too long, length %d codepoints > maximum %d codepoints", l, maxIDLength),
+				Message: fmt.Sprintf("gomatrixserverlib: state key is too long, length %d bytes > maximum %d bytes", l, maxIDLength),
 			}
 		}
 	}
@@ -794,10 +794,10 @@ func checkID(id, kind string, sigil byte) (domain string, err error) {
 		)
 		return
 	}
-	if l := len([]rune(id)); l > maxIDLength {
+	if l := len(id); l > maxIDLength {
 		err = EventValidationError{
 			Code:    EventValidationTooLarge,
-			Message: fmt.Sprintf("gomatrixserverlib: %s ID is too long, length %d codepoints > maximum %d codepoints", kind, l, maxIDLength),
+			Message: fmt.Sprintf("gomatrixserverlib: %s ID is too long, length %d bytes > maximum %d bytes", kind, l, maxIDLength),
 		}
 		return
 	}


### PR DESCRIPTION
This effectively reverts the change made in [5f66df0](https://github.com/matrix-org/gomatrixserverlib/commit/5f66df0) to bytes instead of codepoints, since Synapse will now enforce the same after matrix-org/synapse#13710. 

History here is that Synapse originally calculated bytes in Python 2.x, started counting codepoints in Python 3.x pretty much by accident and then the spec was ambiguous after the fact (hence matrix-org/matrix-spec#1001).

Rationale is that bytes are probably easier for implementations to manage and less likely to generate huge indexes for client-side databases (especially where limits might exist like LMDB). 

cc @reivilibre 