### PR TITLE
Add constants used in space summaries

### DIFF
--- a/eventcontent.go
+++ b/eventcontent.go
@@ -28,7 +28,7 @@ import (
 
 // CreateContent is the JSON content of a m.room.create event along with
 // the top level keys needed for auth.
-// See https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-create for descriptions of the fields.
+// See https://spec.matrix.org/v1.7/client-server-api/#mroomcreate for descriptions of the fields.
 type CreateContent struct {
 	// We need the domain of the create event when checking federatability.
 	senderDomain string
@@ -44,6 +44,8 @@ type CreateContent struct {
 	RoomVersion *RoomVersion `json:"room_version,omitempty"`
 	// The predecessor of the room.
 	Predecessor *PreviousRoom `json:"predecessor,omitempty"`
+	// The room type.
+	RoomType string `json:"type,omitempty"`
 }
 
 // PreviousRoom is the "Previous Room" structure defined at https://matrix.org/docs/spec/client_server/r0.5.0#m-room-create

--- a/spec/eventtypes.go
+++ b/spec/eventtypes.go
@@ -68,4 +68,8 @@ const (
 	MPresence = "m.presence"
 	// MRoomMembership https://github.com/matrix-org/matrix-doc/blob/clokep/restricted-rooms/proposals/3083-restricted-rooms.md
 	MRoomMembership = "m.room_membership"
+	// MSpaceChild https://spec.matrix.org/v1.7/client-server-api/#mspacechild-relationship
+	MSpaceChild = "m.space.child"
+	// MSpaceParent https://spec.matrix.org/v1.7/client-server-api/#mspaceparent-relationships
+	MSpaceParent = "m.space.parent"
 )

--- a/spec/roomtypes.go
+++ b/spec/roomtypes.go
@@ -15,8 +15,6 @@
 package spec
 
 const (
-	// Content key for room type in m.room.create event https://spec.matrix.org/v1.7/client-server-api/#mroomcreate
-	MRoomCreateTypeContentKey = "type"
 	// MSpace https://spec.matrix.org/v1.7/client-server-api/#types
 	MSpace = "m.space"
 )

--- a/spec/roomtypes.go
+++ b/spec/roomtypes.go
@@ -1,0 +1,22 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+const (
+	// Content key for room type in m.room.create event https://spec.matrix.org/v1.7/client-server-api/#mroomcreate
+	MRoomCreateTypeContentKey = "type"
+	// MSpace https://spec.matrix.org/v1.7/client-server-api/#types
+	MSpace = "m.space"
+)


### PR DESCRIPTION
Add some constants used in space summaries / room hierarchy ( https://github.com/matrix-org/dendrite/pull/3134 )

### Pull Request Checklist

* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Sam Wedgwood <sam@wedgwood.dev>`
