### PR TITLE
refactor: move fedclient stuff to a new `fclient` package

### DIFF
--- a/authchain.go
+++ b/authchain.go
@@ -54,7 +54,7 @@ func VerifyEventAuthChain(ctx context.Context, eventToVerify *HeaderedEvent, pro
 			eventsToVerify = append(eventsToVerify, newEvents...) // verify these events too
 		}
 		// verify the event
-		if err := checkAllowedByAuthEvents(curr, eventsByID, provideEvents); err != nil {
+		if err := CheckAllowedByAuthEvents(curr, eventsByID, provideEvents); err != nil {
 			return fmt.Errorf("gomatrixserverlib: VerifyEventAuthChain %v failed auth check: %w", curr.EventID(), err)
 		}
 		// add to the verified list

--- a/fclient/crosssigning.go
+++ b/fclient/crosssigning.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gomatrixserverlib
+package fclient
 
 import (
 	"encoding/json"
 
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/tidwall/gjson"
 )
 
@@ -36,10 +37,10 @@ type CrossSigningKeys struct {
 
 // https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0keysdevice_signingupload
 type CrossSigningKey struct {
-	Signatures map[string]map[KeyID]Base64Bytes `json:"signatures,omitempty"`
-	Keys       map[KeyID]Base64Bytes            `json:"keys"`
-	Usage      []CrossSigningKeyPurpose         `json:"usage"`
-	UserID     string                           `json:"user_id"`
+	Signatures map[string]map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes `json:"signatures,omitempty"`
+	Keys       map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes            `json:"keys"`
+	Usage      []CrossSigningKeyPurpose                                             `json:"usage"`
+	UserID     string                                                               `json:"user_id"`
 }
 
 func (s *CrossSigningKey) isCrossSigningBody() {} // implements CrossSigningBody

--- a/fclient/dnscache.go
+++ b/fclient/dnscache.go
@@ -1,4 +1,4 @@
-package gomatrixserverlib
+package fclient
 
 import (
 	"context"

--- a/fclient/dnscache_test.go
+++ b/fclient/dnscache_test.go
@@ -1,4 +1,4 @@
-package gomatrixserverlib
+package fclient
 
 import (
 	"context"

--- a/fclient/federationclient.go
+++ b/fclient/federationclient.go
@@ -1,4 +1,4 @@
-package gomatrixserverlib
+package fclient
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/gomatrix"
+	"github.com/matrix-org/gomatrixserverlib"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -21,9 +22,9 @@ type FederationClient struct {
 
 type SigningIdentity struct {
 	// YAML annotations so it can be used directly in Dendrite config.
-	ServerName ServerName         `yaml:"server_name"`
-	KeyID      KeyID              `yaml:"key_id"`
-	PrivateKey ed25519.PrivateKey `yaml:"-"`
+	ServerName gomatrixserverlib.ServerName `yaml:"server_name"`
+	KeyID      gomatrixserverlib.KeyID      `yaml:"key_id"`
+	PrivateKey ed25519.PrivateKey           `yaml:"-"`
 }
 
 // NewFederationClient makes a new FederationClient. You can supply
@@ -42,16 +43,16 @@ func NewFederationClient(
 	}
 }
 
-func (ac *FederationClient) doRequest(ctx context.Context, r FederationRequest, resBody interface{}) error {
+func (ac *FederationClient) doRequest(ctx context.Context, r gomatrixserverlib.FederationRequest, resBody interface{}) error {
 	var identity *SigningIdentity
 	for _, id := range ac.identities {
-		if id.ServerName == r.fields.Origin {
+		if id.ServerName == r.Origin() {
 			identity = id
 			break
 		}
 	}
 	if identity == nil {
-		return fmt.Errorf("no signing identity for server name %q", r.fields.Origin)
+		return fmt.Errorf("no signing identity for server name %q", r.Origin())
 	}
 	if err := r.Sign(identity.ServerName, identity.KeyID, identity.PrivateKey); err != nil {
 		return err
@@ -70,10 +71,10 @@ var federationPathPrefixV2 = "/_matrix/federation/v2"
 
 // SendTransaction sends a transaction
 func (ac *FederationClient) SendTransaction(
-	ctx context.Context, t Transaction,
+	ctx context.Context, t gomatrixserverlib.Transaction,
 ) (res RespSend, err error) {
 	path := federationPathPrefixV1 + "/send/" + string(t.TransactionID)
-	req := NewFederationRequest("PUT", t.Origin, t.Destination, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", t.Origin, t.Destination, path)
 	if err = req.SetContent(t); err != nil {
 		return
 	}
@@ -83,12 +84,12 @@ func (ac *FederationClient) SendTransaction(
 
 // P2PSendTransactionToRelay sends a transaction for forwarding to the destination.
 func (ac *FederationClient) P2PSendTransactionToRelay(
-	ctx context.Context, u UserID, t Transaction, forwardingServer ServerName,
+	ctx context.Context, u gomatrixserverlib.UserID, t gomatrixserverlib.Transaction, forwardingServer gomatrixserverlib.ServerName,
 ) (res EmptyResp, err error) {
 	path := federationPathPrefixV1 + "/send_relay/" +
 		string(t.TransactionID) + "/" +
 		url.PathEscape(u.Raw())
-	req := NewFederationRequest("PUT", t.Origin, forwardingServer, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", t.Origin, forwardingServer, path)
 	if err = req.SetContent(t); err != nil {
 		return
 	}
@@ -98,10 +99,10 @@ func (ac *FederationClient) P2PSendTransactionToRelay(
 
 // P2PGetTransactionFromRelay requests a transaction from a relay destined for this server.
 func (ac *FederationClient) P2PGetTransactionFromRelay(
-	ctx context.Context, u UserID, prev RelayEntry, relayServer ServerName,
+	ctx context.Context, u gomatrixserverlib.UserID, prev RelayEntry, relayServer gomatrixserverlib.ServerName,
 ) (res RespGetRelayTransaction, err error) {
 	path := federationPathPrefixV1 + "/relay_txn/" + url.PathEscape(u.Raw())
-	req := NewFederationRequest("GET", u.Domain(), relayServer, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", u.Domain(), relayServer, path)
 	if err = req.SetContent(prev); err != nil {
 		return
 	}
@@ -112,7 +113,7 @@ func (ac *FederationClient) P2PGetTransactionFromRelay(
 // Creates a version query string with all the specified room versions, typically
 // the list of all supported room versions.
 // Needed when making a /make_knock or /make_join request.
-func makeVersionQueryString(roomVersions []RoomVersion) string {
+func makeVersionQueryString(roomVersions []gomatrixserverlib.RoomVersion) string {
 	versionQueryString := ""
 	if len(roomVersions) > 0 {
 		vqs := make([]string, 0, len(roomVersions))
@@ -134,14 +135,14 @@ func makeVersionQueryString(roomVersions []RoomVersion) string {
 // server's key and pass it to SendJoin.
 // See https://matrix.org/docs/spec/server_server/unstable.html#joining-rooms
 func (ac *FederationClient) MakeJoin(
-	ctx context.Context, origin, s ServerName, roomID, userID string,
-	roomVersions []RoomVersion,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string,
+	roomVersions []gomatrixserverlib.RoomVersion,
 ) (res RespMakeJoin, err error) {
 	versionQueryString := makeVersionQueryString(roomVersions)
 	path := federationPathPrefixV1 + "/make_join/" +
 		url.PathEscape(roomID) + "/" +
 		url.PathEscape(userID) + versionQueryString
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -151,7 +152,7 @@ func (ac *FederationClient) MakeJoin(
 // This is used to join a room the local server isn't a member of.
 // See https://matrix.org/docs/spec/server_server/unstable.html#joining-rooms
 func (ac *FederationClient) SendJoin(
-	ctx context.Context, origin, s ServerName, event *Event,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event,
 ) (res RespSendJoin, err error) {
 	return ac.sendJoin(ctx, origin, s, event, false)
 }
@@ -162,14 +163,14 @@ func (ac *FederationClient) SendJoin(
 // This is used to join a room the local server isn't a member of.
 // See https://matrix.org/docs/spec/server_server/unstable.html#joining-rooms
 func (ac *FederationClient) SendJoinPartialState(
-	ctx context.Context, origin, s ServerName, event *Event,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event,
 ) (res RespSendJoin, err error) {
 	return ac.sendJoin(ctx, origin, s, event, true)
 }
 
 // sendJoin is an internal implementation shared between SendJoin and SendJoinPartialState
 func (ac *FederationClient) sendJoin(
-	ctx context.Context, origin, s ServerName, event *Event, partialState bool,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event, partialState bool,
 ) (res RespSendJoin, err error) {
 	path := federationPathPrefixV2 + "/send_join/" +
 		url.PathEscape(event.RoomID()) + "/" +
@@ -178,7 +179,7 @@ func (ac *FederationClient) sendJoin(
 		path += "?omit_members=true"
 	}
 
-	req := NewFederationRequest("PUT", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, path)
 	if err = req.SetContent(event); err != nil {
 		return
 	}
@@ -189,7 +190,7 @@ func (ac *FederationClient) sendJoin(
 		v1path := federationPathPrefixV1 + "/send_join/" +
 			url.PathEscape(event.RoomID()) + "/" +
 			url.PathEscape(event.EventID())
-		v1req := NewFederationRequest("PUT", origin, s, v1path)
+		v1req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, v1path)
 		if err = v1req.SetContent(event); err != nil {
 			return
 		}
@@ -211,14 +212,14 @@ func (ac *FederationClient) sendJoin(
 // server's key and pass it to SendKnock.
 // See https://spec.matrix.org/v1.3/server-server-api/#knocking-upon-a-room
 func (ac *FederationClient) MakeKnock(
-	ctx context.Context, origin, s ServerName, roomID, userID string,
-	roomVersions []RoomVersion,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string,
+	roomVersions []gomatrixserverlib.RoomVersion,
 ) (res RespMakeKnock, err error) {
 	versionQueryString := makeVersionQueryString(roomVersions)
 	path := federationPathPrefixV1 + "/make_knock/" +
 		url.PathEscape(roomID) + "/" +
 		url.PathEscape(userID) + versionQueryString
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -228,13 +229,13 @@ func (ac *FederationClient) MakeKnock(
 // This is used to ask to join a room the local server isn't a member of.
 // See https://spec.matrix.org/v1.3/server-server-api/#knocking-upon-a-room
 func (ac *FederationClient) SendKnock(
-	ctx context.Context, origin, s ServerName, event *Event,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event,
 ) (res RespSendKnock, err error) {
 	path := federationPathPrefixV1 + "/send_knock/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
 
-	req := NewFederationRequest("PUT", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, path)
 	if err = req.SetContent(event); err != nil {
 		return
 	}
@@ -248,12 +249,12 @@ func (ac *FederationClient) SendKnock(
 // the event_id with our own, and pass it to SendLeave.
 // See https://matrix.org/docs/spec/server_server/r0.1.1.html#get-matrix-federation-v1-make-leave-roomid-userid
 func (ac *FederationClient) MakeLeave(
-	ctx context.Context, origin, s ServerName, roomID, userID string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string,
 ) (res RespMakeLeave, err error) {
 	path := federationPathPrefixV1 + "/make_leave/" +
 		url.PathEscape(roomID) + "/" +
 		url.PathEscape(userID)
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -263,12 +264,12 @@ func (ac *FederationClient) MakeLeave(
 // This is used to reject a remote invite.
 // See https://matrix.org/docs/spec/server_server/r0.1.1.html#put-matrix-federation-v1-send-leave-roomid-eventid
 func (ac *FederationClient) SendLeave(
-	ctx context.Context, origin, s ServerName, event *Event,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event,
 ) (err error) {
 	path := federationPathPrefixV2 + "/send_leave/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
-	req := NewFederationRequest("PUT", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, path)
 	if err = req.SetContent(event); err != nil {
 		return
 	}
@@ -280,7 +281,7 @@ func (ac *FederationClient) SendLeave(
 		v1path := federationPathPrefixV1 + "/send_leave/" +
 			url.PathEscape(event.RoomID()) + "/" +
 			url.PathEscape(event.EventID())
-		v1req := NewFederationRequest("PUT", origin, s, v1path)
+		v1req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, v1path)
 		if err = v1req.SetContent(event); err != nil {
 			return
 		}
@@ -296,12 +297,12 @@ func (ac *FederationClient) SendLeave(
 // SendInvite sends an invite m.room.member event to an invited server to be
 // signed by it. This is used to invite a user that is not on the local server.
 func (ac *FederationClient) SendInvite(
-	ctx context.Context, origin, s ServerName, event *Event,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event,
 ) (res RespInvite, err error) {
 	path := federationPathPrefixV1 + "/invite/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
-	req := NewFederationRequest("PUT", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, path)
 	if err = req.SetContent(event); err != nil {
 		return
 	}
@@ -312,13 +313,13 @@ func (ac *FederationClient) SendInvite(
 // SendInviteV2 sends an invite m.room.member event to an invited server to be
 // signed by it. This is used to invite a user that is not on the local server.
 func (ac *FederationClient) SendInviteV2(
-	ctx context.Context, origin, s ServerName, request InviteV2Request,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, request gomatrixserverlib.InviteV2Request,
 ) (res RespInviteV2, err error) {
 	event := request.Event()
 	path := federationPathPrefixV2 + "/invite/" +
 		url.PathEscape(event.RoomID()) + "/" +
 		url.PathEscape(event.EventID())
-	req := NewFederationRequest("PUT", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, path)
 	if err = req.SetContent(request); err != nil {
 		return
 	}
@@ -347,11 +348,11 @@ func (ac *FederationClient) SendInviteV2(
 // This is used to exchange a m.room.third_party_invite event for a m.room.member
 // one in a room the local server isn't a member of.
 func (ac *FederationClient) ExchangeThirdPartyInvite(
-	ctx context.Context, origin, s ServerName, builder EventBuilder,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, builder gomatrixserverlib.EventBuilder,
 ) (err error) {
 	path := federationPathPrefixV1 + "/exchange_third_party_invite/" +
 		url.PathEscape(builder.RoomID)
-	req := NewFederationRequest("PUT", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, path)
 	if err = req.SetContent(builder); err != nil {
 		return
 	}
@@ -363,13 +364,13 @@ func (ac *FederationClient) ExchangeThirdPartyInvite(
 // LookupState retrieves the room state for a room at an event from a
 // remote matrix server as full matrix events.
 func (ac *FederationClient) LookupState(
-	ctx context.Context, origin, s ServerName, roomID, eventID string, roomVersion RoomVersion,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, eventID string, roomVersion gomatrixserverlib.RoomVersion,
 ) (res RespState, err error) {
 	path := federationPathPrefixV1 + "/state/" +
 		url.PathEscape(roomID) +
 		"?event_id=" +
 		url.QueryEscape(eventID)
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -377,13 +378,13 @@ func (ac *FederationClient) LookupState(
 // LookupStateIDs retrieves the room state for a room at an event from a
 // remote matrix server as lists of matrix event IDs.
 func (ac *FederationClient) LookupStateIDs(
-	ctx context.Context, origin, s ServerName, roomID, eventID string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, eventID string,
 ) (res RespStateIDs, err error) {
 	path := federationPathPrefixV1 + "/state_ids/" +
 		url.PathEscape(roomID) +
 		"?event_id=" +
 		url.QueryEscape(eventID)
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -392,12 +393,12 @@ func (ac *FederationClient) LookupStateIDs(
 // given bracket.
 // https://matrix.org/docs/spec/server_server/r0.1.3#post-matrix-federation-v1-get-missing-events-roomid
 func (ac *FederationClient) LookupMissingEvents(
-	ctx context.Context, origin, s ServerName, roomID string,
-	missing MissingEvents, roomVersion RoomVersion,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string,
+	missing MissingEvents, roomVersion gomatrixserverlib.RoomVersion,
 ) (res RespMissingEvents, err error) {
 	path := federationPathPrefixV1 + "/get_missing_events/" +
 		url.PathEscape(roomID)
-	req := NewFederationRequest("POST", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("POST", origin, s, path)
 	if err = req.SetContent(missing); err != nil {
 		return
 	}
@@ -407,8 +408,8 @@ func (ac *FederationClient) LookupMissingEvents(
 
 // Peek starts a peek on a remote server: see MSC2753
 func (ac *FederationClient) Peek(
-	ctx context.Context, origin, s ServerName, roomID, peekID string,
-	roomVersions []RoomVersion,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, peekID string,
+	roomVersions []gomatrixserverlib.RoomVersion,
 ) (res RespPeek, err error) {
 	versionQueryString := ""
 	if len(roomVersions) > 0 {
@@ -421,7 +422,7 @@ func (ac *FederationClient) Peek(
 	path := federationPathPrefixV1 + "/peek/" +
 		url.PathEscape(roomID) + "/" +
 		url.PathEscape(peekID) + versionQueryString
-	req := NewFederationRequest("PUT", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("PUT", origin, s, path)
 	var empty struct{}
 	if err = req.SetContent(empty); err != nil {
 		return
@@ -436,11 +437,11 @@ func (ac *FederationClient) Peek(
 // If the room alias doesn't exist on the remote server then a 404 gomatrix.HTTPError
 // is returned.
 func (ac *FederationClient) LookupRoomAlias(
-	ctx context.Context, origin, s ServerName, roomAlias string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomAlias string,
 ) (res RespDirectory, err error) {
 	path := federationPathPrefixV1 + "/query/directory?room_alias=" +
 		url.QueryEscape(roomAlias)
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -449,7 +450,7 @@ func (ac *FederationClient) LookupRoomAlias(
 // Spec: https://matrix.org/docs/spec/server_server/r0.1.1.html#get-matrix-federation-v1-publicrooms
 // thirdPartyInstanceID can only be non-empty if includeAllNetworks is false.
 func (ac *FederationClient) GetPublicRooms(
-	ctx context.Context, origin, s ServerName, limit int, since string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, limit int, since string,
 	includeAllNetworks bool, thirdPartyInstanceID string,
 ) (res RespPublicRooms, err error) {
 	return ac.GetPublicRoomsFiltered(ctx, origin, s, limit, since, "", includeAllNetworks, thirdPartyInstanceID)
@@ -473,7 +474,7 @@ type postPublicRoomsReq struct {
 // Spec: https://spec.matrix.org/v1.1/server-server-api/#post_matrixfederationv1publicrooms
 // thirdPartyInstanceID can only be non-empty if includeAllNetworks is false.
 func (ac *FederationClient) GetPublicRoomsFiltered(
-	ctx context.Context, origin, s ServerName, limit int, since, filter string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, limit int, since, filter string,
 	includeAllNetworks bool, thirdPartyInstanceID string,
 ) (res RespPublicRooms, err error) {
 	if includeAllNetworks && thirdPartyInstanceID != "" {
@@ -488,7 +489,7 @@ func (ac *FederationClient) GetPublicRoomsFiltered(
 		Since:                since,
 	}
 	path := federationPathPrefixV1 + "/publicRooms"
-	req := NewFederationRequest("POST", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("POST", origin, s, path)
 	if err = req.SetContent(roomsReq); err != nil {
 		return
 	}
@@ -502,14 +503,14 @@ func (ac *FederationClient) GetPublicRoomsFiltered(
 // which field of the profile should be returned.
 // Spec: https://matrix.org/docs/spec/server_server/r0.1.1.html#get-matrix-federation-v1-query-profile
 func (ac *FederationClient) LookupProfile(
-	ctx context.Context, origin, s ServerName, userID string, field string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, userID string, field string,
 ) (res RespProfile, err error) {
 	path := federationPathPrefixV1 + "/query/profile?user_id=" +
 		url.QueryEscape(userID)
 	if field != "" {
 		path += "&field=" + url.QueryEscape(field)
 	}
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -524,9 +525,9 @@ func (ac *FederationClient) LookupProfile(
 //	}
 //
 // https://matrix.org/docs/spec/server_server/latest#post-matrix-federation-v1-user-keys-claim
-func (ac *FederationClient) ClaimKeys(ctx context.Context, origin, s ServerName, oneTimeKeys map[string]map[string]string) (res RespClaimKeys, err error) {
+func (ac *FederationClient) ClaimKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (res RespClaimKeys, err error) {
 	path := federationPathPrefixV1 + "/user/keys/claim"
-	req := NewFederationRequest("POST", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("POST", origin, s, path)
 	if err = req.SetContent(map[string]interface{}{
 		"one_time_keys": oneTimeKeys,
 	}); err != nil {
@@ -538,9 +539,9 @@ func (ac *FederationClient) ClaimKeys(ctx context.Context, origin, s ServerName,
 
 // QueryKeys queries E2E device keys from a remote server.
 // https://matrix.org/docs/spec/server_server/latest#post-matrix-federation-v1-user-keys-query
-func (ac *FederationClient) QueryKeys(ctx context.Context, origin, s ServerName, keys map[string][]string) (res RespQueryKeys, err error) {
+func (ac *FederationClient) QueryKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string) (res RespQueryKeys, err error) {
 	path := federationPathPrefixV1 + "/user/keys/query"
-	req := NewFederationRequest("POST", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("POST", origin, s, path)
 	if err = req.SetContent(map[string]interface{}{
 		"device_keys": keys,
 	}); err != nil {
@@ -553,10 +554,10 @@ func (ac *FederationClient) QueryKeys(ctx context.Context, origin, s ServerName,
 // GetEvent gets an event by ID from a remote server.
 // See https://matrix.org/docs/spec/server_server/r0.1.1.html#get-matrix-federation-v1-event-eventid
 func (ac *FederationClient) GetEvent(
-	ctx context.Context, origin, s ServerName, eventID string,
-) (res Transaction, err error) {
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, eventID string,
+) (res gomatrixserverlib.Transaction, err error) {
 	path := federationPathPrefixV1 + "/event/" + url.PathEscape(eventID)
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -564,10 +565,10 @@ func (ac *FederationClient) GetEvent(
 // GetEventAuth gets an event auth chain from a remote server.
 // See https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-event-auth-roomid-eventid
 func (ac *FederationClient) GetEventAuth(
-	ctx context.Context, origin, s ServerName, roomVersion RoomVersion, roomID, eventID string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomVersion gomatrixserverlib.RoomVersion, roomID, eventID string,
 ) (res RespEventAuth, err error) {
 	path := federationPathPrefixV1 + "/event_auth/" + url.PathEscape(roomID) + "/" + url.PathEscape(eventID)
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -575,10 +576,10 @@ func (ac *FederationClient) GetEventAuth(
 // GetUserDevices returns a list of the user's devices from a remote server.
 // See https://matrix.org/docs/spec/server_server/latest#get-matrix-federation-v1-user-devices-userid
 func (ac *FederationClient) GetUserDevices(
-	ctx context.Context, origin, s ServerName, userID string,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, userID string,
 ) (res RespUserDevices, err error) {
 	path := federationPathPrefixV1 + "/user/devices/" + url.PathEscape(userID)
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
@@ -587,8 +588,8 @@ func (ac *FederationClient) GetUserDevices(
 // local database.
 // See https://matrix.org/docs/spec/server_server/unstable.html#get-matrix-federation-v1-backfill-roomid
 func (ac *FederationClient) Backfill(
-	ctx context.Context, origin, s ServerName, roomID string, limit int, eventIDs []string,
-) (res Transaction, err error) {
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, limit int, eventIDs []string,
+) (res gomatrixserverlib.Transaction, err error) {
 	// Parse the limit into a string so that we can include it in the URL's query.
 	limitStr := strconv.Itoa(limit)
 
@@ -605,17 +606,17 @@ func (ac *FederationClient) Backfill(
 	path := u.RequestURI()
 
 	// Send the request.
-	req := NewFederationRequest("GET", origin, s, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, s, path)
 	err = ac.doRequest(ctx, req, &res)
 	return
 }
 
 // MSC2836EventRelationships performs an MSC2836 /event_relationships request.
 func (ac *FederationClient) MSC2836EventRelationships(
-	ctx context.Context, origin, dst ServerName, r MSC2836EventRelationshipsRequest, roomVersion RoomVersion,
+	ctx context.Context, origin, dst gomatrixserverlib.ServerName, r MSC2836EventRelationshipsRequest, roomVersion gomatrixserverlib.RoomVersion,
 ) (res MSC2836EventRelationshipsResponse, err error) {
 	path := "/_matrix/federation/unstable/event_relationships"
-	req := NewFederationRequest("POST", origin, dst, path)
+	req := gomatrixserverlib.NewFederationRequest("POST", origin, dst, path)
 	if err = req.SetContent(r); err != nil {
 		return
 	}
@@ -624,13 +625,13 @@ func (ac *FederationClient) MSC2836EventRelationships(
 }
 
 func (ac *FederationClient) MSC2946Spaces(
-	ctx context.Context, origin, dst ServerName, roomID string, suggestedOnly bool,
+	ctx context.Context, origin, dst gomatrixserverlib.ServerName, roomID string, suggestedOnly bool,
 ) (res MSC2946SpacesResponse, err error) {
 	path := "/_matrix/federation/v1/hierarchy/" + url.PathEscape(roomID)
 	if suggestedOnly {
 		path += "?suggested_only=true"
 	}
-	req := NewFederationRequest("GET", origin, dst, path)
+	req := gomatrixserverlib.NewFederationRequest("GET", origin, dst, path)
 	err = ac.doRequest(ctx, req, &res)
 	if err != nil {
 		gerr, ok := err.(gomatrix.HTTPError)
@@ -640,7 +641,7 @@ func (ac *FederationClient) MSC2946Spaces(
 			if suggestedOnly {
 				path += "?suggested_only=true"
 			}
-			req := NewFederationRequest("GET", origin, dst, path)
+			req := gomatrixserverlib.NewFederationRequest("GET", origin, dst, path)
 			err = ac.doRequest(ctx, req, &res)
 		}
 	}

--- a/fclient/federationclient_test.go
+++ b/fclient/federationclient_test.go
@@ -1,4 +1,4 @@
-package gomatrixserverlib_test
+package fclient_test
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -34,7 +35,7 @@ func TestSendJoinFallback(t *testing.T) {
 	roomVer := gomatrixserverlib.RoomVersionV1
 	// we don't care about the actual contents, just that it ferries data across fine.
 	retEv := gomatrixserverlib.RawJSON(`{"auth_events":[],"content":{"creator":"@userid:baba.is.you"},"depth":0,"event_id":"$WCraVpPZe5TtHAqs:baba.is.you","hashes":{"sha256":"EehWNbKy+oDOMC0vIvYl1FekdDxMNuabXKUVzV7DG74"},"origin":"baba.is.you","origin_server_ts":0,"prev_events":[],"prev_state":[],"room_id":"!roomid:baba.is.you","sender":"@userid:baba.is.you","signatures":{"baba.is.you":{"ed25519:auto":"08aF4/bYWKrdGPFdXmZCQU6IrOE1ulpevmWBM3kiShJPAbRbZ6Awk7buWkIxlMF6kX3kb4QpbAlZfHLQgncjCw"}},"state_key":"","type":"m.room.create"}`)
-	wantRes := gomatrixserverlib.RespSendJoin{
+	wantRes := fclient.RespSendJoin{
 		StateEvents: gomatrixserverlib.EventJSONs{
 			retEv,
 		},
@@ -46,17 +47,17 @@ func TestSendJoinFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to marshal RespSendJoin: %s", err)
 	}
-	fc := gomatrixserverlib.NewFederationClient(
-		[]*gomatrixserverlib.SigningIdentity{
+	fc := fclient.NewFederationClient(
+		[]*fclient.SigningIdentity{
 			{
 				ServerName: serverName,
 				KeyID:      keyID,
 				PrivateKey: privateKey,
 			},
 		},
-		gomatrixserverlib.WithSkipVerify(true),
+		fclient.WithSkipVerify(true),
 	)
-	fc.Client = *gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(
+	fc.Client = *fclient.NewClient(fclient.WithTransport(
 		&roundTripper{
 			fn: func(req *http.Request) (*http.Response, error) {
 				if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v2/send_join") {
@@ -108,17 +109,17 @@ func TestSendJoinJSON(t *testing.T) {
 		"auth_chain": [%s]
 	}`, string(retEv), string(retEv)))
 
-	fc := gomatrixserverlib.NewFederationClient(
-		[]*gomatrixserverlib.SigningIdentity{
+	fc := fclient.NewFederationClient(
+		[]*fclient.SigningIdentity{
 			{
 				ServerName: serverName,
 				KeyID:      keyID,
 				PrivateKey: privateKey,
 			},
 		},
-		gomatrixserverlib.WithSkipVerify(true),
+		fclient.WithSkipVerify(true),
 	)
-	fc.Client = *gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(
+	fc.Client = *fclient.NewClient(fclient.WithTransport(
 		&roundTripper{
 			fn: func(req *http.Request) (*http.Response, error) {
 				if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v2/send_join") {
@@ -167,17 +168,17 @@ func TestSendTransactionToRelay(t *testing.T) {
 	_, privateKey, _ := ed25519.GenerateKey(nil)
 	respSendResponseJSON := []byte(`{"error": ""}`)
 
-	fc := gomatrixserverlib.NewFederationClient(
-		[]*gomatrixserverlib.SigningIdentity{
+	fc := fclient.NewFederationClient(
+		[]*fclient.SigningIdentity{
 			{
 				ServerName: serverName,
 				KeyID:      keyID,
 				PrivateKey: privateKey,
 			},
 		},
-		gomatrixserverlib.WithSkipVerify(true),
+		fclient.WithSkipVerify(true),
 	)
-	fc.Client = *gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(
+	fc.Client = *fclient.NewClient(fclient.WithTransport(
 		&roundTripper{
 			fn: func(req *http.Request) (*http.Response, error) {
 				if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v1/send_relay") {
@@ -214,17 +215,17 @@ func TestSendTransactionToRelayReportsFailure(t *testing.T) {
 	errorMessage := "Invalid transaction"
 	respSendResponseJSON := []byte(fmt.Sprintf(`{"error": "%s"}`, errorMessage))
 
-	fc := gomatrixserverlib.NewFederationClient(
-		[]*gomatrixserverlib.SigningIdentity{
+	fc := fclient.NewFederationClient(
+		[]*fclient.SigningIdentity{
 			{
 				ServerName: serverName,
 				KeyID:      keyID,
 				PrivateKey: privateKey,
 			},
 		},
-		gomatrixserverlib.WithSkipVerify(true),
+		fclient.WithSkipVerify(true),
 	)
-	fc.Client = *gomatrixserverlib.NewClient(gomatrixserverlib.WithTransport(
+	fc.Client = *fclient.NewClient(fclient.WithTransport(
 		&roundTripper{
 			fn: func(req *http.Request) (*http.Response, error) {
 				if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v1/send_relay") {

--- a/fclient/federationtypes_test.go
+++ b/fclient/federationtypes_test.go
@@ -1,4 +1,4 @@
-package gomatrixserverlib
+package fclient
 
 import (
 	"encoding/json"
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const emptyRespStateResponse = `{"pdus":[],"auth_chain":[]}`
@@ -24,7 +25,7 @@ func TestParseServerName(t *testing.T) {
 	}
 
 	for input, output := range validTests {
-		host, port, isValid := ParseAndValidateServerName(ServerName(input))
+		host, port, isValid := gomatrixserverlib.ParseAndValidateServerName(gomatrixserverlib.ServerName(input))
 		if !isValid {
 			t.Errorf("Expected serverName '%s' to be parsed as valid, but was not", input)
 		}
@@ -55,7 +56,7 @@ func TestParseServerName(t *testing.T) {
 	}
 
 	for _, input := range invalidTests {
-		_, _, isValid := ParseAndValidateServerName(ServerName(input))
+		_, _, isValid := gomatrixserverlib.ParseAndValidateServerName(gomatrixserverlib.ServerName(input))
 		if isValid {
 			t.Errorf("Expected serverName '%s' to be rejected but was accepted", input)
 		}
@@ -108,8 +109,8 @@ func TestRespSendJoinMarshalJSON(t *testing.T) {
 	}
 
 	want := RespSendJoin{
-		StateEvents: []RawJSON{},
-		AuthEvents:  []RawJSON{},
+		StateEvents: []gomatrixserverlib.RawJSON{},
+		AuthEvents:  []gomatrixserverlib.RawJSON{},
 		Origin:      "",
 	}
 	if !cmp.Equal(input, want, cmp.AllowUnexported(RespSendJoin{})) {
@@ -139,8 +140,8 @@ func TestRespSendJoinMarshalJSONPartialState(t *testing.T) {
 	}
 
 	want := RespSendJoin{
-		StateEvents:    []RawJSON{},
-		AuthEvents:     []RawJSON{},
+		StateEvents:    []gomatrixserverlib.RawJSON{},
+		AuthEvents:     []gomatrixserverlib.RawJSON{},
 		Origin:         "o1",
 		MembersOmitted: true,
 		ServersInRoom:  []string{"s1", "s2"},

--- a/fclient/relaytypes.go
+++ b/fclient/relaytypes.go
@@ -1,6 +1,10 @@
-package gomatrixserverlib
+package fclient
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/matrix-org/gomatrixserverlib"
+)
 
 // A RelayEntry is used to track the nid of an event received from a relay server.
 // It is used as the request body of a GET to /_matrix/federation/v1/relay_txn/{userID}
@@ -10,13 +14,13 @@ type RelayEntry struct {
 
 // A RespGetRelayTransaction is the response body of a successful GET to /_matrix/federation/v1/relay_txn/{userID}
 type RespGetRelayTransaction struct {
-	Transaction   Transaction `json:"transaction"`
-	EntryID       int64       `json:"entry_id,omitempty"`
-	EntriesQueued bool        `json:"entries_queued"`
+	Transaction   gomatrixserverlib.Transaction `json:"transaction"`
+	EntryID       int64                         `json:"entry_id,omitempty"`
+	EntriesQueued bool                          `json:"entries_queued"`
 }
 
 // RelayEvents is the request body of a PUT to /_matrix/federation/v1/send_relay/{txnID}/{userID}
 type RelayEvents struct {
-	PDUs []json.RawMessage `json:"pdus"`
-	EDUs []EDU             `json:"edus"`
+	PDUs []json.RawMessage       `json:"pdus"`
+	EDUs []gomatrixserverlib.EDU `json:"edus"`
 }

--- a/fclient/resolve.go
+++ b/fclient/resolve.go
@@ -13,21 +13,23 @@
  * limitations under the License.
  */
 
-package gomatrixserverlib
+package fclient
 
 import (
 	"context"
 	"fmt"
 	"net"
 	"strconv"
+
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // ResolutionResult is a result of looking up a Matrix homeserver according to
 // the federation specification.
 type ResolutionResult struct {
-	Destination   string     // The hostname and port to send federation requests to.
-	Host          ServerName // The value of the Host headers.
-	TLSServerName string     // The TLS server name to request a certificate for.
+	Destination   string                       // The hostname and port to send federation requests to.
+	Host          gomatrixserverlib.ServerName // The value of the Host headers.
+	TLSServerName string                       // The TLS server name to request a certificate for.
 }
 
 // ResolveServer implements the server name resolution algorithm described at
@@ -35,15 +37,15 @@ type ResolutionResult struct {
 // Returns a slice of ResolutionResult that can be used to send a federation
 // request to the server using a given server name.
 // Returns an error if the server name isn't valid.
-func ResolveServer(ctx context.Context, serverName ServerName) (results []ResolutionResult, err error) {
+func ResolveServer(ctx context.Context, serverName gomatrixserverlib.ServerName) (results []ResolutionResult, err error) {
 	return resolveServer(ctx, serverName, true)
 }
 
 // resolveServer does the same thing as ResolveServer, except it also requires
 // the checkWellKnown parameter, which indicates whether a .well-known file
 // should be looked up.
-func resolveServer(ctx context.Context, serverName ServerName, checkWellKnown bool) (results []ResolutionResult, err error) {
-	host, port, valid := ParseAndValidateServerName(serverName)
+func resolveServer(ctx context.Context, serverName gomatrixserverlib.ServerName, checkWellKnown bool) (results []ResolutionResult, err error) {
+	host, port, valid := gomatrixserverlib.ParseAndValidateServerName(serverName)
 	if !valid {
 		err = fmt.Errorf("Invalid server name")
 		return
@@ -104,7 +106,7 @@ func resolveServer(ctx context.Context, serverName ServerName, checkWellKnown bo
 
 // handleNoWellKnown implements steps 4 and 5 of the resolution algorithm (as
 // well as 3.3 and 3.4)
-func handleNoWellKnown(ctx context.Context, serverName ServerName) (results []ResolutionResult) {
+func handleNoWellKnown(ctx context.Context, serverName gomatrixserverlib.ServerName) (results []ResolutionResult) {
 	// 4. If the /.well-known request resulted in an error response
 	_, records, err := net.DefaultResolver.LookupSRV(ctx, "matrix", "tcp", string(serverName))
 	if err == nil && len(records) > 0 {

--- a/fclient/resolve_test.go
+++ b/fclient/resolve_test.go
@@ -1,4 +1,4 @@
-package gomatrixserverlib
+package fclient
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/miekg/dns"
 	"gopkg.in/h2non/gock.v1"
 )
@@ -26,12 +27,12 @@ func assertCritical(t *testing.T, val, expected interface{}) {
 // and expected certificate name.
 // If one of them doesn't match, or the resolution function returned with an
 // error, it aborts the current test.
-func testResolve(t *testing.T, serverName ServerName, destination, host, certName string) {
+func testResolve(t *testing.T, serverName gomatrixserverlib.ServerName, destination, host, certName string) {
 	res, err := ResolveServer(context.Background(), serverName)
 	assertCritical(t, err, nil)
 	assertCritical(t, len(res), 1)
 	assertCritical(t, res[0].Destination, destination)
-	assertCritical(t, res[0].Host, ServerName(host))
+	assertCritical(t, res[0].Host, gomatrixserverlib.ServerName(host))
 	assertCritical(t, res[0].TLSServerName, certName)
 }
 
@@ -39,10 +40,10 @@ func testResolve(t *testing.T, serverName ServerName, destination, host, certNam
 func TestResolutionIPLiteral(t *testing.T) {
 	testResolve(
 		t,
-		ServerName("42.42.42.42"), // The server name is an IP literal without a port
-		"42.42.42.42:8448",        // Destination must be the IP address + port 8448
-		"42.42.42.42",             // Host must be the IP address
-		"42.42.42.42",             // Certificate (Name) must be for the IP address
+		gomatrixserverlib.ServerName("42.42.42.42"), // The server name is an IP literal without a port
+		"42.42.42.42:8448",                          // Destination must be the IP address + port 8448
+		"42.42.42.42",                               // Host must be the IP address
+		"42.42.42.42",                               // Certificate (Name) must be for the IP address
 	)
 }
 
@@ -50,10 +51,10 @@ func TestResolutionIPLiteral(t *testing.T) {
 func TestResolutionIPv6Literal(t *testing.T) {
 	testResolve(
 		t,
-		ServerName("[42:42::42]"), // The server name is an IP literal without a port
-		"[42:42::42]:8448",        // Destination must be the IP address + port 8448
-		"[42:42::42]",             // Host must be the IP address
-		"42:42::42",               // Certificate (Name) must be for the IP address
+		gomatrixserverlib.ServerName("[42:42::42]"), // The server name is an IP literal without a port
+		"[42:42::42]:8448",                          // Destination must be the IP address + port 8448
+		"[42:42::42]",                               // Host must be the IP address
+		"42:42::42",                                 // Certificate (Name) must be for the IP address
 	)
 }
 
@@ -61,10 +62,10 @@ func TestResolutionIPv6Literal(t *testing.T) {
 func TestResolutionIPLiteralWithPort(t *testing.T) {
 	testResolve(
 		t,
-		ServerName("42.42.42.42:443"), // The server name is an IP literal with a port
-		"42.42.42.42:443",             // Destination must be the IP address + port
-		"42.42.42.42:443",             // Host must be the IP address + port
-		"42.42.42.42",                 // Certificate (Name) must be for the IP address
+		gomatrixserverlib.ServerName("42.42.42.42:443"), // The server name is an IP literal with a port
+		"42.42.42.42:443", // Destination must be the IP address + port
+		"42.42.42.42:443", // Host must be the IP address + port
+		"42.42.42.42",     // Certificate (Name) must be for the IP address
 	)
 }
 
@@ -72,10 +73,10 @@ func TestResolutionIPLiteralWithPort(t *testing.T) {
 func TestResolutionIPv6LiteralWithPort(t *testing.T) {
 	testResolve(
 		t,
-		ServerName("[42:42::42]:443"), // The server name is an IP literal with a port
-		"[42:42::42]:443",             // Destination must be the IP address + port
-		"[42:42::42]:443",             // Host must be the IP address + port
-		"42:42::42",                   // Certificate (Name) must be for the IP address
+		gomatrixserverlib.ServerName("[42:42::42]:443"), // The server name is an IP literal with a port
+		"[42:42::42]:443", // Destination must be the IP address + port
+		"[42:42::42]:443", // Host must be the IP address + port
+		"42:42::42",       // Certificate (Name) must be for the IP address
 	)
 }
 
@@ -83,10 +84,10 @@ func TestResolutionIPv6LiteralWithPort(t *testing.T) {
 func TestResolutionHostnameAndPort(t *testing.T) {
 	testResolve(
 		t,
-		ServerName("example.com:4242"), // The server name is not an IP literal and includes an explicit port
-		"example.com:4242",             // Destination must be the hostname + port
-		"example.com:4242",             // Host must be the hostname + port
-		"example.com",                  // Certificate (Name) must be for the hostname
+		gomatrixserverlib.ServerName("example.com:4242"), // The server name is not an IP literal and includes an explicit port
+		"example.com:4242", // Destination must be the hostname + port
+		"example.com:4242", // Host must be the hostname + port
+		"example.com",      // Certificate (Name) must be for the hostname
 	)
 }
 
@@ -101,10 +102,10 @@ func TestResolutionHostnameWellKnownWithIPLiteral(t *testing.T) {
 
 	testResolve(
 		t,
-		ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies an IP literal without a port
-		"42.42.42.42:8448",        // Destination must be the IP literal + port 8448
-		"42.42.42.42",             // Host must be the IP literal
-		"42.42.42.42",             // Certificate (Name) must be for the IP literal
+		gomatrixserverlib.ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies an IP literal without a port
+		"42.42.42.42:8448",                          // Destination must be the IP literal + port 8448
+		"42.42.42.42",                               // Host must be the IP literal
+		"42.42.42.42",                               // Certificate (Name) must be for the IP literal
 	)
 }
 
@@ -119,10 +120,10 @@ func TestResolutionHostnameWellKnownWithIPLiteralAndPort(t *testing.T) {
 
 	testResolve(
 		t,
-		ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies an IP literal with a port
-		"42.42.42.42:443",         // Destination must be the IP literal + port
-		"42.42.42.42:443",         // Host must be the IP literal + port
-		"42.42.42.42",             // Certificate (Name) must be for the IP literal
+		gomatrixserverlib.ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies an IP literal with a port
+		"42.42.42.42:443", // Destination must be the IP literal + port
+		"42.42.42.42:443", // Host must be the IP literal + port
+		"42.42.42.42",     // Certificate (Name) must be for the IP literal
 	)
 }
 
@@ -137,10 +138,10 @@ func TestResolutionHostnameWellKnownWithHostnameAndPort(t *testing.T) {
 
 	testResolve(
 		t,
-		ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies a hostname that's not an IP literal and has a port
-		"matrix.example.com:4242", // Destination must be the hostname + port
-		"matrix.example.com:4242", // Host must be the hostname + port
-		"matrix.example.com",      // Certificate (Name) must be for the hostname
+		gomatrixserverlib.ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies a hostname that's not an IP literal and has a port
+		"matrix.example.com:4242",                   // Destination must be the hostname + port
+		"matrix.example.com:4242",                   // Host must be the hostname + port
+		"matrix.example.com",                        // Certificate (Name) must be for the hostname
 	)
 }
 
@@ -158,10 +159,10 @@ func TestResolutionHostnameWellKnownWithHostnameSRV(t *testing.T) {
 
 	testResolve(
 		t,
-		ServerName("example.com"),      // The server name is a domain hosting a .well-known file which specifies a hostname that's not an IP literal, has no port and for which a SRV record with a non-0 exists
-		"matrix.otherexample.com:4242", // Destination must be the hostname + port from the SRV record
-		"matrix.example.com",           // Host must be the delegated hostname
-		"matrix.example.com",           // Certificate (Name) must be for the delegated hostname
+		gomatrixserverlib.ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies a hostname that's not an IP literal, has no port and for which a SRV record with a non-0 exists
+		"matrix.otherexample.com:4242",              // Destination must be the hostname + port from the SRV record
+		"matrix.example.com",                        // Host must be the delegated hostname
+		"matrix.example.com",                        // Certificate (Name) must be for the delegated hostname
 	)
 }
 
@@ -179,10 +180,10 @@ func TestResolutionHostnameWellKnownWithHostnameNoSRV(t *testing.T) {
 
 	testResolve(
 		t,
-		ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies a hostname that's not an IP literal, has no port and for which no SRV record exists
-		"matrix.example.com:8448", // Destination must be the delegated hostname + port 8448
-		"matrix.example.com",      // Host must be the delegated hostname
-		"matrix.example.com",      // Certificate (Name) must be for the delegated hostname
+		gomatrixserverlib.ServerName("example.com"), // The server name is a domain hosting a .well-known file which specifies a hostname that's not an IP literal, has no port and for which no SRV record exists
+		"matrix.example.com:8448",                   // Destination must be the delegated hostname + port 8448
+		"matrix.example.com",                        // Host must be the delegated hostname
+		"matrix.example.com",                        // Certificate (Name) must be for the delegated hostname
 	)
 }
 
@@ -193,10 +194,10 @@ func TestResolutionHostnameWithSRV(t *testing.T) {
 
 	testResolve(
 		t,
-		ServerName("example.com"),      // The server name is a domain for which a SRV record exists with a non-0 port
-		"matrix.otherexample.com:4242", // Destination must be the hostname + port
-		"example.com",                  // Host must be the server name
-		"example.com",                  // Certificate (Name) must be for the server name
+		gomatrixserverlib.ServerName("example.com"), // The server name is a domain for which a SRV record exists with a non-0 port
+		"matrix.otherexample.com:4242",              // Destination must be the hostname + port
+		"example.com",                               // Host must be the server name
+		"example.com",                               // Certificate (Name) must be for the server name
 	)
 }
 
@@ -213,10 +214,10 @@ func TestResolutionHostnameWithNoWellKnownNorSRV(t *testing.T) {
 
 	testResolve(
 		t,
-		ServerName("example.com"), // The server name is a domain for no .well-known file nor SRV record exist
-		"example.com:8448",        // Destination must be the hostname + 8448
-		"example.com",             // Host must be the server name
-		"example.com",             // Certificate (Name) must be for the server name
+		gomatrixserverlib.ServerName("example.com"), // The server name is a domain for no .well-known file nor SRV record exist
+		"example.com:8448",                          // Destination must be the hostname + 8448
+		"example.com",                               // Host must be the server name
+		"example.com",                               // Certificate (Name) must be for the server name
 	)
 }
 

--- a/fclient/well_known.go
+++ b/fclient/well_known.go
@@ -1,4 +1,4 @@
-package gomatrixserverlib
+package fclient
 
 import (
 	"context"
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 var (
@@ -21,13 +23,13 @@ const WellKnownMaxSize = 50 * 1024 // 50KB
 // WellKnownResult is the result of looking up a matrix server's well-known file.
 // Located at https://<server_name>/.well-known/matrix/server
 type WellKnownResult struct {
-	NewAddress     ServerName `json:"m.server"`
+	NewAddress     gomatrixserverlib.ServerName `json:"m.server"`
 	CacheExpiresAt int64
 }
 
 // LookupWellKnown looks up a well-known record for a matrix server. If one if
 // found, it returns the server to redirect to.
-func LookupWellKnown(ctx context.Context, serverNameType ServerName) (*WellKnownResult, error) {
+func LookupWellKnown(ctx context.Context, serverNameType gomatrixserverlib.ServerName) (*WellKnownResult, error) {
 	serverName := string(serverNameType)
 
 	// Handle ending "/"

--- a/servername.go
+++ b/servername.go
@@ -1,0 +1,104 @@
+package gomatrixserverlib
+
+import (
+	"net"
+	"strconv"
+	"strings"
+)
+
+// A ServerName is the name a matrix homeserver is identified by.
+// It is a DNS name or IP address optionally followed by a port.
+//
+// https://matrix.org/docs/spec/appendices.html#server-name
+type ServerName string
+
+// ParseAndValidateServerName splits a ServerName into a host and port part,
+// and checks that it is a valid server name according to the spec.
+//
+// if there is no explicit port, returns '-1' as the port.
+func ParseAndValidateServerName(serverName ServerName) (host string, port int, valid bool) {
+	// Don't go any further if the server name is an empty string.
+	if len(serverName) == 0 {
+		return
+	}
+
+	host, port = splitServerName(serverName)
+
+	// the host part must be one of:
+	//  - a valid (ascii) dns name
+	//  - an IPv4 address
+	//  - an IPv6 address
+
+	if len(host) == 0 {
+		return
+	}
+
+	if host[0] == '[' {
+		// must be a valid IPv6 address
+		if host[len(host)-1] != ']' {
+			return
+		}
+		ip := host[1 : len(host)-1]
+		if net.ParseIP(ip) == nil {
+			return
+		}
+		valid = true
+		return
+	}
+
+	// try parsing as an IPv4 address
+	ip := net.ParseIP(host)
+	if ip != nil && ip.To4() != nil {
+		valid = true
+		return
+	}
+
+	// must be a valid DNS Name
+	for _, r := range host {
+		if !isDNSNameChar(r) {
+			return
+		}
+	}
+
+	valid = true
+	return
+}
+
+func isDNSNameChar(r rune) bool {
+	if r >= 'A' && r <= 'Z' {
+		return true
+	}
+	if r >= 'a' && r <= 'z' {
+		return true
+	}
+	if r >= '0' && r <= '9' {
+		return true
+	}
+	if r == '-' || r == '.' {
+		return true
+	}
+	return false
+}
+
+// splitServerName splits a ServerName into host and port, without doing
+// any validation.
+//
+// if there is no explicit port, returns '-1' as the port
+func splitServerName(serverName ServerName) (string, int) {
+	nameStr := string(serverName)
+
+	lastColon := strings.LastIndex(nameStr, ":")
+	if lastColon < 0 {
+		// no colon: no port
+		return nameStr, -1
+	}
+
+	portStr := nameStr[lastColon+1:]
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		// invalid port (possibly an ipv6 host)
+		return nameStr, -1
+	}
+
+	return nameStr[:lastColon], int(port)
+}


### PR DESCRIPTION
This removes around 3k out of 16k LoC to a separate package which (mostly) is boring type structs and HTTP wrapper functions.

A notable exception is `RespSendJoin.Check` and `RespState.Check` which do complex logic which suprise surprise isn't tested yet.

This will be refactored further in another PR.
