### PR TITLE
`RespUserDevices` intermediate decoding

### DIFF
--- a/federationtypes.go
+++ b/federationtypes.go
@@ -244,8 +244,8 @@ func (r *RespUserDevices) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(intermediate.UserID, &r.UserID)
 	_ = json.Unmarshal(intermediate.StreamID, &r.StreamID)
-	_ = json.Unmarshal(intermediate.MasterKey, r.MasterKey)
-	_ = json.Unmarshal(intermediate.SelfSigningKey, r.SelfSigningKey)
+	_ = json.Unmarshal(intermediate.MasterKey, &r.MasterKey)
+	_ = json.Unmarshal(intermediate.SelfSigningKey, &r.SelfSigningKey)
 	for _, deviceJSON := range intermediate.Devices {
 		var device RespUserDevice
 		if err := json.Unmarshal(deviceJSON, &device); err == nil {

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -233,8 +233,8 @@ type RespUserDevices struct {
 // anything that fails to unmarshal and returns the rest.
 func (r *RespUserDevices) UnmarshalJSON(data []byte) error {
 	intermediate := struct {
-		UserID         string            `json:"user_id"`
-		StreamID       string            `json:"stream_id"`
+		UserID         json.RawMessage   `json:"user_id"`
+		StreamID       json.RawMessage   `json:"stream_id"`
 		Devices        []json.RawMessage `json:"devices"`
 		MasterKey      json.RawMessage   `json:"master_key"`
 		SelfSigningKey json.RawMessage   `json:"self_signing_key"`
@@ -242,6 +242,8 @@ func (r *RespUserDevices) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &intermediate); err != nil {
 		return err
 	}
+	_ = json.Unmarshal(intermediate.UserID, &r.UserID)
+	_ = json.Unmarshal(intermediate.StreamID, &r.StreamID)
 	_ = json.Unmarshal(intermediate.MasterKey, r.MasterKey)
 	_ = json.Unmarshal(intermediate.SelfSigningKey, r.SelfSigningKey)
 	for _, deviceJSON := range intermediate.Devices {


### PR DESCRIPTION
This should fix cases where Synapse users can upload absolute nonsense into their device keys and then that causes the entire devices response to fail to unmarshal.

This has happened both in the `"devices"` and `"stream_id"` keys that I can see.