### PR TITLE
add M_UNKNOWN_POS to error constants

### DIFF
--- a/spec/matrixerror.go
+++ b/spec/matrixerror.go
@@ -23,6 +23,7 @@ type MatrixErrorCode string
 
 const (
 	ErrorUnknown                     MatrixErrorCode = "M_UNKNOWN"
+	ErrorUnknownPos                  MatrixErrorCode = "M_UNKNOWN_POS"
 	ErrorUnrecognized                MatrixErrorCode = "M_UNRECOGNIZED"
 	ErrorForbidden                   MatrixErrorCode = "M_FORBIDDEN"
 	ErrorBadJSON                     MatrixErrorCode = "M_BAD_JSON"


### PR DESCRIPTION
This pull request includes a small change to the `spec/matrixerror.go` file. The change adds a new error code `ErrorUnknownPos` to the `MatrixErrorCode` type. This error is used by the simplified sliding sync 

* [`spec/matrixerror.go`](diffhunk://#diff-3fd6b2645e9d58a86473fb344ae5b3d849c3085399bf76809aa854e54b6a73f3R26): Added `ErrorUnknownPos` to the `MatrixErrorCode` type.

https://github.com/matrix-org/matrix-spec-proposals/blob/erikj/sss/proposals/4186-simplified-sliding-sync.md#connections

### Pull Request Checklist

* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Roman Isaev <mdnight@riseup.net>`
