### PR TITLE
Disable character range check for user IDs

### DIFF
--- a/spec/userid.go
+++ b/spec/userid.go
@@ -77,11 +77,18 @@ func parseAndValidateUserID(id string, allowHistoricalIDs bool) (*UserID, error)
 }
 
 func historicallyValidCharacters(localpart string) bool {
-	for _, r := range localpart {
-		if r < 0x21 || r == 0x3A || r > 0x7E {
-			return false
+	// This check is currently not safe because Synapse has historically
+	// not enforced these character ranges properly, so there are many
+	// user IDs out in the wild that fall outside this (like with emoji).
+	// TODO: This function needs to be room version aware, as this will be
+	// fixed in a future room version.
+	/*
+		for _, r := range localpart {
+			if r < 0x21 || r == 0x3A || r > 0x7E {
+				return false
+			}
 		}
-	}
+	*/
 
 	return true
 }


### PR DESCRIPTION
This check is not safe in existing room versions because Synapse hasn't enforced it properly either.

Related: matrix-org/matrix-spec#1506, matrix-org/matrix-spec-proposals#2828

Signed-off-by: Neil Alexander <git@neilalexander.dev>