### PR TITLE
Fix authorizing PL changes when users_default≠0

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -674,8 +674,8 @@ func checkUserLevels(senderLevel int64, senderID string, oldPowerLevels, newPowe
 	userLevelChecks := map[string]levelPair{}
 	for userID := range newPowerLevels.Users {
 		userLevelChecks[userID] = levelPair{
-			old: oldPowerLevels.Users[userID],
-			new: newPowerLevels.Users[userID],
+			old: oldPowerLevels.UserLevel(userID),
+			new: newPowerLevels.UserLevel(userID),
 		}
 	}
 


### PR DESCRIPTION
`Users` map access would return 0 for users with no explicit power level, even though it should default to `users_default`. The existing `UserLevel()` helper method already handles it correctly, so this simply switches power level event auth to using that method.