### PR TITLE
Remove senderID input from PerformJoin

### DIFF
--- a/performjoin.go
+++ b/performjoin.go
@@ -86,6 +86,24 @@ func PerformJoin(
 		}
 	}
 
+	switch respMakeJoin.GetRoomVersion() {
+	case RoomVersionPseudoIDs:
+		// TODO : pseudoIDs - need to create a new key here!
+		// create user room key if needed
+		//key, keyErr := r.RSAPI.GetOrCreateUserRoomPrivateKey(ctx, input.UserID, input.RoomID)
+		//if keyErr != nil {
+		//	return nil, &FederationError{
+		//		ServerName: input.ServerName,
+		//		Transient:  false,
+		//		Reachable:  true,
+		//		Err:        fmt.Errorf("Cannot create user room key"),
+		//	}
+		//}
+		//input.SenderID = spec.SenderID(spec.Base64Bytes(key).Encode())
+	default:
+		input.SenderID = spec.SenderID(input.UserID.String())
+	}
+
 	// Set all the fields to be what they should be, this should be a no-op
 	// but it's possible that the remote server returned us something "odd"
 	stateKey := string(input.SenderID)

--- a/performjoin_test.go
+++ b/performjoin_test.go
@@ -197,7 +197,6 @@ func TestPerformJoin(t *testing.T) {
 			FedClient: &TestFederatedJoinClient{shouldMakeFail: false, shouldSendFail: false, roomVersion: RoomVersionV10},
 			Input: PerformJoinInput{
 				UserID:        userID,
-				SenderID:      spec.SenderID(userID.String()),
 				RoomID:        nil,
 				KeyRing:       &KeyRing{[]KeyFetcher{&TestRequestKeyDummy{}}, &joinKeyDatabase{key: pk}},
 				UserIDQuerier: UserIDForSenderTest,
@@ -210,7 +209,6 @@ func TestPerformJoin(t *testing.T) {
 			FedClient: &TestFederatedJoinClient{shouldMakeFail: false, shouldSendFail: false, roomVersion: RoomVersionV10},
 			Input: PerformJoinInput{
 				UserID:        userID,
-				SenderID:      spec.SenderID(userID.String()),
 				RoomID:        roomID,
 				KeyRing:       nil,
 				UserIDQuerier: UserIDForSenderTest,
@@ -223,7 +221,6 @@ func TestPerformJoin(t *testing.T) {
 			FedClient: &TestFederatedJoinClient{shouldMakeFail: true, shouldSendFail: false, roomVersion: RoomVersionV10},
 			Input: PerformJoinInput{
 				UserID:        userID,
-				SenderID:      spec.SenderID(userID.String()),
 				RoomID:        roomID,
 				KeyRing:       &KeyRing{[]KeyFetcher{&TestRequestKeyDummy{}}, &joinKeyDatabase{key: pk}},
 				UserIDQuerier: UserIDForSenderTest,
@@ -236,7 +233,6 @@ func TestPerformJoin(t *testing.T) {
 			FedClient: &TestFederatedJoinClient{shouldMakeFail: false, shouldSendFail: true, roomVersion: RoomVersionV10},
 			Input: PerformJoinInput{
 				UserID:        userID,
-				SenderID:      spec.SenderID(userID.String()),
 				RoomID:        roomID,
 				PrivateKey:    sk,
 				KeyID:         keyID,
@@ -251,7 +247,6 @@ func TestPerformJoin(t *testing.T) {
 			FedClient: &TestFederatedJoinClient{shouldMakeFail: false, shouldSendFail: false, roomVersion: "", createEvent: createEvent, joinEvent: joinEvent, joinEventBuilder: joinProto},
 			Input: PerformJoinInput{
 				UserID:        userID,
-				SenderID:      spec.SenderID(userID.String()),
 				RoomID:        roomID,
 				PrivateKey:    sk,
 				KeyID:         keyID,
@@ -267,7 +262,6 @@ func TestPerformJoin(t *testing.T) {
 			FedClient: &TestFederatedJoinClient{shouldMakeFail: false, shouldSendFail: false, roomVersion: RoomVersionV10, createEvent: createEvent, joinEvent: joinEvent, joinEventBuilder: joinProto},
 			Input: PerformJoinInput{
 				UserID:        userID,
-				SenderID:      spec.SenderID(userID.String()),
 				RoomID:        roomID,
 				PrivateKey:    sk,
 				KeyID:         keyID,

--- a/spec/senderid.go
+++ b/spec/senderid.go
@@ -14,6 +14,10 @@
 
 package spec
 
+import "context"
+
 type SenderID string
 
 type UserIDForSender func(roomID RoomID, senderID SenderID) (*UserID, error)
+
+type CreateSenderID func(ctx context.Context, userID UserID, roomID RoomID) (SenderID, error)


### PR DESCRIPTION
Don't pass in senderID to PerformJoin since we don't know what the senderID is yet.
We require the room version from the response to make_join before we will know how to correctly assign the senderID.