### PR TITLE
Unmarshal onto partial `membershipContent`

### DIFF
--- a/eventauth.go
+++ b/eventauth.go
@@ -112,6 +112,9 @@ type membershipContent struct {
 	// The user that authorised the join, in the case that the restricted join
 	// rule is in effect.
 	AuthorizedVia string `json:"join_authorised_via_users_server,omitempty"`
+
+	// The MXIDMapping used in pseudo ID rooms
+	MXIDMapping *MXIDMapping `json:"mxid_mapping,omitempty"`
 }
 
 // StateNeededForProtoEvent returns the event types and state_keys needed to authenticate the
@@ -983,7 +986,7 @@ func (m *membershipAllower) membershipAllowed(event PDU) error { // nolint: gocy
 	var sender *spec.UserID
 	var err error
 	if event.Type() == spec.MRoomMember {
-		mapping := MemberContent{}
+		mapping := membershipContent{}
 		if err := json.Unmarshal(event.Content(), &mapping); err != nil {
 			return err
 		}

--- a/eventauth_test.go
+++ b/eventauth_test.go
@@ -1539,3 +1539,57 @@ func Test_checkUserLevels(t *testing.T) {
 		})
 	}
 }
+
+// Test that we allow broken membership content, i.e.
+// displayname is boolean, an object or array
+func TestMembershipAllowed(t *testing.T) {
+	testEventAllowed(t, `{
+		"auth_events": {
+			"create": {
+				"type": "m.room.create",
+				"state_key": "",
+				"sender": "@u1:a",
+				"room_id": "!r1:a",
+				"event_id": "$e1:a",
+				"content": {"creator": "@u1:a"}
+			}
+		},
+		"allowed": [{
+			"type": "m.room.member",
+			"state_key": "@u1:a",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"event_id": "$e2:a",
+			"prev_events": [["$e1:a", {}]],
+			"content": {"membership": "join", "displayname": false}
+		},
+		{
+			"type": "m.room.member",
+			"state_key": "@u1:a",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"event_id": "$e2:a",
+			"prev_events": [["$e1:a", {}]],
+			"content": {"membership": "join", "displayname": {}}
+		},
+		{
+			"type": "m.room.member",
+			"state_key": "@u1:a",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"event_id": "$e2:a",
+			"prev_events": [["$e1:a", {}]],
+			"content": {"membership": "join", "displayname": 0}
+		},
+		{
+			"type": "m.room.member",
+			"state_key": "@u1:a",
+			"sender": "@u1:a",
+			"room_id": "!r1:a",
+			"event_id": "$e2:a",
+			"prev_events": [["$e1:a", {}]],
+			"content": {"membership": "join", "displayname": []}
+		}],
+		"not_allowed": []
+	}`)
+}

--- a/eventcontent.go
+++ b/eventcontent.go
@@ -213,6 +213,7 @@ func NewMemberContentFromEvent(event PDU) (c MemberContent, err error) {
 		c.Membership = partial.Membership
 		c.ThirdPartyInvite = partial.ThirdPartyInvite
 		c.AuthorisedVia = partial.AuthorizedVia
+		c.MXIDMapping = partial.MXIDMapping
 	}
 	return
 }


### PR DESCRIPTION
This fixes cases where we e.g. receive valid events, but are unable to unmarshal onto `MembershipContent` because of an invalid `displayname` (which we don't care about when authing events):

```
json: cannot unmarshal bool into Go struct field MemberContent.displayname of type string"
```