### PR TITLE
Fix an issue where we would send an invalid `/user/keys/query` request

### DIFF
--- a/fclient/federationclient.go
+++ b/fclient/federationclient.go
@@ -633,7 +633,13 @@ func (ac *federationClient) ClaimKeys(ctx context.Context, origin, s spec.Server
 func (ac *federationClient) QueryKeys(ctx context.Context, origin, s spec.ServerName, keys map[string][]string) (res RespQueryKeys, err error) {
 	path := federationPathPrefixV1 + "/user/keys/query"
 	req := NewFederationRequest("POST", origin, s, path)
-	if err = req.SetContent(map[string]interface{}{
+	// Ensure that the keys map has empty slices for any nil values.
+	for k, v := range keys {
+		if v == nil {
+			keys[k] = []string{}
+		}
+	}
+	if err = req.SetContent(map[string]map[string][]string{
 		"device_keys": keys,
 	}); err != nil {
 		return

--- a/fclient/federationclient_test.go
+++ b/fclient/federationclient_test.go
@@ -316,6 +316,13 @@ func TestQueryKeysReturnsDeviceKeys(t *testing.T) {
 			&roundTripper{
 				fn: func(req *http.Request) (*http.Response, error) {
 					if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v1/user/keys/query") {
+						body, err := io.ReadAll(req.Body)
+						if err != nil {
+							return nil, fmt.Errorf("failed to read request body: %w", err)
+						}
+						if bytes.Contains(body, []byte("null")) {
+							t.Fatalf("QueryKeys request body should not contain 'null': %s", string(body))
+						}
 						return &http.Response{
 							StatusCode: 200,
 							Body:       io.NopCloser(bytes.NewReader(respQueryKeysJSON)),
@@ -365,6 +372,13 @@ func TestQueryKeysHandlesNilDeviceKeys(t *testing.T) {
 			&roundTripper{
 				fn: func(req *http.Request) (*http.Response, error) {
 					if strings.HasPrefix(req.URL.Path, "/_matrix/federation/v1/user/keys/query") {
+						body, err := io.ReadAll(req.Body)
+						if err != nil {
+							return nil, fmt.Errorf("failed to read request body: %w", err)
+						}
+						if bytes.Contains(body, []byte("null")) {
+							t.Fatalf("QueryKeys request body should not contain 'null': %s", string(body))
+						}
 						return &http.Response{
 							StatusCode: 200,
 							Body:       io.NopCloser(bytes.NewReader(respQueryKeysJSON)),


### PR DESCRIPTION
Discovered while checking Grafana and wondering why there was one server being hit over and over again.
Turns out that we were sending 

```json
{
  "device_keys": {
    "@alice:example.com": null
  }
}
```
instead of an empty list.

This should fix it, even though the server in question still seems to return an invalid response.

### Pull Request Checklist

* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)