### PR TITLE
add new function `NewUserIDOrPanic`

### DIFF
--- a/spec/userid.go
+++ b/spec/userid.go
@@ -18,8 +18,18 @@ type UserID struct {
 	domain string
 }
 
+// Creates a new UserID, returning an error if invalid
 func NewUserID(id string, allowHistoricalIDs bool) (*UserID, error) {
 	return parseAndValidateUserID(id, allowHistoricalIDs)
+}
+
+// Creates a new UserID, panicing if invalid
+func NewUserIDOrPanic(id string, allowHistoricalIDs bool) UserID {
+	userID, err := parseAndValidateUserID(id, allowHistoricalIDs)
+	if err != nil {
+		panic(fmt.Sprintf("NewUserIDOrPanic failed: invalid user ID %s", id))
+	}
+	return *userID
 }
 
 // Returns the full userID string including leading sigil


### PR DESCRIPTION
Add a function for creating user IDs that panics if invalid - useful for constant user IDs (e.g. in testing)

Signed-off-by: `Sam Wedgwood <sam@wedgwood.dev>`
