### PR TITLE
Optimize JSON parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.20", "1.21"]
+        go: ["1.21", "stable"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup go
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.20", "1.21"]
+        go: ["1.21", "stable"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ gomatrixserverlib
 
 [![GoDoc](https://godoc.org/github.com/matrix-org/gomatrixserverlib?status.svg)](https://godoc.org/github.com/matrix-org/gomatrixserverlib)
 
-Go library for common functions needed by matrix servers. This library assumes Go 1.18+.
+Go library for common functions needed by matrix servers. This library assumes Go 1.21+.

--- a/eventV1.go
+++ b/eventV1.go
@@ -215,7 +215,7 @@ func (e *eventV1) SetUnsignedField(path string, value interface{}) error {
 	eventJSON = CanonicalJSONAssumeValid(eventJSON)
 
 	res := gjson.GetBytes(eventJSON, "unsigned")
-	unsigned := RawJSONFromResult(res, eventJSON)
+	unsigned := []byte(res.Raw)
 	e.eventFields.Unsigned = unsigned
 
 	e.eventJSON = eventJSON

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.18
+go 1.21.0

--- a/json_test.go
+++ b/json_test.go
@@ -61,10 +61,10 @@ func TestJSONFloats(t *testing.T) {
 }
 
 func testSortJSON(t *testing.T, input, want string) {
-	got := SortJSON([]byte(input), nil)
+	got := SortJSON([]byte(input))
 
 	// Squash out the whitespace before comparing the JSON in case SortJSON had inserted whitespace.
-	if string(CompactJSON(got, nil)) != want {
+	if string(CompactJSON(got)) != want {
 		t.Errorf("SortJSON(%q): want %q got %q", input, want, got)
 	}
 }
@@ -79,7 +79,7 @@ func TestSortJSON(t *testing.T) {
 }
 
 func testCompactJSON(t *testing.T, input, want string) {
-	bytes := CompactJSON([]byte(input), nil)
+	bytes := CompactJSON([]byte(input))
 	got := string(bytes)
 	if got != want {
 		t.Errorf("CompactJSON(%q):\n want: %q\n got: %q\n bytes: % X", input, want, got, bytes)


### PR DESCRIPTION
Based on https://github.com/neilalexander/harmony/commit/586b0835adadc88da5005f13fb6fa191c78e49d4 with minor changes.

Benchstat vs main:

```
goos: linux
goarch: amd64
pkg: github.com/matrix-org/gomatrixserverlib
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
                              │   old.txt    │               new.txt                │
                              │    sec/op    │    sec/op     vs base                │
ParseLargerEvent-8               56.98µ ± 5%   49.62µ ±  3%  -12.91% (p=0.000 n=10)
ParseSmallerEvent-8              52.12µ ± 5%   47.13µ ± 14%   -9.58% (p=0.019 n=10)
ParseSmallerEventFailedHash-8   109.01µ ± 6%   98.07µ ±  4%  -10.04% (p=0.000 n=10)
ParseSmallerEventRedacted-8      83.67µ ± 3%   73.17µ ±  3%  -12.56% (p=0.000 n=10)
geomean                          72.14µ        64.00µ        -11.28%

                              │   old.txt    │               new.txt                │
                              │     B/op     │     B/op      vs base                │
ParseLargerEvent-8              29.17Ki ± 0%   16.75Ki ± 0%  -42.58% (p=0.000 n=10)
ParseSmallerEvent-8             23.25Ki ± 0%   16.16Ki ± 0%  -30.51% (p=0.000 n=10)
ParseSmallerEventFailedHash-8   40.19Ki ± 0%   26.05Ki ± 0%  -35.18% (p=0.000 n=10)
ParseSmallerEventRedacted-8     33.75Ki ± 0%   19.69Ki ± 0%  -41.65% (p=0.000 n=10)
geomean                         30.97Ki        19.30Ki       -37.67%

                              │  old.txt   │              new.txt               │
                              │ allocs/op  │ allocs/op   vs base                │
ParseLargerEvent-8              209.0 ± 0%   126.0 ± 0%  -39.71% (p=0.000 n=10)
ParseSmallerEvent-8             192.0 ± 0%   132.0 ± 0%  -31.25% (p=0.000 n=10)
ParseSmallerEventFailedHash-8   380.0 ± 0%   263.0 ± 0%  -30.79% (p=0.000 n=10)
ParseSmallerEventRedacted-8     282.0 ± 0%   168.0 ± 0%  -40.43% (p=0.000 n=10)
geomean                         256.1        164.6       -35.70%
```