### PR TITLE
Remove `origin` field from PDUs

### DIFF
--- a/eventcrypto.go
+++ b/eventcrypto.go
@@ -46,13 +46,6 @@ func (e *Event) VerifyEventSignatures(ctx context.Context, verifier JSONVerifier
 	}
 	needed[serverName] = struct{}{}
 
-	// TODO: This enables deprecation of the "origin" field as per MSC1664
-	// (https://github.com/matrix-org/matrix-doc/issues/1664) but really
-	// this has been done so that we can join rooms touched by Conduit again.
-	if serverName != e.Origin() && e.Origin() != "" {
-		needed[e.Origin()] = struct{}{}
-	}
-
 	// In room versions 1 and 2, we should also check that the server
 	// that created the event is included too. This is probably the
 	// same as the sender.

--- a/eventcrypto_test.go
+++ b/eventcrypto_test.go
@@ -387,8 +387,8 @@ func TestVerifyAllEventSignatures(t *testing.T) {
 	}
 
 	// There should be two verification requests
-	if len(verifier.requests) != 2 {
-		t.Fatalf("Number of requests: got %d, want 2", len(verifier.requests))
+	if len(verifier.requests) != 1 {
+		t.Fatalf("Number of requests: got %d, want 1", len(verifier.requests))
 	}
 	wantContent, err := RedactEventJSON(eventJSON, RoomVersionV1)
 	if err != nil {
@@ -410,9 +410,6 @@ func TestVerifyAllEventSignatures(t *testing.T) {
 	sort.Strings(servers)
 	if servers[0] != "localhost" {
 		t.Errorf("Verify server 0: got %s, want %s", servers[0], "localhost")
-	}
-	if servers[1] != "originserver" {
-		t.Errorf("Verify server 1: got %s, want %s", servers[1], "originserver")
 	}
 }
 


### PR DESCRIPTION
This nukes the `origin` field from PDUs as per matrix-org/matrix-spec#998.