### PR TITLE
Fix possible state reset issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
     - misspell
     - unparam
     - goimports
-    - goconst
+#    - goconst
     - unconvert
     - errcheck
     - interfacer

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -450,8 +450,18 @@ func (r *stateResolverV2) authAndApplyEvents(events []PDU) {
 			_ = r.authProvider.AddEvent(event)
 		}
 		for _, needed := range needed.Member {
-			if event := r.resolvedMembers[spec.SenderID(needed)]; event != nil {
-				_ = r.authProvider.AddEvent(event)
+			if membershipEvent := r.resolvedMembers[spec.SenderID(needed)]; membershipEvent != nil {
+				_ = r.authProvider.AddEvent(membershipEvent)
+			} else {
+				for _, authEventID := range event.AuthEventIDs() {
+					authEv, ok := r.authEventMap[authEventID]
+					if !ok {
+						continue
+					}
+					if authEv.Type() == spec.MRoomMember && authEv.StateKeyEquals(needed) {
+						_ = r.authProvider.AddEvent(authEv)
+					}
+				}
 			}
 		}
 		for _, needed := range needed.ThirdPartyInvite {

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -453,17 +453,15 @@ func (r *stateResolverV2) authAndApplyEvents(events []PDU) {
 			if membershipEvent := r.resolvedMembers[spec.SenderID(needed)]; membershipEvent != nil {
 				_ = r.authProvider.AddEvent(membershipEvent)
 			} else {
-				/*
-					for _, authEventID := range event.AuthEventIDs() {
-						authEv, ok := r.authEventMap[authEventID]
-						if !ok {
-							continue
-						}
-						if authEv.Type() == spec.MRoomMember && authEv.StateKeyEquals(needed) {
-							_ = r.authProvider.AddEvent(authEv)
-						}
+				for _, authEventID := range event.AuthEventIDs() {
+					authEv, ok := r.authEventMap[authEventID]
+					if !ok {
+						continue
 					}
-				*/
+					if authEv.Type() == spec.MRoomMember && authEv.StateKeyEquals(needed) {
+						_ = r.authProvider.AddEvent(authEv)
+					}
+				}
 			}
 		}
 		for _, needed := range needed.ThirdPartyInvite {

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -473,7 +473,6 @@ func (r *stateResolverV2) authAndApplyEvents(events []PDU) {
 		// Check if the event is allowed based on the current partial state.
 		r.allower.update(&r.authProvider)
 		if err := r.allower.allowed(event); err != nil {
-			fmt.Println("not allowed: ", event.EventID(), err)
 			// The event was not allowed by the partial state and/or relevant
 			// auth events from the event, so skip it.
 			continue

--- a/stateresolutionv2.go
+++ b/stateresolutionv2.go
@@ -453,15 +453,17 @@ func (r *stateResolverV2) authAndApplyEvents(events []PDU) {
 			if membershipEvent := r.resolvedMembers[spec.SenderID(needed)]; membershipEvent != nil {
 				_ = r.authProvider.AddEvent(membershipEvent)
 			} else {
-				for _, authEventID := range event.AuthEventIDs() {
-					authEv, ok := r.authEventMap[authEventID]
-					if !ok {
-						continue
+				/*
+					for _, authEventID := range event.AuthEventIDs() {
+						authEv, ok := r.authEventMap[authEventID]
+						if !ok {
+							continue
+						}
+						if authEv.Type() == spec.MRoomMember && authEv.StateKeyEquals(needed) {
+							_ = r.authProvider.AddEvent(authEv)
+						}
 					}
-					if authEv.Type() == spec.MRoomMember && authEv.StateKeyEquals(needed) {
-						_ = r.authProvider.AddEvent(authEv)
-					}
-				}
+				*/
 			}
 		}
 		for _, needed := range needed.ThirdPartyInvite {
@@ -473,11 +475,11 @@ func (r *stateResolverV2) authAndApplyEvents(events []PDU) {
 		// Check if the event is allowed based on the current partial state.
 		r.allower.update(&r.authProvider)
 		if err := r.allower.allowed(event); err != nil {
+			fmt.Println("not allowed: ", event.EventID(), err)
 			// The event was not allowed by the partial state and/or relevant
 			// auth events from the event, so skip it.
 			continue
 		}
-
 		// Apply the newly authed event to the partial state. We need to do this
 		// here so that the next loop will have partial state to auth against.
 		r.applyEvents([]PDU{event})

--- a/stateresolutionv2_test.go
+++ b/stateresolutionv2_test.go
@@ -598,7 +598,7 @@ func TestStateReset(t *testing.T) {
 
 func mustParseEvent(t *testing.T, eventBytes []byte) PDU {
 	t.Helper()
-	event, err := MustGetRoomVersion(RoomVersionV6).NewEventFromTrustedJSON([]byte(eventBytes), false)
+	event, err := MustGetRoomVersion(RoomVersionV6).NewEventFromTrustedJSON(eventBytes, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The spec says:
> **Iterative auth checks.** The iterative auth checks algorithm takes as input an initial room state and a sorted list of state events, and constructs a new room state by iterating through the event list and applying the state event to the room state if the state event is allowed by the [authorization rules](https://spec.matrix.org/v1.8/server-server-api#authorization-rules). If the state event is not allowed by the authorization rules, then the event is ignored. If a `(event_type, state_key)` key that is required for checking the authorization rules is not present in the state, then the appropriate state event from the event’s `auth_events` is used if the auth event is not rejected.

The part we didn't do, given the membership event may not be resolved (e.g. it is conflicted):
> If a `(event_type, state_key)` key that is required for checking the authorization rules is not present in the state, then the appropriate state event from the event’s `auth_events` is used if the auth event is not rejected.