### PR TITLE
Move Invite logic to GMSL

### DIFF
--- a/fclient/federationtypes.go
+++ b/fclient/federationtypes.go
@@ -332,7 +332,7 @@ func (r RespSendJoin) MarshalJSON() ([]byte, error) {
 // A RespSendKnock is the content of a response to PUT /_matrix/federation/v2/send_knock/{roomID}/{eventID}
 type RespSendKnock struct {
 	// A list of stripped state events to help the initiator of the knock identify the room.
-	KnockRoomState []InviteV2StrippedState `json:"knock_room_state"`
+	KnockRoomState []gomatrixserverlib.InviteStrippedState `json:"knock_room_state"`
 }
 
 // A RespMakeKnock is the content of a response to GET /_matrix/federation/v2/make_knock/{roomID}/{userID}

--- a/fclient/invitev2.go
+++ b/fclient/invitev2.go
@@ -5,14 +5,13 @@ import (
 	"errors"
 
 	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
 )
 
 // InviteV2Request and InviteV2StrippedState are defined in
 // https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v2-invite-roomid-eventid
 
-func NewInviteV2Request(event gomatrixserverlib.PDU, state []InviteV2StrippedState) (
+func NewInviteV2Request(event gomatrixserverlib.PDU, state []gomatrixserverlib.InviteStrippedState) (
 	request InviteV2Request, err error,
 ) {
 	if !gomatrixserverlib.KnownRoomVersion(event.Version()) {
@@ -30,8 +29,8 @@ func NewInviteV2Request(event gomatrixserverlib.PDU, state []InviteV2StrippedSta
 }
 
 type inviteV2RequestHeaders struct {
-	RoomVersion     gomatrixserverlib.RoomVersion `json:"room_version"`
-	InviteRoomState []InviteV2StrippedState       `json:"invite_room_state"`
+	RoomVersion     gomatrixserverlib.RoomVersion           `json:"room_version"`
+	InviteRoomState []gomatrixserverlib.InviteStrippedState `json:"invite_room_state"`
 }
 
 // InviteV2Request is used in the body of a /_matrix/federation/v2/invite request.
@@ -77,57 +76,6 @@ func (i *InviteV2Request) RoomVersion() gomatrixserverlib.RoomVersion {
 
 // InviteRoomState returns stripped state events for the room, containing
 // enough information for the client to identify the room.
-func (i *InviteV2Request) InviteRoomState() []InviteV2StrippedState {
+func (i *InviteV2Request) InviteRoomState() []gomatrixserverlib.InviteStrippedState {
 	return i.fields.InviteRoomState
-}
-
-// InviteV2StrippedState is a cut-down set of fields from room state
-// events that allow the invited server to identify the room.
-type InviteV2StrippedState struct {
-	fields struct {
-		Content  spec.RawJSON `json:"content"`
-		StateKey *string      `json:"state_key"`
-		Type     string       `json:"type"`
-		Sender   string       `json:"sender"`
-	}
-}
-
-// NewInviteV2StrippedState creates a stripped state event from a
-// regular state event.
-func NewInviteV2StrippedState(event gomatrixserverlib.PDU) (ss InviteV2StrippedState) {
-	ss.fields.Content = event.Content()
-	ss.fields.StateKey = event.StateKey()
-	ss.fields.Type = event.Type()
-	ss.fields.Sender = event.Sender()
-	return
-}
-
-// MarshalJSON implements json.Marshaller
-func (i InviteV2StrippedState) MarshalJSON() ([]byte, error) {
-	return json.Marshal(i.fields)
-}
-
-// UnmarshalJSON implements json.Unmarshaller
-func (i *InviteV2StrippedState) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &i.fields)
-}
-
-// Content returns the content of the stripped state.
-func (i *InviteV2StrippedState) Content() spec.RawJSON {
-	return i.fields.Content
-}
-
-// StateKey returns the state key of the stripped state.
-func (i *InviteV2StrippedState) StateKey() *string {
-	return i.fields.StateKey
-}
-
-// Type returns the type of the stripped state.
-func (i *InviteV2StrippedState) Type() string {
-	return i.fields.Type
-}
-
-// Sender returns the sender of the stripped state.
-func (i *InviteV2StrippedState) Sender() string {
-	return i.fields.Sender
 }

--- a/fclient/invitev2_test.go
+++ b/fclient/invitev2_test.go
@@ -17,7 +17,7 @@ func TestMarshalInviteV2Request(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inviteReq, err := NewInviteV2Request(output, []InviteV2StrippedState{})
+	inviteReq, err := NewInviteV2Request(output, []gomatrixserverlib.InviteStrippedState{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestStrippedState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stripped := NewInviteV2StrippedState(output)
+	stripped := gomatrixserverlib.NewInviteStrippedState(output)
 
 	j, err := json.Marshal(stripped)
 	if err != nil {

--- a/handleinvite.go
+++ b/handleinvite.go
@@ -115,9 +115,9 @@ func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
 				StateKey:  "",
 			})
 		}
-		if is, err := GenerateStrippedState(ctx, input.RoomID, stateWanted, signedEvent, input.StateQuerier); err == nil {
-			inviteState = is
-		} else {
+
+		inviteState, err = GenerateStrippedState(ctx, input.RoomID, stateWanted, signedEvent, input.StateQuerier)
+		if err != nil {
 			util.GetLogger(ctx).WithError(err).Error("failed querying known room")
 			return nil, spec.InternalServerError{}
 		}

--- a/handleinvite.go
+++ b/handleinvite.go
@@ -35,7 +35,7 @@ type HandleInviteInput struct {
 	PrivateKey ed25519.PrivateKey // Used to sign the original invite event
 	Verifier   JSONVerifier       // Used to verify the original invite event
 
-	InviteQuerier     RoomQuerier       // Provides information about the room
+	RoomQuerier       RoomQuerier       // Provides information about the room
 	MembershipQuerier MembershipQuerier // Provides information about the room's membership
 	StateQuerier      StateQuerier      // Provides access to state events
 }
@@ -44,8 +44,8 @@ type HandleInviteInput struct {
 // to return back to the remote server.
 // On success returns a fully formed & signed Invite Event
 func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
-	if input.MembershipQuerier == nil {
-		panic("Missing valid MembershipQuerier")
+	if input.RoomQuerier == nil || input.MembershipQuerier == nil || input.StateQuerier == nil {
+		panic("Missing valid Querier")
 	}
 	if input.Verifier == nil {
 		panic("Missing valid JSONVerifier")
@@ -103,7 +103,7 @@ func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
 		return nil, spec.BadJSON("The state key must be populated")
 	}
 
-	isKnownRoom, err := input.InviteQuerier.IsKnownRoom(ctx, input.RoomID)
+	isKnownRoom, err := input.RoomQuerier.IsKnownRoom(ctx, input.RoomID)
 	if err != nil {
 		util.GetLogger(ctx).WithError(err).Error("failed querying known room")
 		return nil, spec.InternalServerError{}

--- a/handleinvite.go
+++ b/handleinvite.go
@@ -98,11 +98,6 @@ func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
 		string(input.InvitedUser.Domain()), input.KeyID, input.PrivateKey,
 	)
 
-	if signedEvent.StateKey() == nil {
-		util.GetLogger(ctx).Error("invite must be a state event")
-		return nil, spec.BadJSON("The state key must be populated")
-	}
-
 	isKnownRoom, err := input.RoomQuerier.IsKnownRoom(ctx, input.RoomID)
 	if err != nil {
 		util.GetLogger(ctx).WithError(err).Error("failed querying known room")

--- a/handleinvite.go
+++ b/handleinvite.go
@@ -1,0 +1,250 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomatrixserverlib
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ed25519"
+)
+
+// InviteStrippedState is a cut-down set of fields from room state
+// events that allow the invited server to identify the room.
+type InviteStrippedState struct {
+	fields struct {
+		Content  spec.RawJSON `json:"content"`
+		StateKey *string      `json:"state_key"`
+		Type     string       `json:"type"`
+		Sender   string       `json:"sender"`
+	}
+}
+
+// NewInviteStrippedState creates a stripped state event from a
+// regular state event.
+func NewInviteStrippedState(event PDU) (ss InviteStrippedState) {
+	ss.fields.Content = event.Content()
+	ss.fields.StateKey = event.StateKey()
+	ss.fields.Type = event.Type()
+	ss.fields.Sender = event.Sender()
+	return
+}
+
+// MarshalJSON implements json.Marshaller
+func (i InviteStrippedState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.fields)
+}
+
+// UnmarshalJSON implements json.Unmarshaller
+func (i *InviteStrippedState) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &i.fields)
+}
+
+// Content returns the content of the stripped state.
+func (i *InviteStrippedState) Content() spec.RawJSON {
+	return i.fields.Content
+}
+
+// StateKey returns the state key of the stripped state.
+func (i *InviteStrippedState) StateKey() *string {
+	return i.fields.StateKey
+}
+
+// Type returns the type of the stripped state.
+func (i *InviteStrippedState) Type() string {
+	return i.fields.Type
+}
+
+// Sender returns the sender of the stripped state.
+func (i *InviteStrippedState) Sender() string {
+	return i.fields.Sender
+}
+
+type RoomQuerier interface {
+	IsKnownRoom(ctx context.Context, roomID spec.RoomID) (bool, error)
+}
+
+type HandleInviteInput struct {
+	Context               context.Context
+	RoomVersion           RoomVersion
+	RoomID                spec.RoomID
+	EventID               string
+	InvitedUser           spec.UserID
+	KeyID                 KeyID
+	PrivateKey            ed25519.PrivateKey
+	Verifier              JSONVerifier
+	InviteQuerier         RoomQuerier
+	MembershipQuerier     MembershipQuerier
+	GenerateStrippedState func(ctx context.Context, roomID spec.RoomID, stateWanted []StateKeyTuple, inviteEvent PDU) ([]InviteStrippedState, error)
+
+	InviteEvent   PDU
+	StrippedState []InviteStrippedState
+}
+
+func HandleInvite(input HandleInviteInput) (PDU, error) {
+	// Check that we can accept invites for this room version.
+	verImpl, err := GetRoomVersion(input.RoomVersion)
+	if err != nil {
+		return nil, spec.UnsupportedRoomVersion(
+			fmt.Sprintf("Room version %q is not supported by this server.", input.RoomVersion),
+		)
+	}
+
+	// Check that the room ID is correct.
+	if input.InviteEvent.RoomID() != input.RoomID.String() {
+		return nil, spec.BadJSON("The room ID in the request path must match the room ID in the invite event JSON")
+	}
+
+	// Check that the event ID is correct.
+	if input.InviteEvent.EventID() != input.EventID {
+		return nil, spec.BadJSON("The event ID in the request path must match the event ID in the invite event JSON")
+	}
+
+	// Check that the event is signed by the server sending the request.
+	redacted, err := verImpl.RedactEventJSON(input.InviteEvent.JSON())
+	if err != nil {
+		return nil, spec.BadJSON("The event JSON could not be redacted")
+	}
+
+	sender, err := spec.NewUserID(input.InviteEvent.Sender(), true)
+	if err != nil {
+		return nil, spec.BadJSON("The event JSON contains an invalid sender")
+	}
+	verifyRequests := []VerifyJSONRequest{{
+		ServerName:             sender.Domain(),
+		Message:                redacted,
+		AtTS:                   input.InviteEvent.OriginServerTS(),
+		StrictValidityChecking: true,
+	}}
+	verifyResults, err := input.Verifier.VerifyJSONs(input.Context, verifyRequests)
+	if err != nil {
+		util.GetLogger(input.Context).WithError(err).Error("keys.VerifyJSONs failed")
+		return nil, spec.InternalServerError{}
+	}
+	if verifyResults[0].Error != nil {
+		return nil, spec.Forbidden("The invite must be signed by the server it originated on")
+	}
+
+	// Sign the event so that other servers will know that we have received the invite.
+	signedEvent := input.InviteEvent.Sign(
+		string(input.InvitedUser.Domain()), input.KeyID, input.PrivateKey,
+	)
+
+	if signedEvent.StateKey() == nil {
+		util.GetLogger(input.Context).Error("invite must be a state event")
+		return nil, spec.InternalServerError{}
+	}
+
+	isKnownRoom, err := input.InviteQuerier.IsKnownRoom(input.Context, input.RoomID)
+	if err != nil {
+		util.GetLogger(input.Context).WithError(err).Error("failed querying known room")
+		return nil, spec.InternalServerError{}
+	}
+
+	inviteState := input.StrippedState
+	if len(inviteState) == 0 {
+		// "If they are set on the room, at least the state for m.room.avatar, m.room.canonical_alias, m.room.join_rules, and m.room.name SHOULD be included."
+		// https://matrix.org/docs/spec/client_server/r0.6.0#m-room-member
+		stateWanted := []StateKeyTuple{}
+		for _, t := range []string{
+			spec.MRoomName, spec.MRoomCanonicalAlias,
+			spec.MRoomJoinRules, spec.MRoomAvatar,
+			spec.MRoomEncryption, spec.MRoomCreate,
+		} {
+			stateWanted = append(stateWanted, StateKeyTuple{
+				EventType: t,
+				StateKey:  "",
+			})
+		}
+		if is, err := input.GenerateStrippedState(input.Context, input.RoomID, stateWanted, signedEvent); err == nil {
+			inviteState = is
+		} else {
+			util.GetLogger(input.Context).WithError(err).Error("failed querying known room")
+			return nil, spec.InternalServerError{}
+		}
+	}
+
+	logger := util.GetLogger(input.Context).WithFields(map[string]interface{}{
+		"inviter":  signedEvent.Sender(),
+		"invitee":  *signedEvent.StateKey(),
+		"room_id":  input.RoomID.String(),
+		"event_id": signedEvent.EventID(),
+	})
+	logger.WithFields(logrus.Fields{
+		"room_version":     signedEvent.Version(),
+		"room_info_exists": isKnownRoom,
+	}).Debug("processing incoming federation invite event")
+
+	if len(inviteState) == 0 {
+		if err = signedEvent.SetUnsignedField("invite_room_state", struct{}{}); err != nil {
+			util.GetLogger(input.Context).WithError(err).Error("failed setting unsigned field")
+			return nil, spec.InternalServerError{}
+		}
+	} else {
+		if err = signedEvent.SetUnsignedField("invite_room_state", inviteState); err != nil {
+			util.GetLogger(input.Context).WithError(err).Error("failed setting unsigned field")
+			return nil, spec.InternalServerError{}
+		}
+	}
+
+	if isKnownRoom {
+		membership, err := input.MembershipQuerier.CurrentMembership(input.Context, input.RoomID, input.InvitedUser)
+		if err != nil {
+			util.GetLogger(input.Context).WithError(err).Error("failed getting user membership")
+			return nil, spec.InternalServerError{}
+
+		}
+		isAlreadyJoined := (membership == spec.Join)
+
+		if isAlreadyJoined {
+			// If the user is joined to the room then that takes precedence over this
+			// invite event. It makes little sense to move a user that is already
+			// joined to the room into the invite state.
+			// This could plausibly happen if an invite request raced with a join
+			// request for a user. For example if a user was invited to a public
+			// room and they joined the room at the same time as the invite was sent.
+			// The other way this could plausibly happen is if an invite raced with
+			// a kick. For example if a user was kicked from a room in error and in
+			// response someone else in the room re-invited them then it is possible
+			// for the invite request to race with the leave event so that the
+			// target receives invite before it learns that it has been kicked.
+			// There are a few ways this could be plausibly handled in the roomserver.
+			// 1) Store the invite, but mark it as retired. That will result in the
+			//    permanent rejection of that invite event. So even if the target
+			//    user leaves the room and the invite is retransmitted it will be
+			//    ignored. However a new invite with a new event ID would still be
+			//    accepted.
+			// 2) Silently discard the invite event. This means that if the event
+			//    was retransmitted at a later date after the target user had left
+			//    the room we would accept the invite. However since we hadn't told
+			//    the sending server that the invite had been discarded it would
+			//    have no reason to attempt to retry.
+			// 3) Signal the sending server that the user is already joined to the
+			//    room.
+			// For now we will implement option 2. Since in the abesence of a retry
+			// mechanism it will be equivalent to option 1, and we don't have a
+			// signalling mechanism to implement option 3.
+			logger.Debugf("user already joined")
+			util.GetLogger(input.Context).Error("user is already joined to room")
+			return nil, spec.InternalServerError{}
+		}
+	}
+
+	return signedEvent, nil
+}

--- a/handleinvite.go
+++ b/handleinvite.go
@@ -25,21 +25,24 @@ import (
 )
 
 type HandleInviteInput struct {
-	RoomID        spec.RoomID
-	RoomVersion   RoomVersion
-	InvitedUser   spec.UserID
-	InviteEvent   PDU
-	StrippedState []InviteStrippedState
+	RoomID        spec.RoomID           // The room that the user is being invited to join
+	RoomVersion   RoomVersion           // The version of the invited to room
+	InvitedUser   spec.UserID           // The user being invited to join the room
+	InviteEvent   PDU                   // The original invite event
+	StrippedState []InviteStrippedState // A small set of state events that can be used to identify the room
 
-	KeyID      KeyID
-	PrivateKey ed25519.PrivateKey
-	Verifier   JSONVerifier
+	KeyID      KeyID              // Used to sign the original invite event
+	PrivateKey ed25519.PrivateKey // Used to sign the original invite event
+	Verifier   JSONVerifier       // Used to verify the original invite event
 
-	InviteQuerier     RoomQuerier
-	MembershipQuerier MembershipQuerier
-	StateQuerier      StateQuerier
+	InviteQuerier     RoomQuerier       // Provides information about the room
+	MembershipQuerier MembershipQuerier // Provides information about the room's membership
+	StateQuerier      StateQuerier      // Provides access to state events
 }
 
+// HandleInvite - Ensures the incoming invite request is valid and signs the event
+// to return back to the remote server.
+// On success returns a fully formed & signed Invite Event
 func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
 	// Check that we can accept invites for this room version.
 	verImpl, err := GetRoomVersion(input.RoomVersion)

--- a/handleinvite.go
+++ b/handleinvite.go
@@ -44,6 +44,17 @@ type HandleInviteInput struct {
 // to return back to the remote server.
 // On success returns a fully formed & signed Invite Event
 func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
+	if input.MembershipQuerier == nil {
+		panic("Missing valid MembershipQuerier")
+	}
+	if input.Verifier == nil {
+		panic("Missing valid JSONVerifier")
+	}
+
+	if ctx == nil {
+		panic("Missing valid Context")
+	}
+
 	// Check that we can accept invites for this room version.
 	verImpl, err := GetRoomVersion(input.RoomVersion)
 	if err != nil {

--- a/handleinvite.go
+++ b/handleinvite.go
@@ -25,19 +25,22 @@ import (
 )
 
 type HandleInviteInput struct {
-	RoomVersion       RoomVersion
-	RoomID            spec.RoomID
-	EventID           string
-	InvitedUser       spec.UserID
-	KeyID             KeyID
-	PrivateKey        ed25519.PrivateKey
-	Verifier          JSONVerifier
+	RoomID        spec.RoomID
+	RoomVersion   RoomVersion
+	InvitedUser   spec.UserID
+	InviteEvent   PDU
+	StrippedState []InviteStrippedState
+
+	// TODO : remove & move logic up a level
+	EventID string
+
+	KeyID      KeyID
+	PrivateKey ed25519.PrivateKey
+	Verifier   JSONVerifier
+
 	InviteQuerier     RoomQuerier
 	MembershipQuerier MembershipQuerier
 	StateQuerier      StateQuerier
-
-	InviteEvent   PDU
-	StrippedState []InviteStrippedState
 }
 
 func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
@@ -91,7 +94,7 @@ func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
 
 	if signedEvent.StateKey() == nil {
 		util.GetLogger(ctx).Error("invite must be a state event")
-		return nil, spec.InternalServerError{}
+		return nil, spec.BadJSON("The state key must be populated")
 	}
 
 	isKnownRoom, err := input.InviteQuerier.IsKnownRoom(ctx, input.RoomID)
@@ -102,90 +105,31 @@ func HandleInvite(ctx context.Context, input HandleInviteInput) (PDU, error) {
 
 	inviteState := input.StrippedState
 	if len(inviteState) == 0 {
-		// "If they are set on the room, at least the state for m.room.avatar, m.room.canonical_alias, m.room.join_rules, and m.room.name SHOULD be included."
-		// https://matrix.org/docs/spec/client_server/r0.6.0#m-room-member
-		stateWanted := []StateKeyTuple{}
-		for _, t := range []string{
-			spec.MRoomName, spec.MRoomCanonicalAlias,
-			spec.MRoomJoinRules, spec.MRoomAvatar,
-			spec.MRoomEncryption, spec.MRoomCreate,
-		} {
-			stateWanted = append(stateWanted, StateKeyTuple{
-				EventType: t,
-				StateKey:  "",
-			})
-		}
-
-		inviteState, err = GenerateStrippedState(ctx, input.RoomID, stateWanted, signedEvent, input.StateQuerier)
+		inviteState, err = GenerateStrippedState(ctx, input.RoomID, signedEvent, input.StateQuerier)
 		if err != nil {
-			util.GetLogger(ctx).WithError(err).Error("failed querying known room")
+			util.GetLogger(ctx).WithError(err).Error("failed generating stripped state")
 			return nil, spec.InternalServerError{}
 		}
 	}
+	// TODO: can len(inviteState) be 0 after this point? what if not a known room?
+	// if it is a known room it should never be 0...
+	// remove check in setUnsignedFieldForInvite & enforce it here
 
-	logger := util.GetLogger(ctx).WithFields(map[string]interface{}{
-		"inviter":  signedEvent.Sender(),
-		"invitee":  *signedEvent.StateKey(),
-		"room_id":  input.RoomID.String(),
-		"event_id": signedEvent.EventID(),
-	})
+	logger := createInviteLogger(ctx, signedEvent, input.RoomID)
 	logger.WithFields(logrus.Fields{
 		"room_version":     signedEvent.Version(),
 		"room_info_exists": isKnownRoom,
 	}).Debug("processing incoming federation invite event")
 
-	if len(inviteState) == 0 {
-		if err = signedEvent.SetUnsignedField("invite_room_state", struct{}{}); err != nil {
-			util.GetLogger(ctx).WithError(err).Error("failed setting unsigned field")
-			return nil, spec.InternalServerError{}
-		}
-	} else {
-		if err = signedEvent.SetUnsignedField("invite_room_state", inviteState); err != nil {
-			util.GetLogger(ctx).WithError(err).Error("failed setting unsigned field")
-			return nil, spec.InternalServerError{}
-		}
+	err = setUnsignedFieldForInvite(signedEvent, inviteState)
+	if err != nil {
+		return nil, err
 	}
 
 	if isKnownRoom {
-		membership, err := input.MembershipQuerier.CurrentMembership(ctx, input.RoomID, input.InvitedUser)
+		err := abortIfAlreadyJoined(ctx, input.RoomID, input.InvitedUser, input.MembershipQuerier)
 		if err != nil {
-			util.GetLogger(ctx).WithError(err).Error("failed getting user membership")
-			return nil, spec.InternalServerError{}
-
-		}
-		isAlreadyJoined := (membership == spec.Join)
-
-		if isAlreadyJoined {
-			// If the user is joined to the room then that takes precedence over this
-			// invite event. It makes little sense to move a user that is already
-			// joined to the room into the invite state.
-			// This could plausibly happen if an invite request raced with a join
-			// request for a user. For example if a user was invited to a public
-			// room and they joined the room at the same time as the invite was sent.
-			// The other way this could plausibly happen is if an invite raced with
-			// a kick. For example if a user was kicked from a room in error and in
-			// response someone else in the room re-invited them then it is possible
-			// for the invite request to race with the leave event so that the
-			// target receives invite before it learns that it has been kicked.
-			// There are a few ways this could be plausibly handled in the roomserver.
-			// 1) Store the invite, but mark it as retired. That will result in the
-			//    permanent rejection of that invite event. So even if the target
-			//    user leaves the room and the invite is retransmitted it will be
-			//    ignored. However a new invite with a new event ID would still be
-			//    accepted.
-			// 2) Silently discard the invite event. This means that if the event
-			//    was retransmitted at a later date after the target user had left
-			//    the room we would accept the invite. However since we hadn't told
-			//    the sending server that the invite had been discarded it would
-			//    have no reason to attempt to retry.
-			// 3) Signal the sending server that the user is already joined to the
-			//    room.
-			// For now we will implement option 2. Since in the abesence of a retry
-			// mechanism it will be equivalent to option 1, and we don't have a
-			// signalling mechanism to implement option 3.
-			logger.Debugf("user already joined")
-			util.GetLogger(ctx).Error("user is already joined to room")
-			return nil, spec.InternalServerError{}
+			return nil, err
 		}
 	}
 

--- a/handleinvite_test.go
+++ b/handleinvite_test.go
@@ -26,16 +26,20 @@ func (r *TestRoomQuerier) IsKnownRoom(ctx context.Context, roomID spec.RoomID) (
 }
 
 type TestStateQuerier struct {
-	shouldFail bool
-	state      []PDU
+	shouldFailState bool
+	shouldFailAuth  bool
+	state           []PDU
 }
 
 func (r *TestStateQuerier) GetAuthEvents(ctx context.Context, event PDU) (AuthEventProvider, error) {
+	if r.shouldFailAuth {
+		return nil, fmt.Errorf("failed getting auth provider")
+	}
 	return &AuthEvents{}, nil
 }
 
 func (r *TestStateQuerier) GetState(ctx context.Context, roomID spec.RoomID, stateWanted []StateKeyTuple) ([]PDU, error) {
-	if r.shouldFail {
+	if r.shouldFailState {
 		return nil, fmt.Errorf("failed getting state")
 	}
 	return r.state, nil
@@ -179,7 +183,7 @@ func TestHandleInvite(t *testing.T) {
 				InviteEvent:       inviteEvent,
 				RoomQuerier:       &TestRoomQuerier{knownRoom: true},
 				MembershipQuerier: &TestMembershipQuerier{membership: ""},
-				StateQuerier:      &TestStateQuerier{shouldFail: true},
+				StateQuerier:      &TestStateQuerier{shouldFailState: true},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,

--- a/handleinvite_test.go
+++ b/handleinvite_test.go
@@ -31,7 +31,7 @@ type TestStateQuerier struct {
 }
 
 func (r *TestStateQuerier) GetAuthEvents(ctx context.Context, event PDU) (AuthEventProvider, error) {
-	return nil, nil
+	return &AuthEvents{}, nil
 }
 
 func (r *TestStateQuerier) GetState(ctx context.Context, roomID spec.RoomID, stateWanted []StateKeyTuple) ([]PDU, error) {

--- a/handleinvite_test.go
+++ b/handleinvite_test.go
@@ -1,0 +1,143 @@
+package gomatrixserverlib
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+
+	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ed25519"
+)
+
+type TestInviteQuerier struct {
+}
+
+func TestHandleInvite(t *testing.T) {
+	validRoom, err := spec.NewRoomID("!room:server")
+	assert.Nil(t, err)
+
+	pk, sk, err := ed25519.GenerateKey(rand.Reader)
+	assert.Nil(t, err)
+	keyID := KeyID("ed25519:1234")
+	verifier := &KeyRing{[]KeyFetcher{&TestRequestKeyDummy{}}, &joinKeyDatabase{key: pk}}
+
+	type ErrorType int
+	const (
+		InternalErr ErrorType = iota
+		MatrixErr
+	)
+
+	tests := map[string]struct {
+		input       HandleInviteInput
+		expectedErr bool
+		errType     ErrorType
+		errCode     spec.MatrixErrorCode
+	}{
+		"unsupported_room_version": {
+			input: HandleInviteInput{
+				RoomID:            *validRoom,
+				RoomVersion:       "",
+				MembershipQuerier: &TestMembershipQuerier{},
+				KeyID:             keyID,
+				PrivateKey:        sk,
+				Verifier:          verifier,
+			},
+			expectedErr: true,
+			errType:     MatrixErr,
+			errCode:     spec.ErrorUnsupportedRoomVersion,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, joinErr := HandleInvite(context.Background(), tc.input)
+			if tc.expectedErr {
+				switch e := joinErr.(type) {
+				case nil:
+					t.Fatalf("Error should not be nil")
+				case spec.InternalServerError:
+					assert.Equal(t, tc.errType, InternalErr)
+				case spec.MatrixError:
+					assert.Equal(t, tc.errType, MatrixErr)
+					assert.Equal(t, tc.errCode, e.ErrCode)
+				default:
+					t.Fatalf("Unexpected Error Type")
+				}
+			} else {
+				jsonBytes, err := json.Marshal(&joinErr)
+				assert.Nil(t, err)
+				assert.Nil(t, joinErr, string(jsonBytes))
+			}
+		})
+	}
+}
+
+func TestHandleInviteNilVerifier(t *testing.T) {
+	validRoom, err := spec.NewRoomID("!room:remote")
+	assert.Nil(t, err)
+
+	_, sk, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed generating key: %v", err)
+	}
+	keyID := KeyID("ed25519:1234")
+
+	assert.Panics(t, func() {
+		_, _ = HandleInvite(context.Background(), HandleInviteInput{
+			RoomID:            *validRoom,
+			RoomVersion:       "",
+			KeyID:             keyID,
+			PrivateKey:        sk,
+			Verifier:          nil,
+			MembershipQuerier: &TestMembershipQuerier{},
+		})
+	})
+}
+
+func TestHandleInviteNilMembershipQuerier(t *testing.T) {
+	validRoom, err := spec.NewRoomID("!room:remote")
+	assert.Nil(t, err)
+
+	pk, sk, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed generating key: %v", err)
+	}
+	keyID := KeyID("ed25519:1234")
+	verifier := &KeyRing{[]KeyFetcher{&TestRequestKeyDummy{}}, &joinKeyDatabase{key: pk}}
+
+	assert.Panics(t, func() {
+		_, _ = HandleInvite(context.Background(), HandleInviteInput{
+			RoomID:            *validRoom,
+			RoomVersion:       "",
+			KeyID:             keyID,
+			PrivateKey:        sk,
+			Verifier:          verifier,
+			MembershipQuerier: nil,
+		})
+	})
+}
+
+func TestHandleInviteNilContext(t *testing.T) {
+	validRoom, err := spec.NewRoomID("!room:remote")
+	assert.Nil(t, err)
+
+	pk, sk, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed generating key: %v", err)
+	}
+	keyID := KeyID("ed25519:1234")
+	verifier := &KeyRing{[]KeyFetcher{&TestRequestKeyDummy{}}, &joinKeyDatabase{key: pk}}
+
+	assert.Panics(t, func() {
+		_, _ = HandleInvite(nil, HandleInviteInput{ // nolint
+			RoomID:            *validRoom,
+			RoomVersion:       "",
+			KeyID:             keyID,
+			PrivateKey:        sk,
+			Verifier:          verifier,
+			MembershipQuerier: &TestMembershipQuerier{},
+		})
+	})
+}

--- a/handlejoin_test.go
+++ b/handlejoin_test.go
@@ -13,12 +13,12 @@ import (
 	"golang.org/x/crypto/ed25519"
 )
 
-type TestSendJoinQuerier struct {
+type TestMembershipQuerier struct {
 	memberEventErr bool
 	membership     string
 }
 
-func (s *TestSendJoinQuerier) CurrentMembership(ctx context.Context, roomID spec.RoomID, userID spec.UserID) (string, error) {
+func (s *TestMembershipQuerier) CurrentMembership(ctx context.Context, roomID spec.RoomID, userID spec.UserID) (string, error) {
 	if s.memberEventErr {
 		return "", fmt.Errorf("err")
 	}
@@ -592,7 +592,7 @@ func TestHandleMakeJoinNilContext(t *testing.T) {
 	})
 }
 
-func createEventBuilder(sender string, roomID string, stateKey *string, content spec.RawJSON) *EventBuilder {
+func createMemberEventBuilder(sender string, roomID string, stateKey *string, content spec.RawJSON) *EventBuilder {
 	return MustGetRoomVersion(RoomVersionV10).NewEventBuilderFromProtoEvent(&ProtoEvent{
 		Sender:     sender,
 		RoomID:     roomID,
@@ -626,33 +626,33 @@ func TestHandleSendJoin(t *testing.T) {
 	badVerifier := &KeyRing{[]KeyFetcher{&TestRequestKeyDummy{}}, &joinKeyDatabase{key: badPK}}
 
 	stateKey := userID.String()
-	eb := createEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join"}`))
+	eb := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join"}`))
 	joinEvent, err := eb.Build(time.Now(), userID.Domain(), keyID, sk)
 	assert.Nil(t, err)
 
-	ebNotJoin := createEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"ban"}`))
+	ebNotJoin := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"ban"}`))
 	notJoinEvent, err := ebNotJoin.Build(time.Now(), userID.Domain(), keyID, sk)
 	assert.Nil(t, err)
 
-	eb2 := createEventBuilder("@asdf:asdf", validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join"}`))
+	eb2 := createMemberEventBuilder("@asdf:asdf", validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join"}`))
 	joinEventInvalidSender, err := eb2.Build(time.Now(), userID.Domain(), keyID, sk)
 	assert.Nil(t, err)
 
 	stateKey = ""
-	eb3 := createEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join"}`))
+	eb3 := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join"}`))
 	joinEventNoState, err := eb3.Build(time.Now(), userID.Domain(), keyID, sk)
 	assert.Nil(t, err)
 
 	stateKey = userID.String()
-	badAuthViaEB := createEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join","join_authorised_via_users_server":"baduser"}`))
+	badAuthViaEB := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join","join_authorised_via_users_server":"baduser"}`))
 	badAuthViaEvent, err := badAuthViaEB.Build(time.Now(), userID.Domain(), keyID, sk)
 	assert.Nil(t, err)
 
-	authViaNotLocalEB := createEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join","join_authorised_via_users_server":"@user:notlocalserver"}`))
+	authViaNotLocalEB := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join","join_authorised_via_users_server":"@user:notlocalserver"}`))
 	authViaNotLocalEvent, err := authViaNotLocalEB.Build(time.Now(), userID.Domain(), keyID, sk)
 	assert.Nil(t, err)
 
-	authViaEB := createEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join","join_authorised_via_users_server":"@user:local"}`))
+	authViaEB := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"join","join_authorised_via_users_server":"@user:local"}`))
 	authViaEvent, err := authViaEB.Build(time.Now(), userID.Domain(), keyID, sk)
 	assert.Nil(t, err)
 
@@ -677,7 +677,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       "",
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -695,7 +695,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -713,7 +713,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -731,7 +731,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -749,7 +749,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     "bad_origin",
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -767,7 +767,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -785,7 +785,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -803,7 +803,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -821,7 +821,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          badVerifier,
@@ -839,7 +839,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{memberEventErr: true},
+				MembershipQuerier: &TestMembershipQuerier{memberEventErr: true},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -856,7 +856,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{membership: spec.Ban},
+				MembershipQuerier: &TestMembershipQuerier{membership: spec.Ban},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -874,7 +874,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -892,7 +892,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -910,7 +910,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{membership: spec.Join},
+				MembershipQuerier: &TestMembershipQuerier{membership: spec.Join},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -926,7 +926,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -942,7 +942,7 @@ func TestHandleSendJoin(t *testing.T) {
 				RoomVersion:       RoomVersionV10,
 				RequestOrigin:     remoteServer,
 				LocalServerName:   localServer,
-				MembershipQuerier: &TestSendJoinQuerier{},
+				MembershipQuerier: &TestMembershipQuerier{},
 				KeyID:             keyID,
 				PrivateKey:        sk,
 				Verifier:          verifier,
@@ -995,7 +995,7 @@ func TestHandleSendJoinNilVerifier(t *testing.T) {
 			RoomVersion:       RoomVersionV10,
 			RequestOrigin:     remoteServer,
 			LocalServerName:   localServer,
-			MembershipQuerier: &TestSendJoinQuerier{},
+			MembershipQuerier: &TestMembershipQuerier{},
 			KeyID:             keyID,
 			PrivateKey:        sk,
 			Verifier:          nil,
@@ -1053,7 +1053,7 @@ func TestHandleSendJoinNilContext(t *testing.T) {
 			RoomVersion:       RoomVersionV10,
 			RequestOrigin:     remoteServer,
 			LocalServerName:   localServer,
-			MembershipQuerier: &TestSendJoinQuerier{},
+			MembershipQuerier: &TestMembershipQuerier{},
 			KeyID:             keyID,
 			PrivateKey:        sk,
 			Verifier:          verifier,

--- a/invite.go
+++ b/invite.go
@@ -1,0 +1,106 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomatrixserverlib
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/matrix-org/gomatrixserverlib/spec"
+)
+
+type RoomQuerier interface {
+	IsKnownRoom(ctx context.Context, roomID spec.RoomID) (bool, error)
+}
+
+type StateQuerier interface {
+	GetAuthEvents(ctx context.Context, event PDU) (AuthEventProvider, error)
+	GetState(ctx context.Context, roomID spec.RoomID, stateWanted []StateKeyTuple) ([]PDU, error)
+}
+
+type FederatedInviteClient interface {
+	SendInvite(ctx context.Context, event PDU, strippedState []InviteStrippedState) (PDU, error)
+}
+
+// InviteStrippedState is a cut-down set of fields from room state
+// events that allow the invited server to identify the room.
+type InviteStrippedState struct {
+	fields struct {
+		Content  spec.RawJSON `json:"content"`
+		StateKey *string      `json:"state_key"`
+		Type     string       `json:"type"`
+		Sender   string       `json:"sender"`
+	}
+}
+
+// NewInviteStrippedState creates a stripped state event from a
+// regular state event.
+func NewInviteStrippedState(event PDU) (ss InviteStrippedState) {
+	ss.fields.Content = event.Content()
+	ss.fields.StateKey = event.StateKey()
+	ss.fields.Type = event.Type()
+	ss.fields.Sender = event.Sender()
+	return
+}
+
+// MarshalJSON implements json.Marshaller
+func (i InviteStrippedState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.fields)
+}
+
+// UnmarshalJSON implements json.Unmarshaller
+func (i *InviteStrippedState) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &i.fields)
+}
+
+// Content returns the content of the stripped state.
+func (i *InviteStrippedState) Content() spec.RawJSON {
+	return i.fields.Content
+}
+
+// StateKey returns the state key of the stripped state.
+func (i *InviteStrippedState) StateKey() *string {
+	return i.fields.StateKey
+}
+
+// Type returns the type of the stripped state.
+func (i *InviteStrippedState) Type() string {
+	return i.fields.Type
+}
+
+// Sender returns the sender of the stripped state.
+func (i *InviteStrippedState) Sender() string {
+	return i.fields.Sender
+}
+
+func GenerateStrippedState(
+	ctx context.Context, roomID spec.RoomID, stateWanted []StateKeyTuple, inviteEvent PDU, stateQuerier StateQuerier,
+) ([]InviteStrippedState, error) {
+	stateEvents, err := stateQuerier.GetState(ctx, roomID, stateWanted)
+	if err != nil {
+		return nil, err
+	}
+	if stateEvents != nil {
+		inviteState := []InviteStrippedState{
+			NewInviteStrippedState(inviteEvent),
+		}
+		stateEvents = append(stateEvents, inviteEvent)
+		for _, event := range stateEvents {
+			inviteState = append(inviteState, NewInviteStrippedState(event))
+		}
+		return inviteState, nil
+	}
+	return nil, nil
+}

--- a/invite.go
+++ b/invite.go
@@ -107,7 +107,7 @@ func GenerateStrippedState(
 
 	stateEvents, err := stateQuerier.GetState(ctx, roomID, stateWanted)
 	if err != nil {
-		return nil, err
+		return []InviteStrippedState{}, err
 	}
 	if stateEvents != nil {
 		inviteState := []InviteStrippedState{
@@ -119,7 +119,7 @@ func GenerateStrippedState(
 		}
 		return inviteState, nil
 	}
-	return nil, nil
+	return []InviteStrippedState{}, nil
 }
 
 func abortIfAlreadyJoined(ctx context.Context, roomID spec.RoomID, invitedUser spec.UserID, membershipQuerier MembershipQuerier) error {

--- a/performinvite.go
+++ b/performinvite.go
@@ -16,7 +16,6 @@ package gomatrixserverlib
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/util"
@@ -24,11 +23,12 @@ import (
 )
 
 type PerformInviteInput struct {
-	RoomID            spec.RoomID
-	Event             PDU
-	InvitedUser       spec.UserID
-	IsTargetLocal     bool
-	StrippedState     []InviteStrippedState
+	RoomID        spec.RoomID
+	InvitedUser   spec.UserID
+	IsTargetLocal bool
+	Event         PDU
+	StrippedState []InviteStrippedState
+
 	MembershipQuerier MembershipQuerier
 	StateQuerier      StateQuerier
 }
@@ -36,88 +36,29 @@ type PerformInviteInput struct {
 func PerformInvite(ctx context.Context, input PerformInviteInput, fedClient FederatedInviteClient) (PDU, error) {
 	inviteState := input.StrippedState
 	if len(inviteState) == 0 {
-		// "If they are set on the room, at least the state for m.room.avatar, m.room.canonical_alias, m.room.join_rules, and m.room.name SHOULD be included."
-		// https://matrix.org/docs/spec/client_server/r0.6.0#m-room-member
-		stateWanted := []StateKeyTuple{}
-		for _, t := range []string{
-			spec.MRoomName, spec.MRoomCanonicalAlias,
-			spec.MRoomJoinRules, spec.MRoomAvatar,
-			spec.MRoomEncryption, spec.MRoomCreate,
-		} {
-			stateWanted = append(stateWanted, StateKeyTuple{
-				EventType: t,
-				StateKey:  "",
-			})
-		}
-
 		var err error
-		inviteState, err = GenerateStrippedState(ctx, input.RoomID, stateWanted, input.Event, input.StateQuerier)
+		inviteState, err = GenerateStrippedState(ctx, input.RoomID, input.Event, input.StateQuerier)
 		if err != nil {
-			util.GetLogger(ctx).WithError(err).Error("failed querying known room")
+			util.GetLogger(ctx).WithError(err).Error("failed generating stripped state")
 			return nil, spec.InternalServerError{}
 		}
 	}
 
-	logger := util.GetLogger(ctx).WithFields(map[string]interface{}{
-		"inviter":  input.Event.Sender(),
-		"invitee":  *input.Event.StateKey(),
-		"room_id":  input.RoomID.String(),
-		"event_id": input.Event.EventID(),
-	})
+	logger := createInviteLogger(ctx, input.Event, input.RoomID)
 	logger.WithFields(logrus.Fields{
 		"room_version": input.Event.Version(),
 		"target_local": input.IsTargetLocal,
 		"origin_local": true,
 	}).Debug("processing invite event")
 
-	if len(inviteState) == 0 {
-		if err := input.Event.SetUnsignedField("invite_room_state", struct{}{}); err != nil {
-			return nil, fmt.Errorf("event.SetUnsignedField: %w", err)
-		}
-	} else {
-		if err := input.Event.SetUnsignedField("invite_room_state", inviteState); err != nil {
-			return nil, fmt.Errorf("event.SetUnsignedField: %w", err)
-		}
-	}
-
-	membership, err := input.MembershipQuerier.CurrentMembership(ctx, input.RoomID, input.InvitedUser)
+	err := setUnsignedFieldForInvite(input.Event, inviteState)
 	if err != nil {
-		util.GetLogger(ctx).WithError(err).Error("failed getting user membership")
-		return nil, spec.InternalServerError{}
-
+		return nil, err
 	}
-	isAlreadyJoined := (membership == spec.Join)
 
-	if isAlreadyJoined {
-		// If the user is joined to the room then that takes precedence over this
-		// invite event. It makes little sense to move a user that is already
-		// joined to the room into the invite state.
-		// This could plausibly happen if an invite request raced with a join
-		// request for a user. For example if a user was invited to a public
-		// room and they joined the room at the same time as the invite was sent.
-		// The other way this could plausibly happen is if an invite raced with
-		// a kick. For example if a user was kicked from a room in error and in
-		// response someone else in the room re-invited them then it is possible
-		// for the invite request to race with the leave event so that the
-		// target receives invite before it learns that it has been kicked.
-		// There are a few ways this could be plausibly handled in the roomserver.
-		// 1) Store the invite, but mark it as retired. That will result in the
-		//    permanent rejection of that invite event. So even if the target
-		//    user leaves the room and the invite is retransmitted it will be
-		//    ignored. However a new invite with a new event ID would still be
-		//    accepted.
-		// 2) Silently discard the invite event. This means that if the event
-		//    was retransmitted at a later date after the target user had left
-		//    the room we would accept the invite. However since we hadn't told
-		//    the sending server that the invite had been discarded it would
-		//    have no reason to attempt to retry.
-		// 3) Signal the sending server that the user is already joined to the
-		//    room.
-		// For now we will implement option 2. Since in the abesence of a retry
-		// mechanism it will be equivalent to option 1, and we don't have a
-		// signalling mechanism to implement option 3.
-		logger.Debugf("user already joined")
-		return nil, spec.Forbidden("user is already joined to room")
+	err = abortIfAlreadyJoined(ctx, input.RoomID, input.InvitedUser, input.MembershipQuerier)
+	if err != nil {
+		return nil, err
 	}
 
 	// The invite originated locally. Therefore we have a responsibility to

--- a/performinvite.go
+++ b/performinvite.go
@@ -1,0 +1,166 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomatrixserverlib
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
+)
+
+type StateQuerier interface {
+	GetAuthEvents(ctx context.Context, event PDU) (AuthEventProvider, error)
+}
+
+type PerformInviteInput struct {
+	Context               context.Context
+	RoomID                spec.RoomID
+	Event                 PDU
+	InvitedUser           spec.UserID
+	IsTargetLocal         bool
+	StrippedState         []InviteStrippedState
+	MembershipQuerier     MembershipQuerier
+	StateQuerier          StateQuerier
+	GenerateStrippedState func(ctx context.Context, roomID spec.RoomID, stateWanted []StateKeyTuple, inviteEvent PDU) ([]InviteStrippedState, error)
+}
+
+type FederatedInviteClient interface {
+	SendInvite(ctx context.Context, event PDU, strippedState []InviteStrippedState) (PDU, error)
+}
+
+func PerformInvite(input PerformInviteInput, fedClient FederatedInviteClient) (PDU, error) {
+	inviteState := input.StrippedState
+	if len(inviteState) == 0 {
+		// "If they are set on the room, at least the state for m.room.avatar, m.room.canonical_alias, m.room.join_rules, and m.room.name SHOULD be included."
+		// https://matrix.org/docs/spec/client_server/r0.6.0#m-room-member
+		stateWanted := []StateKeyTuple{}
+		for _, t := range []string{
+			spec.MRoomName, spec.MRoomCanonicalAlias,
+			spec.MRoomJoinRules, spec.MRoomAvatar,
+			spec.MRoomEncryption, spec.MRoomCreate,
+		} {
+			stateWanted = append(stateWanted, StateKeyTuple{
+				EventType: t,
+				StateKey:  "",
+			})
+		}
+		if is, generateErr := input.GenerateStrippedState(input.Context, input.RoomID, stateWanted, input.Event); generateErr == nil {
+			inviteState = is
+		} else {
+			util.GetLogger(input.Context).WithError(generateErr).Error("failed querying known room")
+			return nil, spec.InternalServerError{}
+		}
+	}
+
+	logger := util.GetLogger(input.Context).WithFields(map[string]interface{}{
+		"inviter":  input.Event.Sender(),
+		"invitee":  *input.Event.StateKey(),
+		"room_id":  input.RoomID.String(),
+		"event_id": input.Event.EventID(),
+	})
+	logger.WithFields(logrus.Fields{
+		"room_version": input.Event.Version(),
+		"target_local": input.IsTargetLocal,
+		"origin_local": true,
+	}).Debug("processing invite event")
+
+	if len(inviteState) == 0 {
+		if err := input.Event.SetUnsignedField("invite_room_state", struct{}{}); err != nil {
+			return nil, fmt.Errorf("event.SetUnsignedField: %w", err)
+		}
+	} else {
+		if err := input.Event.SetUnsignedField("invite_room_state", inviteState); err != nil {
+			return nil, fmt.Errorf("event.SetUnsignedField: %w", err)
+		}
+	}
+
+	membership, err := input.MembershipQuerier.CurrentMembership(input.Context, input.RoomID, input.InvitedUser)
+	if err != nil {
+		util.GetLogger(input.Context).WithError(err).Error("failed getting user membership")
+		return nil, spec.InternalServerError{}
+
+	}
+	isAlreadyJoined := (membership == spec.Join)
+
+	if isAlreadyJoined {
+		// If the user is joined to the room then that takes precedence over this
+		// invite event. It makes little sense to move a user that is already
+		// joined to the room into the invite state.
+		// This could plausibly happen if an invite request raced with a join
+		// request for a user. For example if a user was invited to a public
+		// room and they joined the room at the same time as the invite was sent.
+		// The other way this could plausibly happen is if an invite raced with
+		// a kick. For example if a user was kicked from a room in error and in
+		// response someone else in the room re-invited them then it is possible
+		// for the invite request to race with the leave event so that the
+		// target receives invite before it learns that it has been kicked.
+		// There are a few ways this could be plausibly handled in the roomserver.
+		// 1) Store the invite, but mark it as retired. That will result in the
+		//    permanent rejection of that invite event. So even if the target
+		//    user leaves the room and the invite is retransmitted it will be
+		//    ignored. However a new invite with a new event ID would still be
+		//    accepted.
+		// 2) Silently discard the invite event. This means that if the event
+		//    was retransmitted at a later date after the target user had left
+		//    the room we would accept the invite. However since we hadn't told
+		//    the sending server that the invite had been discarded it would
+		//    have no reason to attempt to retry.
+		// 3) Signal the sending server that the user is already joined to the
+		//    room.
+		// For now we will implement option 2. Since in the abesence of a retry
+		// mechanism it will be equivalent to option 1, and we don't have a
+		// signalling mechanism to implement option 3.
+		logger.Debugf("user already joined")
+		return nil, spec.Forbidden("user is already joined to room")
+	}
+
+	// The invite originated locally. Therefore we have a responsibility to
+	// try and see if the user is allowed to make this invite. We can't do
+	// this for invites coming in over federation - we have to take those on
+	// trust.
+	authEventProvider, err := input.StateQuerier.GetAuthEvents(input.Context, input.Event)
+	if err != nil {
+		logger.WithError(err).WithField("event_id", input.Event.EventID()).WithField("auth_event_ids", input.Event.AuthEventIDs()).Error(
+			"ProcessInvite.getAuthEvents failed for event",
+		)
+		return nil, spec.Forbidden(err.Error())
+	}
+
+	// Check if the event is allowed.
+	if err = Allowed(input.Event, authEventProvider); err != nil {
+		logger.WithError(err).WithField("event_id", input.Event.EventID()).WithField("auth_event_ids", input.Event.AuthEventIDs()).Error(
+			"ProcessInvite: event not allowed",
+		)
+		return nil, spec.Forbidden(err.Error())
+	}
+
+	// If the target isn't local then we should try and send the invite
+	// over federation first. It might be that the remote user doesn't exist,
+	// in which case we can give up processing here.
+	var inviteEvent PDU
+	if !input.IsTargetLocal {
+		inviteEvent, err = fedClient.SendInvite(input.Context, input.Event, inviteState)
+		if err != nil {
+			logger.WithError(err).WithField("event_id", input.Event.EventID()).Error("fedClient.SendInvite failed")
+			return nil, spec.Forbidden(err.Error())
+		}
+		logger.Debugf("Federated SendInvite success with event ID %s", input.Event.EventID())
+	}
+
+	return inviteEvent, nil
+}

--- a/performinvite.go
+++ b/performinvite.go
@@ -38,6 +38,13 @@ type PerformInviteInput struct {
 // On success will return either nothing (in the case of inviting a local user) or
 // a fully formed & signed Invite Event (in the case of inviting a remote user)
 func PerformInvite(ctx context.Context, input PerformInviteInput, fedClient FederatedInviteClient) (PDU, error) {
+	if input.MembershipQuerier == nil || input.StateQuerier == nil {
+		panic("Missing valid Querier")
+	}
+	if ctx == nil {
+		panic("Missing valid Context")
+	}
+
 	logger := createInviteLogger(ctx, input.InviteEvent, input.RoomID)
 	logger.WithFields(logrus.Fields{
 		"room_version": input.InviteEvent.Version(),

--- a/performinvite.go
+++ b/performinvite.go
@@ -49,10 +49,11 @@ func PerformInvite(ctx context.Context, input PerformInviteInput, fedClient Fede
 				StateKey:  "",
 			})
 		}
-		if is, generateErr := GenerateStrippedState(ctx, input.RoomID, stateWanted, input.Event, input.StateQuerier); generateErr == nil {
-			inviteState = is
-		} else {
-			util.GetLogger(ctx).WithError(generateErr).Error("failed querying known room")
+
+		var err error
+		inviteState, err = GenerateStrippedState(ctx, input.RoomID, stateWanted, input.Event, input.StateQuerier)
+		if err != nil {
+			util.GetLogger(ctx).WithError(err).Error("failed querying known room")
 			return nil, spec.InternalServerError{}
 		}
 	}

--- a/performinvite.go
+++ b/performinvite.go
@@ -23,24 +23,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type StateQuerier interface {
-	GetAuthEvents(ctx context.Context, event PDU) (AuthEventProvider, error)
-}
-
 type PerformInviteInput struct {
-	Context               context.Context
-	RoomID                spec.RoomID
-	Event                 PDU
-	InvitedUser           spec.UserID
-	IsTargetLocal         bool
-	StrippedState         []InviteStrippedState
-	MembershipQuerier     MembershipQuerier
-	StateQuerier          StateQuerier
-	GenerateStrippedState func(ctx context.Context, roomID spec.RoomID, stateWanted []StateKeyTuple, inviteEvent PDU) ([]InviteStrippedState, error)
-}
-
-type FederatedInviteClient interface {
-	SendInvite(ctx context.Context, event PDU, strippedState []InviteStrippedState) (PDU, error)
+	Context           context.Context
+	RoomID            spec.RoomID
+	Event             PDU
+	InvitedUser       spec.UserID
+	IsTargetLocal     bool
+	StrippedState     []InviteStrippedState
+	MembershipQuerier MembershipQuerier
+	StateQuerier      StateQuerier
 }
 
 func PerformInvite(input PerformInviteInput, fedClient FederatedInviteClient) (PDU, error) {
@@ -59,7 +50,7 @@ func PerformInvite(input PerformInviteInput, fedClient FederatedInviteClient) (P
 				StateKey:  "",
 			})
 		}
-		if is, generateErr := input.GenerateStrippedState(input.Context, input.RoomID, stateWanted, input.Event); generateErr == nil {
+		if is, generateErr := GenerateStrippedState(input.Context, input.RoomID, stateWanted, input.Event, input.StateQuerier); generateErr == nil {
 			inviteState = is
 		} else {
 			util.GetLogger(input.Context).WithError(generateErr).Error("failed querying known room")

--- a/performinvite_test.go
+++ b/performinvite_test.go
@@ -1,0 +1,176 @@
+package gomatrixserverlib
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ed25519"
+)
+
+type TestFederatedInviteClient struct {
+	shouldFail bool
+}
+
+func (f *TestFederatedInviteClient) SendInvite(ctx context.Context, event PDU, strippedState []InviteStrippedState) (PDU, error) {
+	if f.shouldFail {
+		return nil, fmt.Errorf("failed sending invite")
+	}
+	return nil, nil
+}
+
+func TestPerformInvite(t *testing.T) {
+	userID, err := spec.NewUserID("@user:server", true)
+	assert.Nil(t, err)
+	validRoom, err := spec.NewRoomID("!room:remote")
+	assert.Nil(t, err)
+
+	_, sk, err := ed25519.GenerateKey(rand.Reader)
+	assert.Nil(t, err)
+	keyID := KeyID("ed25519:1234")
+
+	stateKey := userID.String()
+	eb := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"invite"}`))
+	inviteEvent, err := eb.Build(time.Now(), userID.Domain(), keyID, sk)
+	assert.Nil(t, err)
+
+	type ErrorType int
+	const (
+		InternalErr ErrorType = iota
+		MatrixErr
+	)
+
+	tests := map[string]struct {
+		input       PerformInviteInput
+		expectedErr bool
+		errType     ErrorType
+		errCode     spec.MatrixErrorCode
+	}{
+		"not_allowed_by_auth_events": {
+			input: PerformInviteInput{
+				RoomID:            *validRoom,
+				InvitedUser:       *userID,
+				IsTargetLocal:     true,
+				InviteEvent:       inviteEvent,
+				StrippedState:     []InviteStrippedState{},
+				MembershipQuerier: &TestMembershipQuerier{},
+				StateQuerier:      &TestStateQuerier{},
+			},
+			expectedErr: true,
+			errType:     MatrixErr,
+			errCode:     spec.ErrorForbidden,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, joinErr := PerformInvite(context.Background(), tc.input, &TestFederatedInviteClient{})
+			if tc.expectedErr {
+				switch e := joinErr.(type) {
+				case nil:
+					t.Fatalf("Error should not be nil")
+				case spec.InternalServerError:
+					assert.Equal(t, tc.errType, InternalErr)
+				case spec.MatrixError:
+					assert.Equal(t, tc.errType, MatrixErr)
+					assert.Equal(t, tc.errCode, e.ErrCode)
+				default:
+					t.Fatalf("Unexpected Error Type")
+				}
+			} else {
+				jsonBytes, err := json.Marshal(&joinErr)
+				assert.Nil(t, err)
+				assert.Nil(t, joinErr, string(jsonBytes))
+			}
+		})
+	}
+}
+
+func TestPerformInviteNilMembershipQuerier(t *testing.T) {
+	userID, err := spec.NewUserID("@user:server", true)
+	assert.Nil(t, err)
+	validRoom, err := spec.NewRoomID("!room:remote")
+	assert.Nil(t, err)
+
+	_, sk, err := ed25519.GenerateKey(rand.Reader)
+	assert.Nil(t, err)
+	keyID := KeyID("ed25519:1234")
+
+	stateKey := userID.String()
+	eb := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"invite"}`))
+	inviteEvent, err := eb.Build(time.Now(), userID.Domain(), keyID, sk)
+	assert.Nil(t, err)
+
+	assert.Panics(t, func() {
+		_, _ = PerformInvite(context.Background(), PerformInviteInput{
+			RoomID:            *validRoom,
+			InvitedUser:       *userID,
+			IsTargetLocal:     true,
+			InviteEvent:       inviteEvent,
+			StrippedState:     []InviteStrippedState{},
+			MembershipQuerier: nil,
+			StateQuerier:      &TestStateQuerier{},
+		}, &TestFederatedInviteClient{})
+	})
+}
+
+func TestPerformInviteNilStateQuerier(t *testing.T) {
+	userID, err := spec.NewUserID("@user:server", true)
+	assert.Nil(t, err)
+	validRoom, err := spec.NewRoomID("!room:remote")
+	assert.Nil(t, err)
+
+	_, sk, err := ed25519.GenerateKey(rand.Reader)
+	assert.Nil(t, err)
+	keyID := KeyID("ed25519:1234")
+
+	stateKey := userID.String()
+	eb := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"invite"}`))
+	inviteEvent, err := eb.Build(time.Now(), userID.Domain(), keyID, sk)
+	assert.Nil(t, err)
+
+	assert.Panics(t, func() {
+		_, _ = PerformInvite(context.Background(), PerformInviteInput{
+			RoomID:            *validRoom,
+			InvitedUser:       *userID,
+			IsTargetLocal:     true,
+			InviteEvent:       inviteEvent,
+			StrippedState:     []InviteStrippedState{},
+			MembershipQuerier: &TestMembershipQuerier{},
+			StateQuerier:      nil,
+		}, &TestFederatedInviteClient{})
+	})
+}
+
+func TestPerformInviteNilContext(t *testing.T) {
+	userID, err := spec.NewUserID("@user:server", true)
+	assert.Nil(t, err)
+	validRoom, err := spec.NewRoomID("!room:remote")
+	assert.Nil(t, err)
+
+	_, sk, err := ed25519.GenerateKey(rand.Reader)
+	assert.Nil(t, err)
+	keyID := KeyID("ed25519:1234")
+
+	stateKey := userID.String()
+	eb := createMemberEventBuilder(userID.String(), validRoom.String(), &stateKey, spec.RawJSON(`{"membership":"invite"}`))
+	inviteEvent, err := eb.Build(time.Now(), userID.Domain(), keyID, sk)
+	assert.Nil(t, err)
+
+	assert.Panics(t, func() {
+		_, _ = PerformInvite(nil, PerformInviteInput{ // nolint
+			RoomID:            *validRoom,
+			InvitedUser:       *userID,
+			IsTargetLocal:     true,
+			InviteEvent:       inviteEvent,
+			StrippedState:     []InviteStrippedState{},
+			MembershipQuerier: &TestMembershipQuerier{},
+			StateQuerier:      &TestStateQuerier{},
+		}, &TestFederatedInviteClient{})
+	})
+}

--- a/performjoin.go
+++ b/performjoin.go
@@ -12,17 +12,17 @@ import (
 )
 
 type PerformJoinInput struct {
-	UserID     *spec.UserID
-	RoomID     *spec.RoomID
-	ServerName spec.ServerName
-	Content    map[string]interface{}
-	Unsigned   map[string]interface{}
+	UserID     *spec.UserID           // The user joining the room
+	RoomID     *spec.RoomID           // The room the user is joining
+	ServerName spec.ServerName        // The server to attempt to join via
+	Content    map[string]interface{} // The membership event content
+	Unsigned   map[string]interface{} // The event unsigned content, if any
 
-	PrivateKey ed25519.PrivateKey
-	KeyID      KeyID
-	KeyRing    *KeyRing
+	PrivateKey ed25519.PrivateKey // Used to sign the join event
+	KeyID      KeyID              // Used to sign the join event
+	KeyRing    *KeyRing           // Used to verify the response from send_join
 
-	EventProvider EventProvider
+	EventProvider EventProvider // Provides full events given a list of event IDs
 }
 
 type PerformJoinResponse struct {

--- a/performjoin_test.go
+++ b/performjoin_test.go
@@ -203,6 +203,17 @@ func TestPerformJoin(t *testing.T) {
 			ExpectedHTTPErr:     false,
 			ExpectedRoomVersion: joinEvent.Version(),
 		},
+		"invalid_key_ring": {
+			FedClient: &TestFederatedJoinClient{shouldMakeFail: false, shouldSendFail: false, roomVersion: RoomVersionV10},
+			Input: PerformJoinInput{
+				UserID:  userID,
+				RoomID:  roomID,
+				KeyRing: nil,
+			},
+			ExpectedErr:         true,
+			ExpectedHTTPErr:     false,
+			ExpectedRoomVersion: joinEvent.Version(),
+		},
 		"make_join_http_err": {
 			FedClient: &TestFederatedJoinClient{shouldMakeFail: true, shouldSendFail: false, roomVersion: RoomVersionV10},
 			Input: PerformJoinInput{


### PR DESCRIPTION
Pulls over both outbound & inbound invite logic from Dendrite.