### PR TITLE
Remove remaining mentions of MSC2946

### DIFF
--- a/fclient/federationclient.go
+++ b/fclient/federationclient.go
@@ -41,7 +41,7 @@ type FederationClient interface {
 	QueryKeys(ctx context.Context, origin, s spec.ServerName, keys map[string][]string) (RespQueryKeys, error)
 	Backfill(ctx context.Context, origin, s spec.ServerName, roomID string, limit int, eventIDs []string) (res gomatrixserverlib.Transaction, err error)
 	MSC2836EventRelationships(ctx context.Context, origin, dst spec.ServerName, r MSC2836EventRelationshipsRequest, roomVersion gomatrixserverlib.RoomVersion) (res MSC2836EventRelationshipsResponse, err error)
-	MSC2946Spaces(ctx context.Context, origin, dst spec.ServerName, roomID string, suggestedOnly bool) (res MSC2946SpacesResponse, err error)
+	RoomHierarchy(ctx context.Context, origin, dst spec.ServerName, roomID string, suggestedOnly bool) (res RoomHierarchyResponse, err error)
 
 	ExchangeThirdPartyInvite(ctx context.Context, origin, s spec.ServerName, builder gomatrixserverlib.ProtoEvent) (err error)
 	LookupState(ctx context.Context, origin, s spec.ServerName, roomID string, eventID string, roomVersion gomatrixserverlib.RoomVersion) (res RespState, err error)
@@ -710,9 +710,9 @@ func (ac *federationClient) MSC2836EventRelationships(
 	return
 }
 
-func (ac *federationClient) MSC2946Spaces(
+func (ac *federationClient) RoomHierarchy(
 	ctx context.Context, origin, dst spec.ServerName, roomID string, suggestedOnly bool,
-) (res MSC2946SpacesResponse, err error) {
+) (res RoomHierarchyResponse, err error) {
 	path := "/_matrix/federation/v1/hierarchy/" + url.PathEscape(roomID)
 	if suggestedOnly {
 		path += "?suggested_only=true"

--- a/fclient/federationtypes.go
+++ b/fclient/federationtypes.go
@@ -528,24 +528,24 @@ type MSC2836EventRelationshipsResponse struct {
 	AuthChain gomatrixserverlib.EventJSONs `json:"auth_chain"`
 }
 
-// MSC2946Room represents a public room with additional metadata on the space directory
-type MSC2946Room struct {
+// RoomHierarchyRoom represents a public room with additional metadata on the space directory
+type RoomHierarchyRoom struct {
 	PublicRoom
-	ChildrenState  []MSC2946StrippedEvent `json:"children_state"`
-	AllowedRoomIDs []string               `json:"allowed_room_ids,omitempty"`
-	RoomType       string                 `json:"room_type"`
+	ChildrenState  []RoomHierarchyStrippedEvent `json:"children_state"`
+	AllowedRoomIDs []string                     `json:"allowed_room_ids,omitempty"`
+	RoomType       string                       `json:"room_type"`
 }
 
-// MSC2946SpacesResponse is the HTTP response body for the federation /unstable/spaces/{roomID} endpoint
+// RoomHierarchyResponse is the HTTP response body for the federation /unstable/spaces/{roomID} endpoint
 // See https://github.com/matrix-org/matrix-doc/pull/2946
-type MSC2946SpacesResponse struct {
-	Room                 MSC2946Room   `json:"room"`
-	Children             []MSC2946Room `json:"children"`
-	InaccessibleChildren []string      `json:"inaccessible_children"`
+type RoomHierarchyResponse struct {
+	Room                 RoomHierarchyRoom   `json:"room"`
+	Children             []RoomHierarchyRoom `json:"children"`
+	InaccessibleChildren []string            `json:"inaccessible_children"`
 }
 
-// MSC2946StrippedEvent is the format of events returned in the HTTP response body
-type MSC2946StrippedEvent struct {
+// RoomHierarchyStrippedEvent is the format of events returned in the HTTP response body
+type RoomHierarchyStrippedEvent struct {
 	Type           string          `json:"type"`
 	StateKey       string          `json:"state_key"`
 	Content        json.RawMessage `json:"content"`


### PR DESCRIPTION
Remove mentions of MSC2946, as it it part of the spec. (For https://github.com/matrix-org/dendrite/pull/3134 ).

Any chance outright removing the old names will break things? Does go support some kind of aliasing so we can keep some types alive with deprecation notices? Not sure.

Signed-off-by: `Sam Wedgwood <sam@wedgwood.dev>`
