### PR TITLE
Use stable identifiers from MSC3706 (Faster joins)

### DIFF
--- a/federationclient.go
+++ b/federationclient.go
@@ -147,7 +147,7 @@ func (ac *FederationClient) sendJoin(
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
 	if partialState {
-		path += "?org.matrix.msc3706.partial_state=true"
+		path += "?omit_members=true"
 	}
 
 	req := NewFederationRequest("PUT", origin, s, path)

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -444,9 +444,9 @@ type RespSendJoin struct {
 	// but not guaranteed to be present as it's only since MSC3083.
 	Event RawJSON `json:"event,omitempty"`
 	// true if the state is incomplete
-	PartialState bool `json:"org.matrix.msc3706.partial_state"`
+	PartialState bool `json:"members_omitted"`
 	// a list of servers in the room. Only returned if partial_state is set.
-	ServersInRoom []string `json:"org.matrix.msc3706.servers_in_room"`
+	ServersInRoom []string `json:"servers_in_room"`
 }
 
 // MarshalJSON implements json.Marshaller
@@ -517,8 +517,8 @@ type respSendJoinFields struct {
 // when the response has incomplete state.
 type respSendJoinPartialStateFields struct {
 	respSendJoinFields
-	PartialState  bool     `json:"org.matrix.msc3706.partial_state"`
-	ServersInRoom []string `json:"org.matrix.msc3706.servers_in_room"`
+	PartialState  bool     `json:"members_omitted"`
+	ServersInRoom []string `json:"servers_in_room"`
 }
 
 // ToRespState returns a new RespState with the same data from the given RespSendJoin

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -443,8 +443,8 @@ type RespSendJoin struct {
 	// The returned join event from the remote server. Used for restricted joins,
 	// but not guaranteed to be present as it's only since MSC3083.
 	Event RawJSON `json:"event,omitempty"`
-	// true if the state is incomplete
-	PartialState bool `json:"members_omitted"`
+	// true if m.room.member events have been omitted from StateEvents
+	MembersOmitted bool `json:"members_omitted"`
 	// a list of servers in the room. Only returned if partial_state is set.
 	ServersInRoom []string `json:"servers_in_room"`
 }

--- a/federationtypes.go
+++ b/federationtypes.go
@@ -443,7 +443,7 @@ type RespSendJoin struct {
 	// The returned join event from the remote server. Used for restricted joins,
 	// but not guaranteed to be present as it's only since MSC3083.
 	Event RawJSON `json:"event,omitempty"`
-	// true if m.room.member events have been omitted from StateEvents
+	// true if the state is incomplete
 	MembersOmitted bool `json:"members_omitted"`
 	// a list of servers in the room. Only returned if partial_state is set.
 	ServersInRoom []string `json:"servers_in_room"`
@@ -464,13 +464,13 @@ func (r RespSendJoin) MarshalJSON() ([]byte, error) {
 		fields.StateEvents = EventJSONs{}
 	}
 
-	if !r.PartialState {
+	if !r.MembersOmitted {
 		return json.Marshal(fields)
 	}
 
 	partialJoinFields := respSendJoinPartialStateFields{
 		respSendJoinFields: fields,
-		PartialState:       true,
+		MembersOmitted:     true,
 		ServersInRoom:      r.ServersInRoom,
 	}
 	return json.Marshal(partialJoinFields)
@@ -517,8 +517,8 @@ type respSendJoinFields struct {
 // when the response has incomplete state.
 type respSendJoinPartialStateFields struct {
 	respSendJoinFields
-	PartialState  bool     `json:"members_omitted"`
-	ServersInRoom []string `json:"servers_in_room"`
+	MembersOmitted bool     `json:"members_omitted"`
+	ServersInRoom  []string `json:"servers_in_room"`
 }
 
 // ToRespState returns a new RespState with the same data from the given RespSendJoin

--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -123,8 +123,8 @@ func TestRespSendJoinMarshalJSON(t *testing.T) {
 func TestRespSendJoinMarshalJSONPartialState(t *testing.T) {
 	inputData := `{
 		"state":[],"auth_chain":[],"origin":"o1",
-		"org.matrix.msc3706.partial_state":true,
-		"org.matrix.msc3706.servers_in_room":["s1", "s2"]
+		"members_omitted":true,
+		"servers_in_room":["s1", "s2"]
 	}`
 
 	var input RespSendJoin

--- a/federationtypes_test.go
+++ b/federationtypes_test.go
@@ -133,11 +133,11 @@ func TestRespSendJoinMarshalJSONPartialState(t *testing.T) {
 	}
 
 	want := RespSendJoin{
-		StateEvents:   []RawJSON{},
-		AuthEvents:    []RawJSON{},
-		Origin:        "o1",
-		PartialState:  true,
-		ServersInRoom: []string{"s1", "s2"},
+		StateEvents:    []RawJSON{},
+		AuthEvents:     []RawJSON{},
+		Origin:         "o1",
+		MembersOmitted: true,
+		ServersInRoom:  []string{"s1", "s2"},
 	}
 	if !cmp.Equal(input, want, cmp.AllowUnexported(RespSendJoin{})) {
 		t.Errorf("json.Unmarshal(%s): wanted %+v, got %+v", inputData, want, input)


### PR DESCRIPTION
I haven't made any effort to maintain backwards compatibility (unlike in https://github.com/matrix-org/synapse/pull/14832). I'm happy to do so if needed, but might need some guidance.

Synapse issue: https://github.com/matrix-org/synapse/issues/14828
Synapse PR: https://github.com/matrix-org/synapse/pull/14832
Complement PR: https://github.com/matrix-org/complement/pull/583
GMSL PR: https://github.com/matrix-org/gomatrixserverlib/pull/350
MSC: https://github.com/matrix-org/matrix-spec-proposals/pull/3706
Spec diff: https://github.com/matrix-org/matrix-spec/pull/1393

### Pull Request Checklist

* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `David Robertson <davidr@element.io>`
