### PR TITLE
Remove methods returning/using `EventReference`

### DIFF
--- a/event.go
+++ b/event.go
@@ -364,18 +364,6 @@ func (e *event) updateUnsignedFields(unsigned []byte) error {
 	return nil
 }
 
-// EventReference returns an EventReference for the event.
-// The reference can be used to refer to this event from other events.
-func (e *event) EventReference() EventReference {
-	reference, err := referenceOfEvent(e.eventJSON, e.roomVersion)
-	if err != nil {
-		// This is unreachable for events created with EventBuilder.Build or NewEventFromUntrustedJSON
-		// This can be reached if NewEventFromTrustedJSON is given JSON from an untrusted source.
-		panic(fmt.Errorf("gomatrixserverlib: invalid event %v (%q)", err, string(e.eventJSON)))
-	}
-	return reference
-}
-
 // Sign returns a copy of the event with an additional signature.
 func (e *event) Sign(signingName string, keyID KeyID, privateKey ed25519.PrivateKey) PDU {
 	eventJSON, err := signEvent(signingName, keyID, privateKey, e.eventJSON, e.roomVersion)

--- a/event.go
+++ b/event.go
@@ -669,33 +669,6 @@ func (e *event) Content() []byte {
 	}
 }
 
-// PrevEvents returns references to the direct ancestors of the event.
-func (e *event) PrevEvents() []EventReference {
-	switch fields := e.fields.(type) {
-	case eventFormatV1Fields:
-		return fields.PrevEvents
-	case eventFormatV2Fields:
-		result := make([]EventReference, 0, len(fields.PrevEvents))
-		for _, id := range fields.PrevEvents {
-			// In the new event format, the event ID is already the hash of
-			// the event. Since we will have generated the event ID before
-			// now, we can just knock the sigil $ off the front and use that
-			// as the event SHA256.
-			var sha spec.Base64Bytes
-			if err := sha.Decode(id[1:]); err != nil {
-				panic("gomatrixserverlib: event ID is malformed: " + err.Error())
-			}
-			result = append(result, EventReference{
-				EventID:     id,
-				EventSHA256: sha,
-			})
-		}
-		return result
-	default:
-		panic(e.invalidFieldType())
-	}
-}
-
 // PrevEventIDs returns the event IDs of the direct ancestors of the event.
 func (e *event) PrevEventIDs() []string {
 	switch fields := e.fields.(type) {

--- a/event.go
+++ b/event.go
@@ -715,29 +715,6 @@ func (e *event) PowerLevels() (*PowerLevelContent, error) {
 	return &c, nil
 }
 
-// AuthEvents returns references to the events needed to auth the event.
-func (e *event) AuthEvents() []EventReference {
-	switch fields := e.fields.(type) {
-	case eventFormatV1Fields:
-		return fields.AuthEvents
-	case eventFormatV2Fields:
-		result := make([]EventReference, 0, len(fields.AuthEvents))
-		for _, id := range fields.AuthEvents {
-			var sha spec.Base64Bytes
-			if err := sha.Decode(id[1:]); err != nil {
-				panic("gomatrixserverlib: event ID is malformed: " + err.Error())
-			}
-			result = append(result, EventReference{
-				EventID:     id,
-				EventSHA256: sha,
-			})
-		}
-		return result
-	default:
-		panic(e.invalidFieldType())
-	}
-}
-
 // AuthEventIDs returns the event IDs of the events needed to auth the event.
 func (e *event) AuthEventIDs() []string {
 	switch fields := e.fields.(type) {

--- a/event.go
+++ b/event.go
@@ -75,8 +75,8 @@ type eventFields struct {
 type eventFormatV1Fields struct {
 	eventFields
 	EventID    string           `json:"event_id,omitempty"`
-	PrevEvents []EventReference `json:"prev_events"`
-	AuthEvents []EventReference `json:"auth_events"`
+	PrevEvents []eventReference `json:"prev_events"`
+	AuthEvents []eventReference `json:"auth_events"`
 }
 
 // Fields for room versions 3, 4, 5.
@@ -86,7 +86,7 @@ type eventFormatV2Fields struct {
 	AuthEvents []string `json:"auth_events"`
 }
 
-var emptyEventReferenceList = []EventReference{}
+var emptyEventReferenceList = []eventReference{}
 
 // newEventFromUntrustedJSON loads a new event from some JSON that may be invalid.
 // This checks that the event is valid JSON.
@@ -520,7 +520,7 @@ func (e *event) generateEventID() (eventID string, err error) {
 	case EventFormatV1:
 		eventID = e.fields.(eventFormatV1Fields).EventID
 	case EventFormatV2:
-		var reference EventReference
+		var reference eventReference
 		reference, err = referenceOfEvent(e.eventJSON, e.roomVersion)
 		if err != nil {
 			return
@@ -784,10 +784,10 @@ func SplitID(sigil byte, id string) (local string, domain spec.ServerName, err e
 // situation.
 func (e *eventFormatV1Fields) fixNilSlices() {
 	if e.AuthEvents == nil {
-		e.AuthEvents = []EventReference{}
+		e.AuthEvents = []eventReference{}
 	}
 	if e.PrevEvents == nil {
-		e.PrevEvents = []EventReference{}
+		e.PrevEvents = []eventReference{}
 	}
 }
 

--- a/event_builder.go
+++ b/event_builder.go
@@ -75,8 +75,8 @@ func (eb *EventBuilder) AddAuthEvents(provider AuthEventProvider) error {
 	return nil
 }
 
-// TODO: Remove/unexport
-func ToEventReference(data any) []EventReference {
+// TODO: Remove?
+func toEventReference(data any) []EventReference {
 	switch evs := data.(type) {
 	case nil:
 		return []EventReference{}
@@ -154,8 +154,8 @@ func (eb *EventBuilder) Build(
 		// marshal them into 'null' instead of '[]', which is bad. Since the
 		// EventBuilder struct is instantiated outside of gomatrixserverlib
 		// let's just make sure that they haven't been left as nil slices.
-		eventStruct.PrevEvents = ToEventReference(eventStruct.PrevEvents)
-		eventStruct.AuthEvents = ToEventReference(eventStruct.AuthEvents)
+		eventStruct.PrevEvents = toEventReference(eventStruct.PrevEvents)
+		eventStruct.AuthEvents = toEventReference(eventStruct.AuthEvents)
 	case EventFormatV2:
 		// In this event format, prev_events and auth_events are lists of
 		// event IDs as a []string, rather than full-blown []EventReference.

--- a/event_builder.go
+++ b/event_builder.go
@@ -125,6 +125,8 @@ func (eb *EventBuilder) Build(
 					})
 				}
 				eventStruct.PrevEvents = newPrevEvents
+			} else {
+				eventStruct.PrevEvents = []EventReference{}
 			}
 		}
 		if eventStruct.AuthEvents == nil {
@@ -140,8 +142,9 @@ func (eb *EventBuilder) Build(
 					})
 				}
 				eventStruct.AuthEvents = newAuthEvents
+			} else {
+				eventStruct.AuthEvents = []EventReference{}
 			}
-
 		}
 	case EventFormatV2:
 		// In this event format, prev_events and auth_events are lists of

--- a/eventauth.go
+++ b/eventauth.go
@@ -70,35 +70,35 @@ func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []Eve
 		if e, err = provider.Create(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
 		}
 	}
 	if s.JoinRules {
 		if e, err = provider.JoinRules(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
 		}
 	}
 	if s.PowerLevels {
 		if e, err = provider.PowerLevels(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
 		}
 	}
 	for _, userID := range s.Member {
 		if e, err = provider.Member(userID); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
 		}
 	}
 	for _, token := range s.ThirdPartyInvite {
 		if e, err = provider.ThirdPartyInvite(token); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
 		}
 	}
 	return

--- a/eventauth.go
+++ b/eventauth.go
@@ -70,35 +70,35 @@ func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []Eve
 		if e, err = provider.Create(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, e.EventReference())
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
 		}
 	}
 	if s.JoinRules {
 		if e, err = provider.JoinRules(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, e.EventReference())
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
 		}
 	}
 	if s.PowerLevels {
 		if e, err = provider.PowerLevels(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, e.EventReference())
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
 		}
 	}
 	for _, userID := range s.Member {
 		if e, err = provider.Member(userID); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, e.EventReference())
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
 		}
 	}
 	for _, token := range s.ThirdPartyInvite {
 		if e, err = provider.ThirdPartyInvite(token); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, e.EventReference())
+			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64Bytes(e.EventID())})
 		}
 	}
 	return

--- a/eventauth.go
+++ b/eventauth.go
@@ -63,42 +63,42 @@ func (s StateNeeded) Tuples() (res []StateKeyTuple) {
 // AuthEventReferences returns the auth_events references for the StateNeeded. Returns an error if the
 // provider returns an error. If an event is missing from the provider but is required in StateNeeded, it
 // is skipped over: no error is returned.
-func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []EventReference, err error) { // nolint: gocyclo
-	refs = []EventReference{}
+func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []string, err error) { // nolint: gocyclo
+	refs = make([]string, 0, 5) // we'll probably have about ~5 events, so pre allocate that
 	var e PDU
 	if s.Create {
 		if e, err = provider.Create(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
+			refs = append(refs, e.EventID())
 		}
 	}
 	if s.JoinRules {
 		if e, err = provider.JoinRules(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
+			refs = append(refs, e.EventID())
 		}
 	}
 	if s.PowerLevels {
 		if e, err = provider.PowerLevels(); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
+			refs = append(refs, e.EventID())
 		}
 	}
 	for _, userID := range s.Member {
 		if e, err = provider.Member(userID); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
+			refs = append(refs, e.EventID())
 		}
 	}
 	for _, token := range s.ThirdPartyInvite {
 		if e, err = provider.ThirdPartyInvite(token); err != nil {
 			return
 		} else if e != nil {
-			refs = append(refs, EventReference{EventID: e.EventID(), EventSHA256: spec.Base64FromEventID(e.EventID())})
+			refs = append(refs, e.EventID())
 		}
 	}
 	return

--- a/handlejoin.go
+++ b/handlejoin.go
@@ -119,11 +119,12 @@ func HandleMakeJoin(input HandleMakeJoinInput) (*HandleMakeJoinResponse, error) 
 		return nil, spec.Forbidden(err.Error())
 	}
 
-	// TODO: Remove. This ensures we send event references instead of eventIDs
+	// This ensures we send EventReferences for room version v1 and v2. We need to do this, since we're
+	// returning the proto event, which isn't modified when running `Build`.
 	switch input.RoomVersion {
 	case RoomVersionV1, RoomVersionV2:
-		proto.AuthEvents = ToEventReference(event.AuthEventIDs())
-		proto.PrevEvents = ToEventReference(event.PrevEventIDs())
+		proto.AuthEvents = toEventReference(event.AuthEventIDs())
+		proto.PrevEvents = toEventReference(event.PrevEventIDs())
 	}
 
 	makeJoinResponse := HandleMakeJoinResponse{

--- a/handlejoin.go
+++ b/handlejoin.go
@@ -119,6 +119,13 @@ func HandleMakeJoin(input HandleMakeJoinInput) (*HandleMakeJoinResponse, error) 
 		return nil, spec.Forbidden(err.Error())
 	}
 
+	// TODO: Remove. This ensures we send event references instead of eventIDs
+	switch input.RoomVersion {
+	case RoomVersionV1, RoomVersionV2:
+		proto.AuthEvents = ToEventReference(event.AuthEventIDs())
+		proto.PrevEvents = ToEventReference(event.PrevEventIDs())
+	}
+
 	makeJoinResponse := HandleMakeJoinResponse{
 		JoinTemplateEvent: proto,
 		RoomVersion:       input.RoomVersion,

--- a/handleleave.go
+++ b/handleleave.go
@@ -84,6 +84,14 @@ func HandleMakeLeave(input HandleMakeLeaveInput) (*HandleMakeLeaveResponse, erro
 		return nil, spec.Forbidden(err.Error())
 	}
 
+	// This ensures we send EventReferences for room version v1 and v2. We need to do this, since we're
+	// returning the proto event, which isn't modified when running `Build`.
+	switch event.Version() {
+	case RoomVersionV1, RoomVersionV2:
+		proto.PrevEvents = toEventReference(event.PrevEventIDs())
+		proto.AuthEvents = toEventReference(event.AuthEventIDs())
+	}
+
 	makeLeaveResponse := HandleMakeLeaveResponse{
 		LeaveTemplateEvent: proto,
 		RoomVersion:        input.RoomVersion,

--- a/join.go
+++ b/join.go
@@ -39,10 +39,10 @@ type ProtoEvent struct {
 	// The state_key of the event if the event is a state event or nil if the event is not a state event.
 	StateKey *string `json:"state_key,omitempty"`
 	// The events that immediately preceded this event in the room history. This can be
-	// either []EventReference for room v1/v2, and []string for room v3 onwards.
+	// either []eventReference for room v1/v2, and []string for room v3 onwards.
 	PrevEvents interface{} `json:"prev_events"`
 	// The events needed to authenticate this event. This can be
-	// either []EventReference for room v1/v2, and []string for room v3 onwards.
+	// either []eventReference for room v1/v2, and []string for room v3 onwards.
 	AuthEvents interface{} `json:"auth_events"`
 	// The event ID of the event being redacted if this event is a "m.room.redaction".
 	Redacts string `json:"redacts,omitempty"`

--- a/pdu.go
+++ b/pdu.go
@@ -48,7 +48,6 @@ type PDU interface {
 	SetUnsignedField(path string, value interface{}) error
 	// Sign returns a copy of the event with an additional signature.
 	Sign(signingName string, keyID KeyID, privateKey ed25519.PrivateKey) PDU
-	//EventReference() EventReference  // TODO: remove
 	Depth() int64                    // TODO: remove
 	JSON() []byte                    // TODO: remove
 	AuthEventIDs() []string          // TODO: remove

--- a/pdu.go
+++ b/pdu.go
@@ -32,7 +32,6 @@ type PDU interface {
 	// Redacted returns whether the event is redacted.
 	Redacted() bool
 	PrevEventIDs() []string
-	PrevEvents() []EventReference // TODO: remove, used in Dendrite in (d *EventDatabase) StoreEvent
 	OriginServerTS() spec.Timestamp
 	// Redact redacts the event.
 	Redact()

--- a/pdu.go
+++ b/pdu.go
@@ -48,7 +48,7 @@ type PDU interface {
 	SetUnsignedField(path string, value interface{}) error
 	// Sign returns a copy of the event with an additional signature.
 	Sign(signingName string, keyID KeyID, privateKey ed25519.PrivateKey) PDU
-	EventReference() EventReference  // TODO: remove
+	//EventReference() EventReference  // TODO: remove
 	Depth() int64                    // TODO: remove
 	JSON() []byte                    // TODO: remove
 	AuthEventIDs() []string          // TODO: remove

--- a/pdu.go
+++ b/pdu.go
@@ -76,8 +76,8 @@ type StateKeyTuple struct {
 	StateKey string
 }
 
-// An EventReference is a reference to a matrix event.
-type EventReference struct {
+// An eventReference is a reference to a matrix event.
+type eventReference struct {
 	// The event ID of the event.
 	EventID string
 	// The sha256 of the redacted event.
@@ -85,7 +85,7 @@ type EventReference struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaller
-func (er *EventReference) UnmarshalJSON(data []byte) error {
+func (er *eventReference) UnmarshalJSON(data []byte) error {
 	var tuple []spec.RawJSON
 	if err := json.Unmarshal(data, &tuple); err != nil {
 		return err
@@ -107,7 +107,7 @@ func (er *EventReference) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON implements json.Marshaller
-func (er EventReference) MarshalJSON() ([]byte, error) {
+func (er eventReference) MarshalJSON() ([]byte, error) {
 	hashes := struct {
 		SHA256 spec.Base64Bytes `json:"sha256"`
 	}{er.EventSHA256}

--- a/spec/base64.go
+++ b/spec/base64.go
@@ -39,6 +39,20 @@ func (b64 Base64Bytes) Encode() string {
 	return base64.RawStdEncoding.EncodeToString(b64)
 }
 
+// Base64FromEventID returns, if possible, the base64bytes representation
+// of the given eventID. Returns nil if an error occurs while decoding the eventID.
+func Base64FromEventID(eventID string) Base64Bytes {
+	// In the new event format, the event ID is already the hash of
+	// the event. Since we will have generated the event ID before
+	// now, we can just knock the sigil $ off the front and use that
+	// as the event SHA256.
+	var sha Base64Bytes
+	if err := sha.Decode(eventID[1:]); err != nil {
+		return nil
+	}
+	return sha
+}
+
 // Decode decodes the given input into this Base64Bytes
 func (b64 *Base64Bytes) Decode(str string) error {
 	// We must check whether the string was encoded in a URL-safe way in order

--- a/spec/base64.go
+++ b/spec/base64.go
@@ -39,20 +39,6 @@ func (b64 Base64Bytes) Encode() string {
 	return base64.RawStdEncoding.EncodeToString(b64)
 }
 
-// Base64FromEventID returns, if possible, the base64bytes representation
-// of the given eventID. Returns nil if an error occurs while decoding the eventID.
-func Base64FromEventID(eventID string) Base64Bytes {
-	// In the new event format, the event ID is already the hash of
-	// the event. Since we will have generated the event ID before
-	// now, we can just knock the sigil $ off the front and use that
-	// as the event SHA256.
-	var sha Base64Bytes
-	if err := sha.Decode(eventID[1:]); err != nil {
-		return nil
-	}
-	return sha
-}
-
 // Decode decodes the given input into this Base64Bytes
 func (b64 *Base64Bytes) Decode(str string) error {
 	// We must check whether the string was encoded in a URL-safe way in order

--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -107,10 +107,10 @@ func getBaseStateResV2Graph() []PDU {
 					StateKey:       &ALICE,
 					Content:        []byte(`{"membership": "join"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 				},
 			},
@@ -127,10 +127,10 @@ func getBaseStateResV2Graph() []PDU {
 					StateKey:       &emptyStateKey,
 					Content:        []byte(`{"users": {"` + ALICE + `": 100}}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$IMA:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IMA:example.com"},
 				},
@@ -148,10 +148,10 @@ func getBaseStateResV2Graph() []PDU {
 					StateKey:       &emptyStateKey,
 					Content:        []byte(`{"join_rule": "public"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$IPOWER:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IMA:example.com"},
 					{EventID: "$IPOWER:example.com"},
@@ -170,10 +170,10 @@ func getBaseStateResV2Graph() []PDU {
 					StateKey:       &BOB,
 					Content:        []byte(`{"membership": "join"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$IJR:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IJR:example.com"},
 					{EventID: "$IPOWER:example.com"},
@@ -192,10 +192,10 @@ func getBaseStateResV2Graph() []PDU {
 					StateKey:       &CHARLIE,
 					Content:        []byte(`{"membership": "join"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$IMB:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IJR:example.com"},
 					{EventID: "$IPOWER:example.com"},
@@ -244,10 +244,10 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 					"` + BOB + `": 50
 				}}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$IMZJOIN:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IMA:example.com"},
 					{EventID: "$IPOWER:example.com"},
@@ -269,10 +269,10 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 					"` + BOB + `": 50
 				}}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$IMC:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IMA:example.com"},
 					{EventID: "$IPOWER:example.com"},
@@ -291,10 +291,10 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 					StateKey:       &EVELYN,
 					Content:        []byte(`{"membership": "ban"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$PA:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IMA:example.com"},
 					{EventID: "$PB:example.com"},
@@ -313,10 +313,10 @@ func TestStateResolutionBanVsPowerLevel(t *testing.T) {
 					StateKey:       &EVELYN,
 					Content:        []byte(`{"membership": "join"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$MB:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IJR:example.com"},
 					{EventID: "$PA:example.com"},
@@ -346,10 +346,10 @@ func TestStateResolutionJoinRuleEvasion(t *testing.T) {
 					StateKey:       &emptyStateKey,
 					Content:        []byte(`{"join_rule": "invite"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$IMZ:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$IMA:example.com"},
 					{EventID: "$IPOWER:example.com"},
@@ -368,10 +368,10 @@ func TestStateResolutionJoinRuleEvasion(t *testing.T) {
 					StateKey:       &ZARA,
 					Content:        []byte(`{"membership": "join"}`),
 				},
-				PrevEvents: []EventReference{
+				PrevEvents: []eventReference{
 					{EventID: "$JR:example.com"},
 				},
-				AuthEvents: []EventReference{
+				AuthEvents: []eventReference{
 					{EventID: "$CREATE:example.com"},
 					{EventID: "$JR:example.com"},
 					{EventID: "$IPOWER:example.com"},


### PR DESCRIPTION
Also removes `CacheCost` which is now implemented in Dendrite.