### PR TITLE
Minor improvement of spec.AsTimestamp

### DIFF
--- a/spec/timestamp.go
+++ b/spec/timestamp.go
@@ -9,7 +9,7 @@ type Timestamp uint64
 
 // AsTimestamp turns a time.Time into a millisecond posix timestamp.
 func AsTimestamp(t time.Time) Timestamp {
-	return Timestamp(t.UnixNano() / 1000000)
+	return Timestamp(t.UnixMilli())
 }
 
 // Time turns a millisecond posix timestamp into a UTC time.Time


### PR DESCRIPTION
It is a bit safer to convert `time.Time` using a standard `t.UnixMilli()` method rather than `t.UnixNano() / 1000000`

### Pull Request Checklist

* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Roman Isaev <mdnight@riseup.net>`
